### PR TITLE
refactor: isolate World conversations

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -167,7 +167,6 @@ import {
   parseTerminalScreenReaderText,
 } from "./terminalAccessibleText";
 import { terminalSessionDescriptor } from "./terminalSessions";
-import type { TerminalSessionDescriptor } from "./terminalSessions";
 import { coreSurfaceRegistry } from "./surfaceRegistry";
 import { SurfaceSlotBoundary } from "./SurfaceSlotBoundary";
 import type { WorldSurfaceContext } from "./world/WorldSurface";
@@ -179,7 +178,11 @@ import {
 import type { OfficeHandoffRequest } from "./world/herdrOfficeHandoff";
 import { projectHerdrOffice } from "./world/herdrOfficeProjection";
 import type { OfficeAgent } from "./world/herdrOfficeProjection";
-import { WorldConversationBubble } from "./world/WorldConversationBubble";
+import {
+  useWorldConversationController,
+  worldConversationAdmissionPending,
+} from "./world/WorldConversationController";
+import type { WorldConversationTargetInput } from "./world/WorldConversationController";
 import {
   useWorldSettingsController,
   WorldSettingsOverlay,
@@ -189,7 +192,6 @@ import {
   readWorldCompletionSeenKeys,
   writeWorldCompletionSeenKeys,
 } from "./world/completionSeenState";
-import type { WorldConversationBubblePanel } from "./world/WorldSurface";
 import { herdrOfficeSourcesFromRuntime } from "./world/worldRuntime";
 import {
   DEFAULT_TERMINAL_INPUT_BATCH_DELAY_MS,
@@ -252,15 +254,6 @@ type AgentSort = "attention" | "status" | "workspace" | "lastStatusChange";
 type AgentGroup = "none" | "host" | "workspace" | "hostWorkspace";
 type SpaceGroup = "none" | "host";
 type MenuKind = "space" | "tab" | "pane";
-type WorldConversationTarget = {
-  windowId: string;
-  kind: "agent" | "desk";
-  targetKey: string;
-  agentKey: string | null;
-  bridgeId: BridgeId;
-  paneId: string;
-  generationKey: string;
-};
 type PendingWorldPaneSelection = {
   bridgeId: BridgeId;
   paneId: string;
@@ -272,114 +265,6 @@ type PendingWorldSeatLaunch = {
   baselineTabIds: ReadonlySet<string>;
   baselinePaneIds: ReadonlySet<string>;
 };
-type WorldConversationView = {
-  windowId: string;
-  agent: OfficeAgent | null;
-  targetLabel: string;
-  hostLabel: string;
-  pane: PaneInfo;
-  runtime: BridgeRuntime;
-  session: TerminalSessionDescriptor;
-  targetKey: string;
-};
-
-const MAX_WORLD_CONVERSATIONS = 5;
-const WORLD_CONVERSATIONS_STORAGE_KEY = "herdrWeb.worldConversations.v1";
-
-function worldConversationWindowId(bridgeId: BridgeId, paneId: string) {
-  return `${bridgeId}:${paneId}`;
-}
-
-function readWorldConversationTargets(): WorldConversationTarget[] {
-  try {
-    const raw = globalThis.sessionStorage?.getItem(WORLD_CONVERSATIONS_STORAGE_KEY);
-    if (!raw) {
-      return [];
-    }
-    const parsed = JSON.parse(raw);
-    if (!Array.isArray(parsed)) {
-      return [];
-    }
-    const targets = parsed.flatMap((value: unknown) => {
-      if (!value || typeof value !== "object" || Array.isArray(value)) {
-        return [];
-      }
-      const record = value as Record<string, unknown>;
-      if (
-        (record.kind !== "agent" && record.kind !== "desk") ||
-        typeof record.targetKey !== "string" ||
-        typeof record.bridgeId !== "string" ||
-        typeof record.paneId !== "string" ||
-        typeof record.generationKey !== "string" ||
-        (record.agentKey !== null && typeof record.agentKey !== "string")
-      ) {
-        return [];
-      }
-      return [{
-        windowId: worldConversationWindowId(record.bridgeId, record.paneId),
-        kind: record.kind,
-        targetKey: record.targetKey,
-        agentKey: record.agentKey as string | null,
-        bridgeId: record.bridgeId,
-        paneId: record.paneId,
-        generationKey: record.generationKey,
-      } satisfies WorldConversationTarget];
-    });
-    return targets.slice(0, MAX_WORLD_CONVERSATIONS);
-  } catch {
-    return [];
-  }
-}
-
-function writeWorldConversationTargets(targets: readonly WorldConversationTarget[]) {
-  try {
-    globalThis.sessionStorage?.setItem(
-      WORLD_CONVERSATIONS_STORAGE_KEY,
-      JSON.stringify(targets.map((target) => ({
-        kind: target.kind,
-        targetKey: target.targetKey,
-        agentKey: target.agentKey,
-        bridgeId: target.bridgeId,
-        paneId: target.paneId,
-        generationKey: target.generationKey,
-      }))),
-    );
-  } catch {
-    // Session storage can be unavailable in private or locked-down contexts.
-  }
-}
-
-function worldConversationAdmissionPending(
-  runtime: BridgeRuntime | null,
-  state: BridgeConnectionState | null | undefined,
-  generationKey: string,
-) {
-  return Boolean(
-    runtime &&
-      runtime.generationKey === generationKey &&
-      (runtime.capabilityState === "idle" ||
-        runtime.capabilityState === "probing" ||
-        !state ||
-        state.connectionKey !== generationKey ||
-        state.loadState === "loading" ||
-        (state.snapshot === null && state.loadState !== "error")),
-  );
-}
-
-function worldConversationObservationPending(
-  runtime: BridgeRuntime | null,
-  state: BridgeConnectionState | null | undefined,
-) {
-  return Boolean(
-    !runtime ||
-      !state ||
-      runtime.capabilityState === "idle" ||
-      runtime.capabilityState === "probing" ||
-      state.connectionKey !== runtime.generationKey ||
-      state.loadState !== "ready" ||
-      state.snapshot === null,
-  );
-}
 
 export function findNewWorldSeatPane(
   snapshot: Snapshot | null,
@@ -1229,17 +1114,10 @@ export function App() {
   const [worldCompletionSeenKeys, setWorldCompletionSeenKeys] = useState<Set<string>>(
     () => readWorldCompletionSeenKeys(),
   );
-  const [worldConversationTargets, setWorldConversationTargets] = useState<WorldConversationTarget[]>(
-    () => readWorldConversationTargets(),
-  );
   const pendingWorldPaneSelectionRef = useRef<PendingWorldPaneSelection | null>(null);
   const pendingWorldSeatLaunchRef = useRef<PendingWorldSeatLaunch | null>(null);
-  const worldConversationCacheRef = useRef<Map<string, WorldConversationView>>(new Map());
   const worldCanvasSelectionTimerRef = useRef<number | null>(null);
   const worldSelectionSeedPendingRef = useRef(false);
-  useEffect(() => {
-    writeWorldConversationTargets(worldConversationTargets);
-  }, [worldConversationTargets]);
   useEffect(() => () => {
     if (worldCanvasSelectionTimerRef.current !== null) {
       window.clearTimeout(worldCanvasSelectionTimerRef.current);
@@ -1634,62 +1512,29 @@ export function App() {
       worldCanvasSelectionTimerRef.current = null;
     }
   };
-  const selectWorldAgent = (agent: WorldConversationTarget | null) => {
+  const selectWorldAgent = (agent: WorldConversationTargetInput) => {
     cancelWorldCanvasSelection();
     pendingWorldPaneSelectionRef.current = null;
     officeDebug("selection:target-set", {
-      target: agent
-        ? {
-            kind: agent.kind,
-            targetKey: agent.targetKey,
-            agentKey: agent.agentKey,
-            bridgeId: agent.bridgeId,
-            paneId: agent.paneId,
-            generationKey: agent.generationKey,
-          }
-        : null,
+      target: {
+        kind: agent.kind,
+        targetKey: agent.targetKey,
+        agentKey: agent.agentKey,
+        bridgeId: agent.bridgeId,
+        paneId: agent.paneId,
+        generationKey: agent.generationKey,
+      },
     });
-    if (!agent) {
-      setWorldConversationTargets([]);
-      worldConversationCacheRef.current.clear();
-      return;
-    }
-    const windowId = worldConversationWindowId(agent.bridgeId, agent.paneId);
-    const target = { ...agent, windowId };
-    const existing = worldConversationTargets.some(({ windowId: id }) => id === windowId);
-    if (!existing && !isCompactLayout && worldConversationTargets.length >= MAX_WORLD_CONVERSATIONS) {
-      setWorldHandoffStatus("Five Office terminals are open. Close one before opening another.");
-      return;
-    }
-    setSelectedBridgeId(agent.bridgeId);
-    setWorldSelectedKey(agent.agentKey ?? agent.targetKey);
-    setWorldHandoffStatus(null);
-    setWorldConversationTargets((current) => {
-      const index = current.findIndex(({ windowId: id }) => id === windowId);
-      if (index < 0) {
-        return isCompactLayout ? [target] : [...current, target];
-      }
-      return current.map((currentTarget, currentIndex) =>
-        currentIndex === index ? target : currentTarget,
-      );
-    });
+    worldConversationController.open(agent);
   };
   const closeWorldConversation = (windowId: string) => {
-    worldConversationCacheRef.current.delete(windowId);
-    setWorldConversationTargets((current) => current.filter(({ windowId: id }) => id !== windowId));
+    worldConversationController.close(windowId);
   };
   const clearWorldConversations = () => {
-    setWorldConversationTargets([]);
-    worldConversationCacheRef.current.clear();
+    worldConversationController.clear();
   };
   const focusWorldConversation = (windowId: string) => {
-    const target = worldConversationTargets.find(({ windowId: id }) => id === windowId);
-    if (!target) {
-      return;
-    }
-    setWorldSelectedKey(target.agentKey ?? target.targetKey);
-    setSelectedBridgeId(target.bridgeId);
-    setWorldHandoffStatus(null);
+    worldConversationController.focus(windowId);
   };
   const selectWorldProjectedAgent = (agent: {
     key: string;
@@ -1744,7 +1589,6 @@ export function App() {
       markWorldCompletionSeen(agent.key);
     }
     selectWorldAgent({
-      windowId: worldConversationWindowId(agent.hostKey, pane.pane_id),
       kind: "agent",
       targetKey: agent.key,
       agentKey: agent.key,
@@ -1816,7 +1660,6 @@ export function App() {
       markWorldCompletionSeen(occupant.key);
     }
     selectWorldAgent({
-      windowId: worldConversationWindowId(desk.hostKey, pane.pane_id),
       kind: "desk",
       targetKey: desk.key,
       agentKey: occupant?.key ?? null,
@@ -2154,6 +1997,30 @@ export function App() {
     () => buildAgentActivityTransitionMap(bridgeViews, agentActivityStates),
     [agentActivityStates, bridgeViews],
   );
+  const worldConversationController = useWorldConversationController({
+    active: activeSurface.id === "world",
+    compact: isCompactLayout,
+    projection: worldProjection,
+    getRuntime: bridge.getRuntime,
+    connectionStates,
+    onSelectBridge: setSelectedBridgeId,
+    onSelectKey: setWorldSelectedKey,
+    onStatus: setWorldHandoffStatus,
+    onOpenInSpaces: openWorldConversationInSpaces,
+    agentActivityTransitions,
+    terminalScreenReaderText,
+    touchInput: isTouchInput,
+    terminalFontSizePx,
+    mobileControlsScalePercent,
+    mobileTapTarget: mobileTerminalTapTarget,
+    mobileLongPressBehavior,
+    mobileTouchSelectionEndpointTimeoutMs,
+    mobileCommandExpandingInput,
+    mobileCommandEnterNewline,
+    terminalInputTransport,
+    terminalInputBatchDelayMs,
+    terminalOutputCoalesceMs,
+  });
   const effectiveAgentPinnedOnly =
     visibleHostBridgeViews(bridgeViews, selectedBridgeId, hostScope).some((view) =>
       supportsAgentPins(view.runtime.capabilities),
@@ -4756,209 +4623,7 @@ export function App() {
     activeSurface.requiredCapabilities,
   );
   const renderTerminal = !isCompactLayout || showDetail;
-  const worldConversations = useMemo(() => {
-    if (activeSurface.id !== "world") {
-      return [] as WorldConversationView[];
-    }
-    return worldConversationTargets.flatMap((worldConversationTarget) => {
-      const agentEntry = worldConversationTarget.agentKey
-        ? worldProjection.roster.find(
-            ({ agent }) => agent.key === worldConversationTarget.agentKey,
-          ) ?? null
-        : null;
-      const deskEntry = worldConversationTarget.kind === "desk"
-        ? worldProjection.deskRoster.find(
-            ({ desk }) => desk.key === worldConversationTarget.targetKey,
-          ) ?? null
-        : null;
-      const runtime = bridge.getRuntime(worldConversationTarget.bridgeId);
-      const state = runtime &&
-          connectionStates[runtime.id]?.connectionKey === runtime.generationKey
-        ? connectionStates[runtime.id]
-        : null;
-      const pane = state?.snapshot?.panes.find(
-        ({ pane_id }) => pane_id === worldConversationTarget.paneId,
-      ) ?? null;
-      const agent = agentEntry?.agent ?? null;
-      const runtimeMatchesTarget = Boolean(
-        runtime && runtime.generationKey === worldConversationTarget.generationKey,
-      );
-      const observationPending = worldConversationObservationPending(runtime, state);
-      const paneStillObserved = Boolean(
-        state?.snapshot?.panes.some(({ pane_id }) => pane_id === worldConversationTarget.paneId),
-      );
-      if (
-        runtimeMatchesTarget &&
-        runtime &&
-        state &&
-        pane &&
-        runtimeAdmissionReady(runtime, state, ["snapshot", "terminal_attach"])
-      ) {
-        const session = terminalSessionDescriptor(runtime, pane, state, ["snapshot"]);
-        if (session?.attachEnabled) {
-          const next: WorldConversationView = {
-            windowId: worldConversationTarget.windowId,
-            agent,
-            targetLabel:
-              agent?.displayLabel ??
-              pane.display_agent ??
-              pane.label ??
-              pane.title ??
-              pane.terminal_title ??
-              "Shell",
-            hostLabel: agentEntry?.hostLabel ?? deskEntry?.hostLabel ?? "Host",
-            pane,
-            runtime,
-            session,
-            targetKey: worldConversationTarget.targetKey,
-          };
-          // Keep the last admitted terminal view across a transient observation
-          // refresh. The terminal identity is the selected pane, not the
-          // agent's animated destination or the desk's current occupant.
-          worldConversationCacheRef.current.set(worldConversationTarget.windowId, next);
-          return [next];
-        }
-      }
-
-      const cached = worldConversationCacheRef.current.get(worldConversationTarget.windowId);
-      if (
-        runtimeMatchesTarget &&
-        cached?.targetKey === worldConversationTarget.targetKey &&
-        (observationPending || paneStillObserved)
-      ) {
-        return [{
-          ...cached,
-          agent: agent ?? cached.agent,
-          targetLabel: agent?.displayLabel ?? cached.targetLabel,
-          hostLabel: agentEntry?.hostLabel ?? deskEntry?.hostLabel ?? cached.hostLabel,
-        }];
-      }
-      return [];
-    });
-  }, [
-    activeSurface.id,
-    bridge,
-    connectionStates,
-    worldConversationTargets,
-    worldProjection,
-  ]);
-  useEffect(() => {
-    officeDebug("conversation:views", {
-      visible: worldConversations.length,
-      targets: worldConversationTargets.length,
-      windows: worldConversations.map(({ windowId, targetKey, session }) => ({
-        windowId,
-        targetKey,
-        sessionKey: session.sessionKey,
-      })),
-      activeSurface: activeSurface.id,
-    });
-  }, [activeSurface.id, worldConversationTargets.length, worldConversations]);
-  useEffect(() => {
-    if (activeSurface.id !== "world") {
-      return;
-    }
-    const targetsToClose = new Set<string>();
-    const targetsToRebind = new Map<string, string>();
-    for (const target of worldConversationTargets) {
-      const runtime = bridge.getRuntime(target.bridgeId);
-      const state = runtime ? connectionStates[runtime.id] : null;
-      if (worldConversationObservationPending(runtime, state)) {
-        continue;
-      }
-      const paneStillObserved = Boolean(
-        state?.snapshot?.panes.some(({ pane_id }) => pane_id === target.paneId),
-      );
-      if (paneStillObserved && runtime && runtime.generationKey !== target.generationKey) {
-        targetsToRebind.set(target.windowId, runtime.generationKey);
-        continue;
-      }
-      if (paneStillObserved) {
-        continue;
-      }
-      targetsToClose.add(target.windowId);
-      officeDebug("conversation:cleanup-check", {
-        windowId: target.windowId,
-        targetKey: target.targetKey,
-        activeSurface: activeSurface.id,
-        reason: "pane-absent-from-admitted-snapshot",
-      });
-    }
-    if (targetsToClose.size === 0 && targetsToRebind.size === 0) {
-      return;
-    }
-    for (const windowId of targetsToClose) {
-      worldConversationCacheRef.current.delete(windowId);
-    }
-    for (const windowId of targetsToRebind.keys()) {
-      worldConversationCacheRef.current.delete(windowId);
-    }
-    setWorldConversationTargets((current) =>
-      current.flatMap((target) => {
-        if (targetsToClose.has(target.windowId)) {
-          return [];
-        }
-        const generationKey = targetsToRebind.get(target.windowId);
-        return generationKey ? [{ ...target, generationKey }] : [target];
-      }),
-    );
-  }, [activeSurface.id, bridge, connectionStates, worldConversationTargets]);
-  const worldConversationPanels = useMemo<WorldConversationBubblePanel[]>(
-    () => worldConversations.map((worldConversation) => ({
-      id: worldConversation.windowId,
-      targetKey: worldConversation.targetKey,
-      selectedKey: worldConversation.agent?.key ?? null,
-      content: (
-        <WorldConversationBubble
-          key={`${worldConversation.windowId}:${worldConversation.session.sessionKey}`}
-          agent={worldConversation.agent}
-          targetLabel={worldConversation.targetLabel}
-          hostLabel={worldConversation.hostLabel}
-          pane={worldConversation.pane}
-          runtime={worldConversation.runtime}
-          session={worldConversation.session}
-          onClose={() => closeWorldConversation(worldConversation.windowId)}
-          onOpenInSpaces={() =>
-            openWorldConversationInSpaces(
-              worldConversation.windowId,
-              worldConversation.runtime.id,
-              worldConversation.pane,
-            )
-          }
-          agentActivityTransitions={agentActivityTransitions}
-          terminalScreenReaderText={terminalScreenReaderText}
-          touchInput={isTouchInput}
-          terminalFontSizePx={terminalFontSizePx}
-          mobileControlsScalePercent={mobileControlsScalePercent}
-          mobileTapTarget={mobileTerminalTapTarget}
-          mobileLongPressBehavior={mobileLongPressBehavior}
-          mobileTouchSelectionEndpointTimeoutMs={mobileTouchSelectionEndpointTimeoutMs}
-          mobileCommandExpandingInput={mobileCommandExpandingInput}
-          mobileCommandEnterNewline={mobileCommandEnterNewline}
-          terminalInputTransport={terminalInputTransport}
-          terminalInputBatchDelayMs={terminalInputBatchDelayMs}
-          terminalOutputCoalesceMs={terminalOutputCoalesceMs}
-        />
-      ),
-    })),
-    [
-      closeWorldConversation,
-      isTouchInput,
-      mobileCommandEnterNewline,
-      mobileCommandExpandingInput,
-      mobileControlsScalePercent,
-      mobileLongPressBehavior,
-      mobileTerminalTapTarget,
-      mobileTouchSelectionEndpointTimeoutMs,
-      openWorldConversationInSpaces,
-      terminalInputBatchDelayMs,
-      terminalInputTransport,
-      terminalOutputCoalesceMs,
-      terminalFontSizePx,
-      terminalScreenReaderText,
-      worldConversations,
-    ],
-  );
+  const worldConversationPanels = worldConversationController.panels;
   const WorldSurface =
     activeSurface.id === "world" ? coreSurfaceRegistry.component("world") : null;
   const worldRoomActions = createWorldRoomActions({

--- a/web/src/world/WorldConversationController.test.ts
+++ b/web/src/world/WorldConversationController.test.ts
@@ -1,0 +1,119 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import type { BridgeRuntime } from "../bridge";
+import type { BridgeConnectionState } from "../runtimeConnection";
+import type { Snapshot } from "../types";
+import {
+  readWorldConversationTargets,
+  worldConversationAdmissionPending,
+} from "./WorldConversationController";
+
+const STORAGE_KEY = "herdrWeb.worldConversations.v1";
+
+afterEach(() => {
+  sessionStorage.clear();
+});
+
+describe("World conversation controller boundary", () => {
+  it("restores only bounded valid targets and derives their window identity", () => {
+    sessionStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify([
+        ...Array.from({ length: 6 }, (_, index) => ({
+          windowId: "untrusted",
+          kind: index % 2 === 0 ? "agent" : "desk",
+          targetKey: `target-${index}`,
+          agentKey: index % 2 === 0 ? `agent-${index}` : null,
+          bridgeId: `host-${index}`,
+          paneId: `pane-${index}`,
+          generationKey: `generation-${index}`,
+        })),
+        { kind: "agent", targetKey: "missing-runtime-fields" },
+      ]),
+    );
+
+    expect(readWorldConversationTargets()).toHaveLength(5);
+    expect(readWorldConversationTargets()[0]).toMatchObject({
+      windowId: "host-0:pane-0",
+      targetKey: "target-0",
+    });
+    expect(readWorldConversationTargets().map(({ targetKey }) => targetKey)).not.toContain(
+      "missing-runtime-fields",
+    );
+  });
+
+  it("keeps a current target pending only while capability or snapshot admission is unresolved", () => {
+    const candidate = runtime();
+
+    expect(worldConversationAdmissionPending(candidate, null, candidate.generationKey)).toBe(
+      true,
+    );
+    expect(
+      worldConversationAdmissionPending(
+        { ...candidate, capabilityState: "probing" },
+        null,
+        candidate.generationKey,
+      ),
+    ).toBe(true);
+    expect(
+      worldConversationAdmissionPending(
+        candidate,
+        state(candidate.generationKey, "loading"),
+        candidate.generationKey,
+      ),
+    ).toBe(true);
+    expect(
+      worldConversationAdmissionPending(
+        candidate,
+        state(candidate.generationKey, "ready"),
+        candidate.generationKey,
+      ),
+    ).toBe(false);
+    expect(
+      worldConversationAdmissionPending(
+        candidate,
+        state(candidate.generationKey, "error"),
+        candidate.generationKey,
+      ),
+    ).toBe(false);
+    expect(
+      worldConversationAdmissionPending(candidate, null, "stale-generation"),
+    ).toBe(false);
+  });
+});
+
+function runtime(): BridgeRuntime {
+  return {
+    id: "host-a",
+    mode: "configured",
+    label: "Host A",
+    color: "#89b4fa",
+    backend: null,
+    connectionKey: "host-a:connection",
+    capabilityGeneration: 1,
+    generationKey: "host-a:connection:capability:1",
+    resumeToken: 0,
+    capabilities: {
+      features: ["snapshot", "terminal_attach"],
+      commands: [],
+    },
+    capabilityState: "ready",
+    capabilityError: null,
+    canConnect: true,
+    httpUrl: (path) => path,
+    wsUrl: (path) => path,
+  };
+}
+
+function state(
+  connectionKey: string,
+  loadState: BridgeConnectionState["loadState"],
+): BridgeConnectionState {
+  return {
+    connectionKey,
+    snapshot: loadState === "ready" ? ({} as Snapshot) : null,
+    loadState,
+  };
+}

--- a/web/src/world/WorldConversationController.tsx
+++ b/web/src/world/WorldConversationController.tsx
@@ -1,0 +1,440 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { ComponentProps } from "react";
+
+import type { BridgeId, BridgeRuntime } from "../bridge";
+import type { BridgeConnectionState } from "../runtimeConnection";
+import { runtimeAdmissionReady } from "../runtimeClient";
+import { terminalSessionDescriptor } from "../terminalSessions";
+import type { TerminalSessionDescriptor } from "../terminalSessions";
+import type { PaneInfo } from "../types";
+import { officeDebug } from "../officeDebug";
+import { WorldConversationBubble } from "./WorldConversationBubble";
+import type { WorldConversationBubblePanel } from "./WorldSurface";
+import type { HerdrOfficeProjection, OfficeAgent } from "./herdrOfficeProjection";
+
+export type WorldConversationTargetInput = {
+  kind: "agent" | "desk";
+  targetKey: string;
+  agentKey: string | null;
+  bridgeId: BridgeId;
+  paneId: string;
+  generationKey: string;
+};
+
+export type WorldConversationTarget = WorldConversationTargetInput & {
+  windowId: string;
+};
+
+type WorldConversationView = {
+  windowId: string;
+  agent: OfficeAgent | null;
+  targetLabel: string;
+  hostLabel: string;
+  pane: PaneInfo;
+  runtime: BridgeRuntime;
+  session: TerminalSessionDescriptor;
+  targetKey: string;
+};
+
+type BubblePreferences = Pick<
+  ComponentProps<typeof WorldConversationBubble>,
+  | "agentActivityTransitions"
+  | "touchInput"
+  | "terminalFontSizePx"
+  | "terminalScreenReaderText"
+  | "mobileControlsScalePercent"
+  | "mobileTapTarget"
+  | "mobileLongPressBehavior"
+  | "mobileTouchSelectionEndpointTimeoutMs"
+  | "mobileCommandExpandingInput"
+  | "mobileCommandEnterNewline"
+  | "terminalInputTransport"
+  | "terminalInputBatchDelayMs"
+  | "terminalOutputCoalesceMs"
+>;
+
+type UseWorldConversationControllerOptions = BubblePreferences & {
+  active: boolean;
+  compact: boolean;
+  projection: HerdrOfficeProjection;
+  getRuntime: (bridgeId: BridgeId | null | undefined) => BridgeRuntime | null;
+  connectionStates: Readonly<Partial<Record<BridgeId, BridgeConnectionState>>>;
+  onSelectBridge: (bridgeId: BridgeId) => void;
+  onSelectKey: (key: string | null) => void;
+  onStatus: (message: string | null) => void;
+  onOpenInSpaces: (windowId: string, bridgeId: BridgeId, pane: PaneInfo) => void;
+};
+
+export type WorldConversationController = {
+  panels: readonly WorldConversationBubblePanel[];
+  open: (target: WorldConversationTargetInput) => void;
+  close: (windowId: string) => void;
+  clear: () => void;
+  focus: (windowId: string) => void;
+};
+
+const MAX_WORLD_CONVERSATIONS = 5;
+const WORLD_CONVERSATIONS_STORAGE_KEY = "herdrWeb.worldConversations.v1";
+
+export function worldConversationWindowId(bridgeId: BridgeId, paneId: string) {
+  return `${bridgeId}:${paneId}`;
+}
+
+export function readWorldConversationTargets(): WorldConversationTarget[] {
+  try {
+    const raw = globalThis.sessionStorage?.getItem(WORLD_CONVERSATIONS_STORAGE_KEY);
+    if (!raw) {
+      return [];
+    }
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+    const targets = parsed.flatMap((value: unknown) => {
+      if (!value || typeof value !== "object" || Array.isArray(value)) {
+        return [];
+      }
+      const record = value as Record<string, unknown>;
+      if (
+        (record.kind !== "agent" && record.kind !== "desk") ||
+        typeof record.targetKey !== "string" ||
+        typeof record.bridgeId !== "string" ||
+        typeof record.paneId !== "string" ||
+        typeof record.generationKey !== "string" ||
+        (record.agentKey !== null && typeof record.agentKey !== "string")
+      ) {
+        return [];
+      }
+      return [{
+        windowId: worldConversationWindowId(record.bridgeId, record.paneId),
+        kind: record.kind,
+        targetKey: record.targetKey,
+        agentKey: record.agentKey as string | null,
+        bridgeId: record.bridgeId,
+        paneId: record.paneId,
+        generationKey: record.generationKey,
+      } satisfies WorldConversationTarget];
+    });
+    return targets.slice(0, MAX_WORLD_CONVERSATIONS);
+  } catch {
+    return [];
+  }
+}
+
+export function worldConversationAdmissionPending(
+  runtime: BridgeRuntime | null,
+  state: BridgeConnectionState | null | undefined,
+  generationKey: string,
+) {
+  return Boolean(
+    runtime &&
+      runtime.generationKey === generationKey &&
+      (runtime.capabilityState === "idle" ||
+        runtime.capabilityState === "probing" ||
+        !state ||
+        state.connectionKey !== generationKey ||
+        state.loadState === "loading" ||
+        (state.snapshot === null && state.loadState !== "error")),
+  );
+}
+
+function writeWorldConversationTargets(targets: readonly WorldConversationTarget[]) {
+  try {
+    globalThis.sessionStorage?.setItem(
+      WORLD_CONVERSATIONS_STORAGE_KEY,
+      JSON.stringify(targets.map((target) => ({
+        kind: target.kind,
+        targetKey: target.targetKey,
+        agentKey: target.agentKey,
+        bridgeId: target.bridgeId,
+        paneId: target.paneId,
+        generationKey: target.generationKey,
+      }))),
+    );
+  } catch {
+    // Session storage can be unavailable in private or locked-down contexts.
+  }
+}
+
+function worldConversationObservationPending(
+  runtime: BridgeRuntime | null,
+  state: BridgeConnectionState | null | undefined,
+) {
+  return Boolean(
+    !runtime ||
+      !state ||
+      runtime.capabilityState === "idle" ||
+      runtime.capabilityState === "probing" ||
+      state.connectionKey !== runtime.generationKey ||
+      state.loadState !== "ready" ||
+      state.snapshot === null,
+  );
+}
+
+export function useWorldConversationController({
+  active,
+  compact,
+  projection,
+  getRuntime,
+  connectionStates,
+  onSelectBridge,
+  onSelectKey,
+  onStatus,
+  onOpenInSpaces,
+  agentActivityTransitions,
+  touchInput,
+  terminalFontSizePx,
+  terminalScreenReaderText,
+  mobileControlsScalePercent,
+  mobileTapTarget,
+  mobileLongPressBehavior,
+  mobileTouchSelectionEndpointTimeoutMs,
+  mobileCommandExpandingInput,
+  mobileCommandEnterNewline,
+  terminalInputTransport,
+  terminalInputBatchDelayMs,
+  terminalOutputCoalesceMs,
+}: UseWorldConversationControllerOptions): WorldConversationController {
+  const [targets, setTargets] = useState<WorldConversationTarget[]>(readWorldConversationTargets);
+  const cacheRef = useRef<Map<string, WorldConversationView>>(new Map());
+
+  useEffect(() => {
+    writeWorldConversationTargets(targets);
+  }, [targets]);
+
+  const open = useCallback((target: WorldConversationTargetInput) => {
+    const windowId = worldConversationWindowId(target.bridgeId, target.paneId);
+    const nextTarget = { ...target, windowId };
+    const existing = targets.some(({ windowId: id }) => id === windowId);
+    if (!existing && !compact && targets.length >= MAX_WORLD_CONVERSATIONS) {
+      onStatus("Five Office terminals are open. Close one before opening another.");
+      return;
+    }
+    onSelectBridge(target.bridgeId);
+    onSelectKey(target.agentKey ?? target.targetKey);
+    onStatus(null);
+    setTargets((current) => {
+      const index = current.findIndex(({ windowId: id }) => id === windowId);
+      if (index < 0) {
+        return compact ? [nextTarget] : [...current, nextTarget];
+      }
+      return current.map((currentTarget, currentIndex) =>
+        currentIndex === index ? nextTarget : currentTarget,
+      );
+    });
+  }, [compact, onSelectBridge, onSelectKey, onStatus, targets]);
+
+  const close = useCallback((windowId: string) => {
+    cacheRef.current.delete(windowId);
+    setTargets((current) => current.filter(({ windowId: id }) => id !== windowId));
+  }, []);
+
+  const clear = useCallback(() => {
+    setTargets([]);
+    cacheRef.current.clear();
+  }, []);
+
+  const focus = useCallback((windowId: string) => {
+    const target = targets.find(({ windowId: id }) => id === windowId);
+    if (!target) {
+      return;
+    }
+    onSelectKey(target.agentKey ?? target.targetKey);
+    onSelectBridge(target.bridgeId);
+    onStatus(null);
+  }, [onSelectBridge, onSelectKey, onStatus, targets]);
+
+  const conversations = useMemo(() => {
+    if (!active) {
+      return [] as WorldConversationView[];
+    }
+    return targets.flatMap((target) => {
+      const agentEntry = target.agentKey
+        ? projection.roster.find(({ agent }) => agent.key === target.agentKey) ?? null
+        : null;
+      const deskEntry = target.kind === "desk"
+        ? projection.deskRoster.find(({ desk }) => desk.key === target.targetKey) ?? null
+        : null;
+      const runtime = getRuntime(target.bridgeId);
+      const state = runtime && connectionStates[runtime.id]?.connectionKey === runtime.generationKey
+        ? connectionStates[runtime.id]
+        : null;
+      const pane = state?.snapshot?.panes.find(({ pane_id }) => pane_id === target.paneId) ?? null;
+      const agent = agentEntry?.agent ?? null;
+      const runtimeMatchesTarget = Boolean(
+        runtime && runtime.generationKey === target.generationKey,
+      );
+      const observationPending = worldConversationObservationPending(runtime, state);
+      const paneStillObserved = Boolean(
+        state?.snapshot?.panes.some(({ pane_id }) => pane_id === target.paneId),
+      );
+      if (
+        runtimeMatchesTarget &&
+        runtime &&
+        state &&
+        pane &&
+        runtimeAdmissionReady(runtime, state, ["snapshot", "terminal_attach"])
+      ) {
+        const session = terminalSessionDescriptor(runtime, pane, state, ["snapshot"]);
+        if (session?.attachEnabled) {
+          const next: WorldConversationView = {
+            windowId: target.windowId,
+            agent,
+            targetLabel:
+              agent?.displayLabel ??
+              pane.display_agent ??
+              pane.label ??
+              pane.title ??
+              pane.terminal_title ??
+              "Shell",
+            hostLabel: agentEntry?.hostLabel ?? deskEntry?.hostLabel ?? "Host",
+            pane,
+            runtime,
+            session,
+            targetKey: target.targetKey,
+          };
+          cacheRef.current.set(target.windowId, next);
+          return [next];
+        }
+      }
+
+      const cached = cacheRef.current.get(target.windowId);
+      if (
+        runtimeMatchesTarget &&
+        cached?.targetKey === target.targetKey &&
+        (observationPending || paneStillObserved)
+      ) {
+        return [{
+          ...cached,
+          agent: agent ?? cached.agent,
+          targetLabel: agent?.displayLabel ?? cached.targetLabel,
+          hostLabel: agentEntry?.hostLabel ?? deskEntry?.hostLabel ?? cached.hostLabel,
+        }];
+      }
+      return [];
+    });
+  }, [active, connectionStates, getRuntime, projection, targets]);
+
+  useEffect(() => {
+    officeDebug("conversation:views", {
+      visible: conversations.length,
+      targets: targets.length,
+      windows: conversations.map(({ windowId, targetKey, session }) => ({
+        windowId,
+        targetKey,
+        sessionKey: session.sessionKey,
+      })),
+      activeSurface: active ? "world" : "spaces",
+    });
+  }, [active, conversations, targets.length]);
+
+  useEffect(() => {
+    if (!active) {
+      return;
+    }
+    const targetsToClose = new Set<string>();
+    const targetsToRebind = new Map<string, string>();
+    for (const target of targets) {
+      const runtime = getRuntime(target.bridgeId);
+      const state = runtime ? connectionStates[runtime.id] : null;
+      if (worldConversationObservationPending(runtime, state)) {
+        continue;
+      }
+      const paneStillObserved = Boolean(
+        state?.snapshot?.panes.some(({ pane_id }) => pane_id === target.paneId),
+      );
+      if (paneStillObserved && runtime && runtime.generationKey !== target.generationKey) {
+        targetsToRebind.set(target.windowId, runtime.generationKey);
+        continue;
+      }
+      if (paneStillObserved) {
+        continue;
+      }
+      targetsToClose.add(target.windowId);
+      officeDebug("conversation:cleanup-check", {
+        windowId: target.windowId,
+        targetKey: target.targetKey,
+        activeSurface: "world",
+        reason: "pane-absent-from-admitted-snapshot",
+      });
+    }
+    if (targetsToClose.size === 0 && targetsToRebind.size === 0) {
+      return;
+    }
+    for (const windowId of targetsToClose) {
+      cacheRef.current.delete(windowId);
+    }
+    for (const windowId of targetsToRebind.keys()) {
+      cacheRef.current.delete(windowId);
+    }
+    setTargets((current) =>
+      current.flatMap((target) => {
+        if (targetsToClose.has(target.windowId)) {
+          return [];
+        }
+        const generationKey = targetsToRebind.get(target.windowId);
+        return generationKey ? [{ ...target, generationKey }] : [target];
+      }),
+    );
+  }, [active, connectionStates, getRuntime, targets]);
+
+  const panels = useMemo<WorldConversationBubblePanel[]>(
+    () => conversations.map((conversation) => ({
+      id: conversation.windowId,
+      targetKey: conversation.targetKey,
+      selectedKey: conversation.agent?.key ?? null,
+      content: (
+        <WorldConversationBubble
+          key={`${conversation.windowId}:${conversation.session.sessionKey}`}
+          agent={conversation.agent}
+          targetLabel={conversation.targetLabel}
+          hostLabel={conversation.hostLabel}
+          pane={conversation.pane}
+          runtime={conversation.runtime}
+          session={conversation.session}
+          onClose={() => close(conversation.windowId)}
+          onOpenInSpaces={() =>
+            onOpenInSpaces(
+              conversation.windowId,
+              conversation.runtime.id,
+              conversation.pane,
+            )
+          }
+          agentActivityTransitions={agentActivityTransitions}
+          terminalScreenReaderText={terminalScreenReaderText}
+          touchInput={touchInput}
+          terminalFontSizePx={terminalFontSizePx}
+          mobileControlsScalePercent={mobileControlsScalePercent}
+          mobileTapTarget={mobileTapTarget}
+          mobileLongPressBehavior={mobileLongPressBehavior}
+          mobileTouchSelectionEndpointTimeoutMs={mobileTouchSelectionEndpointTimeoutMs}
+          mobileCommandExpandingInput={mobileCommandExpandingInput}
+          mobileCommandEnterNewline={mobileCommandEnterNewline}
+          terminalInputTransport={terminalInputTransport}
+          terminalInputBatchDelayMs={terminalInputBatchDelayMs}
+          terminalOutputCoalesceMs={terminalOutputCoalesceMs}
+        />
+      ),
+    })),
+    [
+      agentActivityTransitions,
+      close,
+      conversations,
+      mobileCommandEnterNewline,
+      mobileCommandExpandingInput,
+      mobileControlsScalePercent,
+      mobileLongPressBehavior,
+      mobileTapTarget,
+      mobileTouchSelectionEndpointTimeoutMs,
+      onOpenInSpaces,
+      terminalFontSizePx,
+      terminalInputBatchDelayMs,
+      terminalInputTransport,
+      terminalOutputCoalesceMs,
+      terminalScreenReaderText,
+      touchInput,
+    ],
+  );
+
+  return { panels, open, close, clear, focus };
+}


### PR DESCRIPTION
## Summary

- move Office conversation persistence, bounded window admission, generation-aware recovery, and bubble rendering out of the shared application shell
- expose one World-owned controller with narrow open, close, clear, focus, and rendered-panel operations
- retain the existing bridge federation and canonical terminal session/renderer ownership unchanged
- add focused restoration and admission regression coverage

This is a behavior-preserving frontend refactor. It does not change bridge routes, protocol, terminal ownership, observability, packaging, or release behavior.

## Validation

- `npm run check`: passed
  - 61 frontend files / 439 tests
  - 116 vendored compatibility tests plus 3 protocol-20 fixtures
  - 162 bridge tests
  - production frontend and bridge builds
- Playwright: 43 passed, 2 documented skips; the one failure is the pre-existing timing issue tracked in #5
  - all later conversation restoration, cap, move/resize, mobile, Escape, Spaces handoff, desk, and multi-host tests passed
- `npm run test:security`: passed with the existing three allowed Rust advisory warnings
- `npm run test:independence`: passed
- `git diff --check`: passed

## Known timing issue

`tests/e2e/world.spec.ts:251` again transiently retained two bubbles after the Reset-office-view focus/Escape sequence. This exact issue is documented in #5 and remains unchanged: no skip, assertion weakening, or product workaround was added.
