### PR TITLE
refactor: isolate World frontend integration

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -180,25 +180,16 @@ import type { OfficeHandoffRequest } from "./world/herdrOfficeHandoff";
 import { projectHerdrOffice } from "./world/herdrOfficeProjection";
 import type { OfficeAgent } from "./world/herdrOfficeProjection";
 import { WorldConversationBubble } from "./world/WorldConversationBubble";
-import { WorldSettingsDialog } from "./world/WorldSettingsDialog";
 import {
-  hasStoredWorldSettings,
-  readWorldLongRoomTitleMode,
-  readWorldSettings,
-  readWorldRoomAlignment,
-  updateWorldObservabilityConfiguration,
-} from "./world/worldSettings";
+  useWorldSettingsController,
+  WorldSettingsOverlay,
+} from "./world/WorldSettingsController";
 import {
   readWorldCompletionSeenKeys,
   writeWorldCompletionSeenKeys,
 } from "./world/completionSeenState";
 import type { WorldConversationBubblePanel } from "./world/WorldSurface";
 import { herdrOfficeSourcesFromRuntime } from "./world/worldRuntime";
-import {
-  EMPTY_OFFICE_OBSERVABILITY,
-  fetchOfficeObservability,
-} from "./world/officeObservability";
-import type { OfficeObservability } from "./world/officeObservability";
 import {
   DEFAULT_TERMINAL_INPUT_BATCH_DELAY_MS,
   DEFAULT_TERMINAL_INPUT_TRANSPORT,
@@ -1237,13 +1228,6 @@ export function App() {
   const [worldCompletionSeenKeys, setWorldCompletionSeenKeys] = useState<Set<string>>(
     () => readWorldCompletionSeenKeys(),
   );
-  const [worldObservability, setWorldObservability] = useState<OfficeObservability>(
-    EMPTY_OFFICE_OBSERVABILITY,
-  );
-  const [worldRoomAlignment, setWorldRoomAlignment] = useState(() => readWorldRoomAlignment());
-  const [worldLongRoomTitleMode, setWorldLongRoomTitleMode] = useState(
-    () => readWorldLongRoomTitleMode(),
-  );
   const [worldConversationTargets, setWorldConversationTargets] = useState<WorldConversationTarget[]>(
     () => readWorldConversationTargets(),
   );
@@ -1294,11 +1278,7 @@ export function App() {
   const [noteDeleteTarget, setNoteDeleteTarget] = useState<ScopedNoteEntry | null>(null);
   const [deletingNote, setDeletingNote] = useState(false);
   const [backendSettingsOpen, setBackendSettingsOpen] = useState(false);
-  const [worldSettingsOpen, setWorldSettingsOpen] = useState(false);
-  const [worldObservabilityRevision, setWorldObservabilityRevision] = useState(0);
   const backendSettingsReturnFocusRef = useRef<HTMLElement | null>(null);
-  const worldSettingsAppliedRef = useRef(new Map<string, string>());
-  const worldSettingsSyncRef = useRef(new Map<string, Promise<void>>());
   const openBackendSettings = useCallback(() => {
     backendSettingsReturnFocusRef.current =
       document.activeElement instanceof HTMLElement ? document.activeElement : null;
@@ -1314,63 +1294,15 @@ export function App() {
       }
     });
   }, []);
-  const openWorldSettings = useCallback(() => {
+  const prepareWorldSettingsOpen = useCallback(() => {
     setBackendSettingsOpen(false);
-    setWorldSettingsOpen(true);
   }, []);
-  const closeWorldSettings = useCallback(() => {
-    setWorldSettingsOpen(false);
-  }, []);
-  const markWorldSettingsSaved = useCallback(() => {
-    setWorldObservabilityRevision((revision) => revision + 1);
-    setWorldRoomAlignment(readWorldRoomAlignment());
-    setWorldLongRoomTitleMode(readWorldLongRoomTitleMode());
-  }, []);
-  const synchronizeStoredWorldSettings = useCallback(async (
-    runtimes: readonly BridgeRuntime[],
-  ) => {
-    const pending: Promise<void>[] = [];
-    for (const runtime of runtimes) {
-      const inFlight = worldSettingsSyncRef.current.get(runtime.id);
-      if (inFlight) {
-        pending.push(inFlight);
-        continue;
-      }
-      if (
-        runtime.capabilityState !== "ready" ||
-        !runtime.canConnect ||
-        !hasStoredWorldSettings(runtime.id)
-      ) {
-        continue;
-      }
-      const settings = readWorldSettings(runtime.id);
-      if (!settings) {
-        continue;
-      }
-      const value = settings.prometheusUrl ?? "";
-      const marker = `${runtime.generationKey}:${value}`;
-      if (worldSettingsAppliedRef.current.get(runtime.id) === marker) {
-        continue;
-      }
-      worldSettingsAppliedRef.current.set(runtime.id, marker);
-      const sync: Promise<void> = updateWorldObservabilityConfiguration(runtime, settings.prometheusUrl)
-        .then(() => undefined)
-        .catch(() => {
-          worldSettingsAppliedRef.current.delete(runtime.id);
-        });
-      worldSettingsSyncRef.current.set(runtime.id, sync);
-      void sync.finally(() => {
-        if (worldSettingsSyncRef.current.get(runtime.id) === sync) {
-          worldSettingsSyncRef.current.delete(runtime.id);
-        }
-      });
-      pending.push(sync);
-    }
-    await Promise.all(pending);
-  }, []);
-  useEffect(() => {
-    void synchronizeStoredWorldSettings(bridge.enabledRuntimes);
-  }, [bridge.enabledRuntimes, synchronizeStoredWorldSettings]);
+  const worldSettingsController = useWorldSettingsController({
+    active: activeSurface.id === "world",
+    runtimes: bridge.enabledRuntimes,
+    onBeforeOpen: prepareWorldSettingsOpen,
+  });
+  const { isOpen: worldSettingsOpen, close: closeWorldSettings } = worldSettingsController;
   const [terminalFontSizePx, setTerminalFontSizePx] = useState(
     initialPrefs.terminalFontSizePx,
   );
@@ -1681,36 +1613,6 @@ export function App() {
       : worldSources,
     [hostScope, selectedBridgeId, worldSources],
   );
-  useEffect(() => {
-    if (activeSurface.id !== "world") {
-      return;
-    }
-    let disposed = false;
-    const refresh = async () => {
-      await synchronizeStoredWorldSettings(bridge.enabledRuntimes);
-      if (disposed) {
-        return;
-      }
-      const next = await fetchOfficeObservability(bridge.enabledRuntimes).catch(() => ({
-        ...EMPTY_OFFICE_OBSERVABILITY,
-        health: "degraded" as const,
-      }));
-      if (!disposed) {
-        setWorldObservability(next);
-      }
-    };
-    void refresh();
-    const interval = window.setInterval(refresh, 30_000);
-    return () => {
-      disposed = true;
-      window.clearInterval(interval);
-    };
-  }, [
-    activeSurface.id,
-    bridge.enabledRuntimes,
-    synchronizeStoredWorldSettings,
-    worldObservabilityRevision,
-  ]);
   const worldProjection = useMemo(
     () => projectHerdrOffice(worldSourcesInScope, Date.now()),
     [worldSourcesInScope],
@@ -5193,7 +5095,7 @@ export function App() {
   };
   const worldSurfaceContext: WorldSurfaceContext = {
     projection: worldProjection,
-    observability: worldObservability,
+    observability: worldSettingsController.observability,
     selectedKey: worldSelectedKey,
     completionSeenKeys: worldCompletionSeenKeys,
     onSelect: selectWorldKey,
@@ -5206,8 +5108,8 @@ export function App() {
     onCloseConversation: closeWorldConversation,
     onFocusConversation: focusWorldConversation,
     agentActivityTransitions,
-    roomAlignment: worldRoomAlignment,
-    longRoomTitleMode: worldLongRoomTitleMode,
+    roomAlignment: worldSettingsController.roomAlignment,
+    longRoomTitleMode: worldSettingsController.longRoomTitleMode,
     canCreateSeat: canCreateWorldSeat,
     onNewSeat: openNewWorldSeat,
     canCreateRoom: canCreateWorldRoom,
@@ -5883,7 +5785,7 @@ export function App() {
       {backendSettingsOpen ? (
         <BackendSettingsDialog
           showMobileTerminalSettings={isTouchInput}
-          onOpenWorldSettings={openWorldSettings}
+          onOpenWorldSettings={worldSettingsController.open}
           notesEnabled={notesEnabled}
           onNotesEnabled={setNotesEnabled}
           navigationSyncMode={navigationSyncMode}
@@ -5929,9 +5831,7 @@ export function App() {
         />
       ) : null}
 
-      {worldSettingsOpen ? (
-        <WorldSettingsDialog onClose={closeWorldSettings} onSaved={markWorldSettingsSaved} />
-      ) : null}
+      <WorldSettingsOverlay controller={worldSettingsController} />
 
       {error ? (
         <div className="toast" role="alert">

--- a/web/src/surfaceRegistry.tsx
+++ b/web/src/surfaceRegistry.tsx
@@ -1,6 +1,8 @@
 import { lazy } from "react";
 import type { ComponentType, LazyExoticComponent } from "react";
 
+import { worldSurfaceDefinition } from "./world/worldSurfaceDefinition";
+
 export type SurfaceHostScope = "single-host" | "multi-host";
 
 export type SurfaceSlot = "sidebar" | "stage";
@@ -98,13 +100,5 @@ export const coreSurfaceRegistry = new SurfaceRegistry([
     requiredCapabilities: ["snapshot", "terminal_attach"],
     load: () => import("./SpacesSurface"),
   },
-  {
-    id: "world",
-    label: "Office",
-    route: "/world",
-    semanticIcon: "pixel-office",
-    hostScope: "multi-host",
-    requiredCapabilities: ["snapshot"],
-    load: () => import("./world/WorldSurface"),
-  },
+  worldSurfaceDefinition,
 ]);

--- a/web/src/world/WorldSettingsController.test.tsx
+++ b/web/src/world/WorldSettingsController.test.tsx
@@ -1,0 +1,118 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { BridgeRuntime } from "../bridge";
+import {
+  useWorldSettingsController,
+  type WorldSettingsController,
+} from "./WorldSettingsController";
+import { writeWorldSettings } from "./worldSettings";
+
+afterEach(() => {
+  localStorage.clear();
+  document.body.innerHTML = "";
+  vi.unstubAllGlobals();
+});
+
+describe("World settings controller", () => {
+  it("owns the settings overlay state and runs the shared-dialog handoff", async () => {
+    const onBeforeOpen = vi.fn();
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        <ControllerProbe runtimes={[]} active={false} onBeforeOpen={onBeforeOpen} />,
+      );
+    });
+    const button = container.querySelector("button");
+    expect(button?.dataset.open).toBe("false");
+
+    await act(async () => {
+      button?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    expect(onBeforeOpen).toHaveBeenCalledOnce();
+    expect(button?.dataset.open).toBe("true");
+
+    await act(async () => root.unmount());
+  });
+
+  it("applies stored observability settings through the qualified runtime", async () => {
+    writeWorldSettings("host-a", { prometheusUrl: "http://127.0.0.1:9101/" });
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      void input;
+      void init;
+      return new Response(JSON.stringify({
+        provider_id: "prometheus.otel",
+        configured: true,
+        endpoint: "http://127.0.0.1:9101/",
+      }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const runtime = testRuntime();
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(<ControllerProbe runtimes={[runtime]} active={false} />);
+    });
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledOnce());
+    const [url, init] = fetchMock.mock.calls[0] ?? [];
+    expect(url).toBe("http://host-a.test/api/extensions/observability/config");
+    expect(init).toMatchObject({
+      method: "PUT",
+      body: JSON.stringify({ prometheus_url: "http://127.0.0.1:9101/" }),
+    });
+
+    await act(async () => root.unmount());
+  });
+});
+
+function ControllerProbe({
+  runtimes,
+  active,
+  onBeforeOpen,
+}: {
+  runtimes: readonly BridgeRuntime[];
+  active: boolean;
+  onBeforeOpen?: () => void;
+}) {
+  const controller: WorldSettingsController = useWorldSettingsController({
+    runtimes,
+    active,
+    onBeforeOpen,
+  });
+  return (
+    <button type="button" data-open={String(controller.isOpen)} onClick={controller.open}>
+      Open settings
+    </button>
+  );
+}
+
+function testRuntime(): BridgeRuntime {
+  return {
+    id: "host-a",
+    mode: "configured",
+    label: "Host A",
+    color: "#89b4fa",
+    backend: null,
+    connectionKey: "connection-a",
+    capabilityGeneration: 1,
+    generationKey: "connection-a:1",
+    resumeToken: 0,
+    capabilities: { commands: [] },
+    capabilityState: "ready",
+    capabilityError: null,
+    canConnect: true,
+    httpUrl: (path) => `http://host-a.test${path}`,
+    wsUrl: (path) => `ws://host-a.test${path}`,
+  };
+}

--- a/web/src/world/WorldSettingsController.tsx
+++ b/web/src/world/WorldSettingsController.tsx
@@ -1,0 +1,156 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import type { BridgeRuntime } from "../bridge";
+import { WorldSettingsDialog } from "./WorldSettingsDialog";
+import type { OfficeLongRoomTitleMode, OfficeRoomAlignment } from "./officeGeometry";
+import {
+  EMPTY_OFFICE_OBSERVABILITY,
+  fetchOfficeObservability,
+} from "./officeObservability";
+import type { OfficeObservability } from "./officeObservability";
+import {
+  hasStoredWorldSettings,
+  readWorldLongRoomTitleMode,
+  readWorldRoomAlignment,
+  readWorldSettings,
+  updateWorldObservabilityConfiguration,
+} from "./worldSettings";
+
+export type WorldSettingsController = {
+  observability: OfficeObservability;
+  roomAlignment: OfficeRoomAlignment;
+  longRoomTitleMode: OfficeLongRoomTitleMode;
+  isOpen: boolean;
+  open: () => void;
+  close: () => void;
+  markSaved: () => void;
+};
+
+type UseWorldSettingsControllerOptions = {
+  active: boolean;
+  runtimes: readonly BridgeRuntime[];
+  onBeforeOpen?: () => void;
+};
+
+export function useWorldSettingsController({
+  active,
+  runtimes,
+  onBeforeOpen,
+}: UseWorldSettingsControllerOptions): WorldSettingsController {
+  const [observability, setObservability] = useState<OfficeObservability>(
+    EMPTY_OFFICE_OBSERVABILITY,
+  );
+  const [roomAlignment, setRoomAlignment] = useState(readWorldRoomAlignment);
+  const [longRoomTitleMode, setLongRoomTitleMode] = useState(readWorldLongRoomTitleMode);
+  const [isOpen, setOpen] = useState(false);
+  const [observabilityRevision, setObservabilityRevision] = useState(0);
+  const appliedSettingsRef = useRef(new Map<string, string>());
+  const settingsSyncRef = useRef(new Map<string, Promise<void>>());
+
+  const open = useCallback(() => {
+    onBeforeOpen?.();
+    setOpen(true);
+  }, [onBeforeOpen]);
+  const close = useCallback(() => setOpen(false), []);
+  const markSaved = useCallback(() => {
+    setObservabilityRevision((revision) => revision + 1);
+    setRoomAlignment(readWorldRoomAlignment());
+    setLongRoomTitleMode(readWorldLongRoomTitleMode());
+  }, []);
+
+  const synchronizeStoredSettings = useCallback(async (
+    currentRuntimes: readonly BridgeRuntime[],
+  ) => {
+    const pending: Promise<void>[] = [];
+    for (const runtime of currentRuntimes) {
+      const inFlight = settingsSyncRef.current.get(runtime.id);
+      if (inFlight) {
+        pending.push(inFlight);
+        continue;
+      }
+      if (
+        runtime.capabilityState !== "ready" ||
+        !runtime.canConnect ||
+        !hasStoredWorldSettings(runtime.id)
+      ) {
+        continue;
+      }
+      const settings = readWorldSettings(runtime.id);
+      if (!settings) {
+        continue;
+      }
+      const value = settings.prometheusUrl ?? "";
+      const marker = `${runtime.generationKey}:${value}`;
+      if (appliedSettingsRef.current.get(runtime.id) === marker) {
+        continue;
+      }
+      appliedSettingsRef.current.set(runtime.id, marker);
+      const sync: Promise<void> = updateWorldObservabilityConfiguration(
+        runtime,
+        settings.prometheusUrl,
+      )
+        .then(() => undefined)
+        .catch(() => {
+          appliedSettingsRef.current.delete(runtime.id);
+        });
+      settingsSyncRef.current.set(runtime.id, sync);
+      void sync.finally(() => {
+        if (settingsSyncRef.current.get(runtime.id) === sync) {
+          settingsSyncRef.current.delete(runtime.id);
+        }
+      });
+      pending.push(sync);
+    }
+    await Promise.all(pending);
+  }, []);
+
+  useEffect(() => {
+    void synchronizeStoredSettings(runtimes);
+  }, [runtimes, synchronizeStoredSettings]);
+
+  useEffect(() => {
+    if (!active) {
+      return;
+    }
+    let disposed = false;
+    const refresh = async () => {
+      await synchronizeStoredSettings(runtimes);
+      if (disposed) {
+        return;
+      }
+      const next = await fetchOfficeObservability(runtimes).catch(() => ({
+        ...EMPTY_OFFICE_OBSERVABILITY,
+        health: "degraded" as const,
+      }));
+      if (!disposed) {
+        setObservability(next);
+      }
+    };
+    void refresh();
+    const interval = window.setInterval(refresh, 30_000);
+    return () => {
+      disposed = true;
+      window.clearInterval(interval);
+    };
+  }, [active, observabilityRevision, runtimes, synchronizeStoredSettings]);
+
+  return {
+    observability,
+    roomAlignment,
+    longRoomTitleMode,
+    isOpen,
+    open,
+    close,
+    markSaved,
+  };
+}
+
+export function WorldSettingsOverlay({
+  controller,
+}: {
+  controller: WorldSettingsController;
+}) {
+  return controller.isOpen ? (
+    <WorldSettingsDialog onClose={controller.close} onSaved={controller.markSaved} />
+  ) : null;
+}

--- a/web/src/world/worldSurfaceDefinition.ts
+++ b/web/src/world/worldSurfaceDefinition.ts
@@ -1,0 +1,11 @@
+import type { SurfaceDefinition } from "../surfaceRegistry";
+
+export const worldSurfaceDefinition = {
+  id: "world",
+  label: "Office",
+  route: "/world",
+  semanticIcon: "pixel-office",
+  hostScope: "multi-host",
+  requiredCapabilities: ["snapshot"],
+  load: () => import("./WorldSurface"),
+} satisfies SurfaceDefinition;


### PR DESCRIPTION
## Summary

- move the World surface descriptor beside the World implementation, leaving the shared registry with a one-line registration seam
- move World settings state, stored observability synchronization, polling, and dialog orchestration out of the shared `App.tsx`
- add focused regression coverage for settings-dialog handoff and qualified per-runtime settings synchronization

This is a behavior-preserving frontend boundary cleanup. It does not change the bridge, protocol, terminal ownership, federation, shell, packaging, or release model.

## Validation

- `npm run lint:web`
- focused Vitest: 10 passed
- full frontend Vitest: 59 files / 434 tests passed
- vendored Herdr compatibility: 116 tests passed
- bridge: 162 tests passed
- `npm run test:observability`: 10 browser + 15 bridge tests passed
- `npm run test:security`
- `npm run test:independence`
- production frontend and bridge builds
- Playwright: 43 passed, 2 documented skips, and the known timing-sensitive Office conversation test failed once in the full run then passed in isolation
- `git diff --check`

## Live verification

The exact candidate is running as the sole listener on `127.0.0.1:8787` for owner testing. `/` and `/world` load successfully against Herdr 0.8.2 / terminal protocol 20; live browser smoke reported no console or page errors. The Herdr daemon and user data were not changed.
