### PR TITLE
refactor: isolate World room actions

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -184,6 +184,7 @@ import {
   useWorldSettingsController,
   WorldSettingsOverlay,
 } from "./world/WorldSettingsController";
+import { createWorldRoomActions } from "./world/worldRoomActions";
 import {
   readWorldCompletionSeenKeys,
   writeWorldCompletionSeenKeys,
@@ -4960,139 +4961,37 @@ export function App() {
   );
   const WorldSurface =
     activeSurface.id === "world" ? coreSurfaceRegistry.component("world") : null;
-  const canCreateWorldSeat = (roomKey: string) => {
-    const room = worldProjection.rooms.find(({ key }) => key === roomKey);
-    if (!room) {
-      return false;
-    }
-    const runtime = bridge.getRuntime(room.hostKey);
-    const state = runtime ? connectionStates[runtime.id] : null;
-    return Boolean(
-      runtimeFeatureReady(
-        runtime,
-        state,
-        "launcher_presets",
-        activeSurface.requiredCapabilities,
-      ) &&
-      supportsLauncherPresets(runtime?.capabilities) &&
-      runtimeCommandReady(
-        runtime,
-        state,
-        "tab.create",
-        activeSurface.requiredCapabilities,
-      ),
-    );
-  };
-  const openNewWorldSeat = (roomKey?: string) => {
-    const room = roomKey
-      ? worldProjection.rooms.find(({ key }) => key === roomKey)
-      : null;
-    const bridgeId = room?.hostKey ?? selectedRuntime?.id;
-    const workspaceId = room?.workspaceRef.nativeTargetId ?? activeSpace?.workspace_id ?? null;
-    if (!bridgeId) {
-      setWorldHandoffStatus("Select a connected workspace before starting a seat.");
-      return;
-    }
-    const runtime = bridge.getRuntime(bridgeId);
-    if (!runtime) {
-      setWorldHandoffStatus("Select a connected workspace before starting a seat.");
-      return;
-    }
-    if (!workspaceId) {
-      setWorldHandoffStatus("No active workspace is available on this host.");
-      return;
-    }
-    if (roomKey ? !canCreateWorldSeat(roomKey) : !createTabSupported) {
-      setWorldHandoffStatus("New seats are unavailable on this host.");
-      return;
-    }
-    setSelectedBridgeId(bridgeId);
-    setActiveWorkspaceRefState({ bridgeId, workspaceId });
-    setActiveWorkspacesByBridgeId((current) =>
-      current[bridgeId] === workspaceId ? current : { ...current, [bridgeId]: workspaceId },
-    );
-    setLaunchTarget({
-      mode: "tab",
-      workspaceId,
-      bridgeId,
-    });
-  };
-  const worldRoomForKey = (roomKey?: string) =>
-    roomKey ? worldProjection.rooms.find(({ key }) => key === roomKey) ?? null : null;
-  const worldRoomRuntime = (roomKey?: string) => {
-    const room = worldRoomForKey(roomKey);
-    return bridge.getRuntime(room?.hostKey ?? selectedRuntime?.id ?? "") ?? null;
-  };
-  const canCreateWorldRoom = (roomKey?: string) => {
-    const runtime = worldRoomRuntime(roomKey);
-    const state = runtime ? connectionStates[runtime.id] : null;
-    return Boolean(
-      runtimeCommandReady(
-        runtime,
-        state,
-        "workspace.create",
-        activeSurface.requiredCapabilities,
-      ),
-    );
-  };
-  const openNewWorldRoom = (roomKey?: string) => {
-    const runtime = worldRoomRuntime(roomKey);
-    if (!runtime || !canCreateWorldRoom(roomKey)) {
-      setWorldHandoffStatus("Room creation is unavailable on this host.");
-      return;
-    }
-    setSelectedBridgeId(runtime.id);
-    setDialog({
-      mode: "create",
-      kind: "space",
-      bridgeId: runtime.id,
-      id: "new",
-      label: "",
-      noun: "room",
-    });
-  };
-  const canManageWorldRoom = (roomKey: string, command: "workspace.rename" | "workspace.close") => {
-    const runtime = worldRoomRuntime(roomKey);
-    const state = runtime ? connectionStates[runtime.id] : null;
-    return Boolean(
-      runtimeCommandReady(
-        runtime,
-        state,
-        command,
-        activeSurface.requiredCapabilities,
-      ),
-    );
-  };
-  const openWorldRoomRename = (roomKey: string) => {
-    const room = worldRoomForKey(roomKey);
-    if (!room || !canManageWorldRoom(roomKey, "workspace.rename")) {
-      setWorldHandoffStatus("Room renaming is unavailable on this host.");
-      return;
-    }
-    setDialog({
-      mode: "rename",
-      kind: "space",
-      bridgeId: room.hostKey,
-      id: room.workspaceRef.nativeTargetId,
-      label: room.displayLabel,
-      noun: "room",
-    });
-  };
-  const openWorldRoomClose = (roomKey: string) => {
-    const room = worldRoomForKey(roomKey);
-    if (!room || !canManageWorldRoom(roomKey, "workspace.close")) {
-      setWorldHandoffStatus("Room closing is unavailable on this host.");
-      return;
-    }
-    setDialog({
-      mode: "close",
-      kind: "space",
-      bridgeId: room.hostKey,
-      id: room.workspaceRef.nativeTargetId,
-      label: room.displayLabel,
-      noun: "room",
-    });
-  };
+  const worldRoomActions = createWorldRoomActions({
+    projection: worldProjection,
+    getRuntime: bridge.getRuntime,
+    connectionStates,
+    selectedRuntimeId: selectedRuntime?.id ?? null,
+    selectedWorkspaceId: activeSpace?.workspace_id ?? null,
+    createTabSupported,
+    requiredCapabilities: activeSurface.requiredCapabilities,
+    onStatus: setWorldHandoffStatus,
+    onSelectBridge: setSelectedBridgeId,
+    onSelectWorkspace: (bridgeId, workspaceId) => {
+      setSelectedBridgeId(bridgeId);
+      setActiveWorkspaceRefState({ bridgeId, workspaceId });
+      setActiveWorkspacesByBridgeId((current) =>
+        current[bridgeId] === workspaceId ? current : { ...current, [bridgeId]: workspaceId },
+      );
+    },
+    onOpenSeatLauncher: ({ bridgeId, workspaceId }) => {
+      setLaunchTarget({ mode: "tab", workspaceId, bridgeId });
+    },
+    onOpenRoomDialog: ({ mode, bridgeId, workspaceId, label }) => {
+      setDialog({
+        mode,
+        kind: "space",
+        bridgeId,
+        id: workspaceId,
+        label,
+        noun: "room",
+      });
+    },
+  });
   const worldSurfaceContext: WorldSurfaceContext = {
     projection: worldProjection,
     observability: worldSettingsController.observability,
@@ -5110,14 +5009,14 @@ export function App() {
     agentActivityTransitions,
     roomAlignment: worldSettingsController.roomAlignment,
     longRoomTitleMode: worldSettingsController.longRoomTitleMode,
-    canCreateSeat: canCreateWorldSeat,
-    onNewSeat: openNewWorldSeat,
-    canCreateRoom: canCreateWorldRoom,
-    onCreateRoom: openNewWorldRoom,
-    canRenameRoom: (roomKey) => canManageWorldRoom(roomKey, "workspace.rename"),
-    onRenameRoom: openWorldRoomRename,
-    canCloseRoom: (roomKey) => canManageWorldRoom(roomKey, "workspace.close"),
-    onCloseRoom: openWorldRoomClose,
+    canCreateSeat: worldRoomActions.canCreateSeat,
+    onNewSeat: worldRoomActions.openNewSeat,
+    canCreateRoom: worldRoomActions.canCreateRoom,
+    onCreateRoom: worldRoomActions.openNewRoom,
+    canRenameRoom: worldRoomActions.canRenameRoom,
+    onRenameRoom: worldRoomActions.openRoomRename,
+    canCloseRoom: worldRoomActions.canCloseRoom,
+    onCloseRoom: worldRoomActions.openRoomClose,
   };
   const worldStage = WorldSurface ? (
     <SurfaceSlotBoundary label="Pixel Office" resetKey={activeSurface.id}>

--- a/web/src/world/worldRoomActions.test.ts
+++ b/web/src/world/worldRoomActions.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { BridgeRuntime } from "../bridge";
+import type { BridgeConnectionState } from "../runtimeConnection";
+import type { Snapshot } from "../types";
+import type { HerdrOfficeProjection, OfficeRoom } from "./herdrOfficeProjection";
+import { createWorldRoomActions } from "./worldRoomActions";
+
+describe("World room actions", () => {
+  it("routes a new seat to the room's qualified host and workspace", () => {
+    const hostA = runtime("host-a", ["snapshot", "launcher_presets"], ["tab.create"]);
+    const hostB = runtime("host-b", ["snapshot", "launcher_presets"], ["tab.create"]);
+    const callbacks = callbackSpies();
+    const actions = createWorldRoomActions({
+      ...options([hostA, hostB], [room("room-b", "host-b", "workspace-b")], callbacks),
+      selectedRuntimeId: "host-a",
+      selectedWorkspaceId: "workspace-a",
+    });
+
+    expect(actions.canCreateSeat("room-b")).toBe(true);
+    actions.openNewSeat("room-b");
+
+    expect(callbacks.onSelectWorkspace).toHaveBeenCalledWith("host-b", "workspace-b");
+    expect(callbacks.onOpenSeatLauncher).toHaveBeenCalledWith({
+      bridgeId: "host-b",
+      workspaceId: "workspace-b",
+    });
+    expect(callbacks.onStatus).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when a host omits one required capability or command", () => {
+    const host = runtime("host-a", ["snapshot"], ["workspace.rename"]);
+    const callbacks = callbackSpies();
+    const actions = createWorldRoomActions(
+      options([host], [room("room-a", "host-a", "workspace-a")], callbacks),
+    );
+
+    expect(actions.canCreateSeat("room-a")).toBe(false);
+    expect(actions.canCreateRoom("room-a")).toBe(false);
+    expect(actions.canRenameRoom("room-a")).toBe(true);
+    expect(actions.canCloseRoom("room-a")).toBe(false);
+
+    actions.openNewSeat("room-a");
+    expect(callbacks.onStatus).toHaveBeenLastCalledWith(
+      "New seats are unavailable on this host.",
+    );
+    expect(callbacks.onOpenSeatLauncher).not.toHaveBeenCalled();
+  });
+
+  it("emits bounded semantic dialog requests for room operations", () => {
+    const host = runtime(
+      "host-a",
+      ["snapshot"],
+      ["workspace.create", "workspace.rename", "workspace.close"],
+    );
+    const callbacks = callbackSpies();
+    const actions = createWorldRoomActions(
+      options([host], [room("room-a", "host-a", "workspace-a", "Studio")], callbacks),
+    );
+
+    actions.openNewRoom("room-a");
+    actions.openRoomRename("room-a");
+    actions.openRoomClose("room-a");
+
+    expect(callbacks.onOpenRoomDialog.mock.calls).toEqual([
+      [{ mode: "create", bridgeId: "host-a", workspaceId: "new", label: "" }],
+      [{
+        mode: "rename",
+        bridgeId: "host-a",
+        workspaceId: "workspace-a",
+        label: "Studio",
+      }],
+      [{
+        mode: "close",
+        bridgeId: "host-a",
+        workspaceId: "workspace-a",
+        label: "Studio",
+      }],
+    ]);
+    expect(callbacks.onSelectBridge).toHaveBeenCalledOnce();
+    expect(callbacks.onSelectBridge).toHaveBeenCalledWith("host-a");
+  });
+});
+
+function options(
+  runtimes: readonly BridgeRuntime[],
+  rooms: readonly OfficeRoom[],
+  callbacks: ReturnType<typeof callbackSpies>,
+) {
+  const states = Object.fromEntries(
+    runtimes.map((candidate) => [candidate.id, admittedState(candidate)]),
+  );
+  return {
+    projection: { rooms } as HerdrOfficeProjection,
+    getRuntime: (bridgeId: string | null | undefined) =>
+      runtimes.find(({ id }) => id === bridgeId) ?? null,
+    connectionStates: states,
+    selectedRuntimeId: runtimes[0]?.id ?? null,
+    selectedWorkspaceId: "selected-workspace",
+    createTabSupported: true,
+    requiredCapabilities: ["snapshot"],
+    ...callbacks,
+  };
+}
+
+function callbackSpies() {
+  return {
+    onStatus: vi.fn<(message: string) => void>(),
+    onSelectBridge: vi.fn<(bridgeId: string) => void>(),
+    onSelectWorkspace: vi.fn<(bridgeId: string, workspaceId: string) => void>(),
+    onOpenSeatLauncher: vi.fn(),
+    onOpenRoomDialog: vi.fn(),
+  };
+}
+
+function runtime(
+  id: string,
+  features: string[],
+  commands: string[],
+): BridgeRuntime {
+  return {
+    id,
+    mode: "configured",
+    label: id,
+    color: "#89b4fa",
+    backend: null,
+    connectionKey: `${id}:connection`,
+    capabilityGeneration: 1,
+    generationKey: `${id}:connection:1`,
+    resumeToken: 0,
+    capabilities: {
+      features,
+      commands,
+      launcher_presets: { version: 1 },
+    },
+    capabilityState: "ready",
+    capabilityError: null,
+    canConnect: true,
+    httpUrl: (path) => `http://${id}.test${path}`,
+    wsUrl: (path) => `ws://${id}.test${path}`,
+  };
+}
+
+function admittedState(candidate: BridgeRuntime): BridgeConnectionState {
+  return {
+    connectionKey: candidate.generationKey,
+    snapshot: {} as Snapshot,
+    loadState: "ready",
+  };
+}
+
+function room(
+  key: string,
+  hostKey: string,
+  workspaceId: string,
+  displayLabel = key,
+): OfficeRoom {
+  return {
+    key,
+    hostKey,
+    workspaceRef: {
+      profileId: hostKey,
+      kind: "workspace",
+      nativeTargetId: workspaceId,
+    },
+    observedGeneration: `${hostKey}:connection:1`,
+    displayLabel,
+    order: 0,
+    stale: false,
+    canOpenInSpaces: true,
+    desks: [],
+    roomAgents: [],
+    omittedDeskCount: 0,
+    omittedAgentCount: 0,
+    observedDeskCount: 0,
+    observedAgentCount: 0,
+  };
+}

--- a/web/src/world/worldRoomActions.ts
+++ b/web/src/world/worldRoomActions.ts
@@ -1,0 +1,165 @@
+import type { BridgeId, BridgeRuntime } from "../bridge";
+import { supportsLauncherPresets } from "../launcherPresets";
+import type { BridgeConnectionState } from "../runtimeConnection";
+import { runtimeCommandReady, runtimeFeatureReady } from "../runtimeClient";
+import type { HerdrOfficeProjection, OfficeRoom } from "./herdrOfficeProjection";
+
+export type WorldSeatLaunchRequest = {
+  bridgeId: BridgeId;
+  workspaceId: string;
+};
+
+export type WorldRoomDialogRequest = {
+  mode: "create" | "rename" | "close";
+  bridgeId: BridgeId;
+  workspaceId: string;
+  label: string;
+};
+
+type CreateWorldRoomActionsOptions = {
+  projection: HerdrOfficeProjection;
+  getRuntime: (bridgeId: BridgeId | null | undefined) => BridgeRuntime | null;
+  connectionStates: Readonly<Partial<Record<BridgeId, BridgeConnectionState>>>;
+  selectedRuntimeId: BridgeId | null;
+  selectedWorkspaceId: string | null;
+  createTabSupported: boolean;
+  requiredCapabilities: readonly string[];
+  onStatus: (message: string) => void;
+  onSelectBridge: (bridgeId: BridgeId) => void;
+  onSelectWorkspace: (bridgeId: BridgeId, workspaceId: string) => void;
+  onOpenSeatLauncher: (request: WorldSeatLaunchRequest) => void;
+  onOpenRoomDialog: (request: WorldRoomDialogRequest) => void;
+};
+
+export type WorldRoomActions = {
+  canCreateSeat: (roomKey: string) => boolean;
+  openNewSeat: (roomKey?: string) => void;
+  canCreateRoom: (roomKey?: string) => boolean;
+  openNewRoom: (roomKey?: string) => void;
+  canRenameRoom: (roomKey: string) => boolean;
+  openRoomRename: (roomKey: string) => void;
+  canCloseRoom: (roomKey: string) => boolean;
+  openRoomClose: (roomKey: string) => void;
+};
+
+export function createWorldRoomActions({
+  projection,
+  getRuntime,
+  connectionStates,
+  selectedRuntimeId,
+  selectedWorkspaceId,
+  createTabSupported,
+  requiredCapabilities,
+  onStatus,
+  onSelectBridge,
+  onSelectWorkspace,
+  onOpenSeatLauncher,
+  onOpenRoomDialog,
+}: CreateWorldRoomActionsOptions): WorldRoomActions {
+  const roomForKey = (roomKey?: string) =>
+    roomKey ? projection.rooms.find(({ key }) => key === roomKey) ?? null : null;
+
+  const runtimeForRoom = (room?: OfficeRoom | null) =>
+    getRuntime(room?.hostKey ?? selectedRuntimeId) ?? null;
+
+  const canCreateSeat = (roomKey: string) => {
+    const room = roomForKey(roomKey);
+    if (!room) {
+      return false;
+    }
+    const runtime = runtimeForRoom(room);
+    const state = runtime ? connectionStates[runtime.id] : null;
+    return Boolean(
+      runtimeFeatureReady(runtime, state, "launcher_presets", requiredCapabilities) &&
+      supportsLauncherPresets(runtime?.capabilities) &&
+      runtimeCommandReady(runtime, state, "tab.create", requiredCapabilities),
+    );
+  };
+
+  const openNewSeat = (roomKey?: string) => {
+    const room = roomForKey(roomKey);
+    const bridgeId = room?.hostKey ?? selectedRuntimeId;
+    const workspaceId = room?.workspaceRef.nativeTargetId ?? selectedWorkspaceId;
+    if (!bridgeId || !getRuntime(bridgeId)) {
+      onStatus("Select a connected workspace before starting a seat.");
+      return;
+    }
+    if (!workspaceId) {
+      onStatus("No active workspace is available on this host.");
+      return;
+    }
+    if (roomKey ? !canCreateSeat(roomKey) : !createTabSupported) {
+      onStatus("New seats are unavailable on this host.");
+      return;
+    }
+    onSelectWorkspace(bridgeId, workspaceId);
+    onOpenSeatLauncher({ bridgeId, workspaceId });
+  };
+
+  const canCreateRoom = (roomKey?: string) => {
+    const runtime = runtimeForRoom(roomForKey(roomKey));
+    const state = runtime ? connectionStates[runtime.id] : null;
+    return Boolean(
+      runtimeCommandReady(runtime, state, "workspace.create", requiredCapabilities),
+    );
+  };
+
+  const openNewRoom = (roomKey?: string) => {
+    const runtime = runtimeForRoom(roomForKey(roomKey));
+    if (!runtime || !canCreateRoom(roomKey)) {
+      onStatus("Room creation is unavailable on this host.");
+      return;
+    }
+    onSelectBridge(runtime.id);
+    onOpenRoomDialog({
+      mode: "create",
+      bridgeId: runtime.id,
+      workspaceId: "new",
+      label: "",
+    });
+  };
+
+  const canManageRoom = (
+    roomKey: string,
+    command: "workspace.rename" | "workspace.close",
+  ) => {
+    const room = roomForKey(roomKey);
+    const runtime = runtimeForRoom(room);
+    const state = runtime ? connectionStates[runtime.id] : null;
+    return Boolean(
+      room && runtimeCommandReady(runtime, state, command, requiredCapabilities),
+    );
+  };
+
+  const openRoomDialog = (
+    roomKey: string,
+    mode: "rename" | "close",
+    unavailableMessage: string,
+  ) => {
+    const room = roomForKey(roomKey);
+    const command = mode === "rename" ? "workspace.rename" : "workspace.close";
+    if (!room || !canManageRoom(roomKey, command)) {
+      onStatus(unavailableMessage);
+      return;
+    }
+    onOpenRoomDialog({
+      mode,
+      bridgeId: room.hostKey,
+      workspaceId: room.workspaceRef.nativeTargetId,
+      label: room.displayLabel,
+    });
+  };
+
+  return {
+    canCreateSeat,
+    openNewSeat,
+    canCreateRoom,
+    openNewRoom,
+    canRenameRoom: (roomKey) => canManageRoom(roomKey, "workspace.rename"),
+    openRoomRename: (roomKey) =>
+      openRoomDialog(roomKey, "rename", "Room renaming is unavailable on this host."),
+    canCloseRoom: (roomKey) => canManageRoom(roomKey, "workspace.close"),
+    openRoomClose: (roomKey) =>
+      openRoomDialog(roomKey, "close", "Room closing is unavailable on this host."),
+  };
+}


### PR DESCRIPTION
## Summary

- move World room and seat capability gating out of the shared application shell
- expose a narrow World-owned action controller that emits semantic workspace selection, launcher, dialog, and status callbacks
- add focused coverage for exact multi-host routing, fail-closed admission, and bounded create/rename/close requests

This is a behavior-preserving frontend refactor. It does not change bridge commands, terminal ownership, federation, protocol, packaging, or release behavior.

## Validation

- `npm run check`: passed
  - 60 frontend files / 437 tests
  - 116 vendored compatibility tests plus 3 protocol-20 fixtures
  - 162 bridge tests
  - production frontend and bridge builds
- Playwright: 44 passed, 2 documented skips
- `npm run test:security`: passed with the existing three allowed Rust advisory warnings
- `npm run test:independence`: passed
- `git diff --check`: passed

## Live verification

The exact candidate is the sole listener on `127.0.0.1:8787`. `/world` renders against Herdr 0.8.2 / terminal protocol 20, room actions are present, the existing 5 workspaces / 11 tabs / 11 panes are observed, and the browser smoke reported no console or page errors. The Herdr daemon and user data were not changed.
