### PR TITLE
chore: complete Herdr World identity

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,8 +67,9 @@ This is a lightweight internal onboarding note for agents working in this repo.
   the source of truth for tarball layout.
 - Build final release artifacts from the final release commit/tag after `scripts/release.mjs`
   stamps the changelog and creates the release. Inspect tarball/APK contents before upload.
-- Desktop tarballs include only `herdr-web-bridge`, bundled `web/dist` assets, a wrapper script, and
-  docs. They do not include Herdr itself.
+- Desktop tarballs include `herdr-world-bridge`, bundled `web/dist` assets, the `herdr-world`
+  wrapper, license/notices, and docs. They do not include Herdr itself. The development Cargo target
+  remains `herdr-web-bridge` for upstream alignment.
 
 ## Changelog
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,13 @@
 
 ### Changed
 
+- Completed the Herdr World product identity across the visible shell, Android
+  application ID (`dev.herdr.world`), and desktop `herdr-world-*` release
+  artifacts. Release tarballs now carry the project license, explicit
+  third-party notices, retained license texts, upstream record, and source/asset
+  provenance. Internal Cargo target and browser-state names remain unchanged for
+  upstream comparison and existing-user compatibility.
+  [Herdr World PR #7](https://github.com/IvoryHeart/herdr-world/pull/7)
 - Established `IvoryHeart/herdr-world` as the independent downstream monorepo,
   renamed the app/package identity to Herdr World, and replaced the overlapping
   Specs 004/010/011 with one practical independence and upstream-sync contract.

--- a/README.md
+++ b/README.md
@@ -10,9 +10,11 @@ the Pixel Office at `/world`, direct multi-bridge support, and downstream
 integrations such as Office observability.
 
 This repository is a standalone monorepo that can be distributed without asking users to
-modify their installed Herdr checkout. The bridge builds as `herdr-web-bridge`, a repo-owned
-executable that uses vendored Herdr compatibility code because the app needs private Herdr APIs for
-terminal attach, terminal resize/scroll/input, workspace snapshots, and event subscriptions.
+modify their installed Herdr checkout. Release bundles ship the repo-owned bridge as
+`herdr-world-bridge`; its development-only Cargo target remains `herdr-web-bridge` so generic bridge
+changes stay easy to compare with Herdr Web. It uses vendored Herdr compatibility code because the
+app needs private Herdr APIs for terminal attach, terminal resize/scroll/input, workspace snapshots,
+and event subscriptions.
 
 The goal is to provide a browser-native interface for monitoring and controlling Herdr agents from
 desktop and mobile clients. It keeps the terminal experience close to Herdr while adding web-focused
@@ -34,15 +36,15 @@ visualizations. The upstream relationship and synchronization record are documen
 
 | Desktop | Android tablet |
 |:--:|:--:|
-| <img src="docs/images/desktop.png" alt="herdr-web desktop terminal workspace" width="640"> | <img src="docs/images/android-tablet.png" alt="herdr-web Android tablet terminal workspace" width="640"> |
+| <img src="docs/images/desktop.png" alt="herdr-world desktop terminal workspace" width="640"> | <img src="docs/images/android-tablet.png" alt="herdr-world Android tablet terminal workspace" width="640"> |
 
 | Android phone switcher | Android phone terminal |
 |:--:|:--:|
-| <img src="docs/images/android-phone-switcher.png" alt="herdr-web Android phone switcher" width="260"> | <img src="docs/images/android-phone-terminal.png" alt="herdr-web Android phone terminal" width="260"> |
+| <img src="docs/images/android-phone-switcher.png" alt="herdr-world Android phone switcher" width="260"> | <img src="docs/images/android-phone-terminal.png" alt="herdr-world Android phone terminal" width="260"> |
 
 | Android bridge configuration |
 |:--:|
-| <img src="docs/images/android-phone-bridge-settings.png" alt="herdr-web Android bridge settings and color picker" width="260"> |
+| <img src="docs/images/android-phone-bridge-settings.png" alt="herdr-world Android bridge settings and color picker" width="260"> |
 
 ## Layout
 
@@ -91,9 +93,9 @@ Download the matching desktop tarball from the GitHub release, unpack it, and ru
 wrapper:
 
 ```bash
-tar -xzf herdr-web-vX.Y.Z-linux-x86_64.tar.gz
-cd herdr-web-vX.Y.Z-linux-x86_64
-bin/herdr-web
+tar -xzf herdr-world-vX.Y.Z-linux-x86_64.tar.gz
+cd herdr-world-vX.Y.Z-linux-x86_64
+bin/herdr-world
 ```
 
 Open:
@@ -102,7 +104,7 @@ Open:
 http://127.0.0.1:8787
 ```
 
-The desktop tarball includes the web assets and `herdr-web-bridge`; it does not include Herdr.
+The desktop tarball includes the web assets and `herdr-world-bridge`; it does not include Herdr.
 Start or attach Herdr `v0.8.2` or newer with terminal protocol `20` separately before running the
 bridge.
 
@@ -110,7 +112,7 @@ For Android, install the APK from the same release and add the bridge URL in the
 Settings. LAN bridges must admit the bridge hostname and Android's app origin explicitly:
 
 ```bash
-bin/herdr-web --host 0.0.0.0 --port 4000 \
+bin/herdr-world --host 0.0.0.0 --port 4000 \
   --allow-host herdr-host.example \
   --allow-origin http://localhost
 ```
@@ -217,7 +219,9 @@ The bridge can load local launcher presets from:
 ${XDG_CONFIG_HOME:-~/.config}/herdr-web/launcher-presets.json
 ```
 
-Override the path with `--launcher-presets PATH` or `HERDR_WEB_LAUNCHER_PRESETS=PATH`.
+Override the path with `--launcher-presets PATH` or `HERDR_WEB_LAUNCHER_PRESETS=PATH`. The legacy
+configuration name and location are retained so existing Herdr Web/World installations do not lose
+their launcher list during the product rename.
 
 Optional `builtins` is an allowlist that chooses which built-ins appear and in what order. Omit it to
 show every built-in. Use `[]` to hide all built-ins and keep only custom presets. Entries may be short
@@ -325,10 +329,11 @@ HOST=0.0.0.0 PORT=4000 scripts/run-bridge.sh \
 ```
 
 Uploads are saved under `HERDR_WEB_UPLOAD_DIR`, `XDG_DATA_HOME/herdr-web/uploads`, or
-`~/.local/share/herdr-web/uploads` by default. Override the bridge upload directory with:
+`~/.local/share/herdr-web/uploads` by default. These legacy storage names remain compatible with
+existing installations. Override the bridge upload directory with:
 
 ```bash
-UPLOAD_DIR=/tmp/herdr-web-uploads scripts/run-bridge.sh
+UPLOAD_DIR=/tmp/herdr-world-uploads scripts/run-bridge.sh
 ```
 
 The bridge rejects cross-origin browser requests unless the request origin is explicitly allowed.
@@ -443,7 +448,7 @@ needs private APIs that are not available from released Herdr:
 - terminal ANSI render encoding
 - scroll and resize protocol frames
 
-The shipped bridge is `herdr-web-bridge`, a slim executable owned by this repo. It depends on the
+The shipped bridge is `herdr-world-bridge`, a slim executable owned by this repo. It depends on the
 local `vendor/herdr-compat` crate for copied Herdr protocol/schema/client/socket helpers and keeps
 bridge HTTP/WebSocket behavior in `bridge/src/web_bridge.rs`. A separate upstream Herdr checkout can
 be used for refreshes and drift audits, but a full `vendor/herdr` snapshot is not part of this repo.
@@ -457,6 +462,19 @@ See [docs/packaging.md](docs/packaging.md) for desktop tarball and APK artifact 
 
 See [docs/release.md](docs/release.md) for release validation, browser smoke testing, tagging,
 GitHub release creation, and manual artifact upload.
+
+## License And Attribution
+
+Herdr World's MIT license retains the Herdr Web copyright notice and adds the
+downstream `IvoryHeart contributors` notice; publishing under the IvoryHeart
+project identity does not require exposing a maintainer's legal name.
+
+Apache-2.0 Herdr compatibility source, Claw-Empire character assets and Office
+adaptations, and the PixiJS MIT dependency are declared in
+[`THIRD_PARTY_NOTICES.md`](THIRD_PARTY_NOTICES.md). Exact Herdr source hashes
+are in [`vendor/herdr-compat/VENDOR-MANIFEST.toml`](vendor/herdr-compat/VENDOR-MANIFEST.toml),
+and the World asset hashes and modification record are in
+[`docs/world-assets.md`](docs/world-assets.md).
 
 ## Long-Term Direction
 
@@ -475,9 +493,9 @@ surface.
 
 ## Acknowledgements
 
-`herdr-web` builds on several projects and tools:
+`herdr-world` builds on several projects and tools:
 
-- [Herdr](https://github.com/ogulcancelik/herdr), the terminal workspace manager this app extends.
+- [Herdr](https://github.com/herdrdev/herdr), the terminal workspace manager this app extends.
 - [Ghostty Web](https://www.npmjs.com/package/ghostty-web), used by the browser terminal renderer.
 - [Ghostty](https://github.com/ghostty-org/ghostty), including Ghostty VT / `libghostty-vt`,
   vendored through Herdr and used for terminal emulation in Herdr core.

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,50 @@
+# Third-party notices
+
+Herdr World contains code and assets from the projects below. The repository
+history, lockfiles, and referenced manifests provide the exact version record.
+
+## Herdr Web
+
+Herdr World is derived from
+[`kcosr/herdr-web`](https://github.com/kcosr/herdr-web), licensed under the MIT
+License, Copyright (c) 2026 Kevin. The retained MIT terms are in the repository
+[`LICENSE`](LICENSE). The current synchronized revision is recorded in
+[`UPSTREAM.md`](UPSTREAM.md).
+
+## Herdr compatibility source
+
+`vendor/herdr-compat` contains copied or adapted source from
+[`herdrdev/herdr`](https://github.com/herdrdev/herdr) v0.8.2 at commit
+`9eb521456ac0d19d3ab3d9d7cea3cca10baa8a4c`, licensed under Apache-2.0.
+The exact source paths, hashes, and local dispositions are recorded in
+[`vendor/herdr-compat/VENDOR-MANIFEST.toml`](vendor/herdr-compat/VENDOR-MANIFEST.toml).
+The license text is retained in
+[`third_party/licenses/Apache-2.0.txt`](third_party/licenses/Apache-2.0.txt).
+
+## Claw-Empire character assets and Office adaptations
+
+The character sprites in `web/public/world/characters` are copied from
+[`GreenSheep01201/claw-empire`](https://github.com/GreenSheep01201/claw-empire)
+at commit `66a24ea7df2435ef897c48c147deb7ec572c01c2`, licensed under
+Apache-2.0, Copyright 2026 GreenSheep01201 (seowongil@gmail.com).
+
+The Office geometry and drawing TypeScript files are modified adaptations of
+the historical sources identified by hash in [`docs/world-assets.md`](docs/world-assets.md).
+Herdr World's TypeScript port and subsequent modifications are documented
+there as modified material. The Apache-2.0 text is retained in
+[`third_party/licenses/Apache-2.0.txt`](third_party/licenses/Apache-2.0.txt).
+
+## PixiJS
+
+World rendering uses PixiJS 8.3.4, licensed under the MIT License, Copyright
+(c) 2013-2023 Mathew Groves and Chad Engler. Its license is retained in
+[`third_party/licenses/PixiJS-MIT.txt`](third_party/licenses/PixiJS-MIT.txt)
+and alongside the shipped World assets.
+
+## Other dependencies
+
+JavaScript and Rust dependency versions are pinned by `package-lock.json`,
+`web/package-lock.json`, `bridge/Cargo.lock`, and
+`vendor/herdr-compat/Cargo.lock`. Their upstream license files remain in the
+installed package/crate sources; binary release preparation must verify that
+all notices required by the selected artifact are included before publication.

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -1,10 +1,10 @@
 apply plugin: 'com.android.application'
 
 android {
-    namespace = "dev.herdr.web"
+    namespace = "dev.herdr.world"
     compileSdk = rootProject.ext.compileSdkVersion
     defaultConfig {
-        applicationId "dev.herdr.web"
+        applicationId "dev.herdr.world"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1

--- a/android/app/src/androidTest/java/dev/herdr/world/ExampleInstrumentedTest.java
+++ b/android/app/src/androidTest/java/dev/herdr/world/ExampleInstrumentedTest.java
@@ -1,4 +1,4 @@
-package dev.herdr.web;
+package dev.herdr.world;
 
 import static org.junit.Assert.assertEquals;
 
@@ -15,6 +15,6 @@ public class ExampleInstrumentedTest {
     public void useAppContext() {
         Context appContext = InstrumentationRegistry.getInstrumentation().getTargetContext();
 
-        assertEquals("dev.herdr.web", appContext.getPackageName());
+        assertEquals("dev.herdr.world", appContext.getPackageName());
     }
 }

--- a/android/app/src/main/java/dev/herdr/world/MainActivity.java
+++ b/android/app/src/main/java/dev/herdr/world/MainActivity.java
@@ -1,4 +1,4 @@
-package dev.herdr.web;
+package dev.herdr.world;
 
 import android.graphics.Color;
 import android.os.Build;

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='utf-8'?>
 <resources>
-    <string name="app_name">Herdr Web</string>
-    <string name="title_activity_main">Herdr Web</string>
-    <string name="package_name">dev.herdr.web</string>
-    <string name="custom_url_scheme">dev.herdr.web</string>
+    <string name="app_name">Herdr World</string>
+    <string name="title_activity_main">Herdr World</string>
+    <string name="package_name">dev.herdr.world</string>
+    <string name="custom_url_scheme">dev.herdr.world</string>
 </resources>

--- a/android/app/src/test/java/dev/herdr/world/ExampleUnitTest.java
+++ b/android/app/src/test/java/dev/herdr/world/ExampleUnitTest.java
@@ -1,4 +1,4 @@
-package dev.herdr.web;
+package dev.herdr.world;
 
 import static org.junit.Assert.assertEquals;
 

--- a/bridge/src/web_bridge.rs
+++ b/bridge/src/web_bridge.rs
@@ -893,7 +893,7 @@ pub(crate) fn run_command(args: &[String]) -> io::Result<i32> {
         Err(message) => {
             eprintln!("{message}");
             eprintln!(
-                "usage: herdr-web-bridge [--session NAME] [--host HOST] [--port PORT] [--static-dir DIR] [--launcher-presets PATH] [--bridge-label LABEL] [--allow-origin ORIGIN] [--allow-host HOST] [--allow-connect-origin ORIGIN]"
+                "usage: herdr-world-bridge [--session NAME] [--host HOST] [--port PORT] [--static-dir DIR] [--launcher-presets PATH] [--bridge-label LABEL] [--allow-origin ORIGIN] [--allow-host HOST] [--allow-connect-origin ORIGIN]"
             );
             return Ok(2);
         }
@@ -1006,7 +1006,7 @@ fn parse_options(args: &[String]) -> Result<Option<BridgeOptions>, String> {
                 configured_label = Some(normalize_configured_label(value)?);
                 index += 2;
             }
-            arg => return Err(format!("unknown herdr-web option: {arg}")),
+            arg => return Err(format!("unknown herdr-world option: {arg}")),
         }
     }
 
@@ -1048,11 +1048,11 @@ fn print_help() {
 }
 
 fn help_text() -> &'static str {
-    "herdr-web-bridge\n\
+    "herdr-world-bridge\n\
 \n\
-Usage: herdr-web-bridge [--session NAME] [--host HOST] [--port PORT] [--static-dir DIR] [--upload-dir DIR] [--launcher-presets PATH] [--bridge-label LABEL] [--allow-origin ORIGIN] [--allow-host HOST] [--allow-connect-origin ORIGIN]\n\
+Usage: herdr-world-bridge [--session NAME] [--host HOST] [--port PORT] [--static-dir DIR] [--upload-dir DIR] [--launcher-presets PATH] [--bridge-label LABEL] [--allow-origin ORIGIN] [--allow-host HOST] [--allow-connect-origin ORIGIN]\n\
 \n\
-Runs the local HTTP/WebSocket bridge for herdr-web.\n\
+Runs the local HTTP/WebSocket bridge for Herdr World.\n\
 Defaults to the active Herdr daemon sockets and 127.0.0.1:8787.\n\
 Use --session NAME to target a named Herdr session and ignore HERDR_SOCKET_PATH.\n\
 Non-loopback --host values require explicit --allow-host and --allow-origin values.\n\
@@ -1100,7 +1100,7 @@ async fn run_server(options: BridgeOptions) -> io::Result<()> {
     info!(
         version = daemon_version,
         protocol = daemon_protocol,
-        "herdr-web bridge connected to compatible Herdr daemon"
+        "Herdr World bridge connected to compatible Herdr daemon"
     );
     let state = BridgeState {
         api,
@@ -1223,7 +1223,7 @@ async fn run_server(options: BridgeOptions) -> io::Result<()> {
         .with_state(state);
     let bind = format!("{}:{}", options.host, options.port);
     let listener = tokio::net::TcpListener::bind(&bind).await?;
-    info!(url = %format!("http://{bind}"), "herdr-web-bridge listening");
+    info!(url = %format!("http://{bind}"), "Herdr World bridge listening");
     axum::serve(listener, app).await
 }
 
@@ -1735,7 +1735,7 @@ fn validate_web_command(method: &Method) -> Result<(), BridgeError> {
         Method::WorkspaceCreate(params) => {
             if params.cwd.is_some() || !params.env.is_empty() || !params.focus {
                 return Err(BridgeError::BadRequest(
-                    "workspace.create is limited to focused default workspaces through herdr-web"
+                    "workspace.create is limited to focused default workspaces through Herdr World"
                         .to_string(),
                 ));
             }
@@ -1791,7 +1791,7 @@ fn validate_web_command(method: &Method) -> Result<(), BridgeError> {
                 || !params.focus
             {
                 return Err(BridgeError::BadRequest(
-                    "tab.create is limited to focused tabs in an existing workspace through herdr-web"
+                    "tab.create is limited to focused tabs in an existing workspace through Herdr World"
                         .to_string(),
                 ));
             }
@@ -1835,7 +1835,7 @@ fn validate_web_command(method: &Method) -> Result<(), BridgeError> {
                 || !params.env.is_empty()
             {
                 return Err(BridgeError::BadRequest(
-                    "pane.split supports only target pane, direction, and focus through herdr-web"
+                    "pane.split supports only target pane, direction, and focus through Herdr World"
                         .to_string(),
                 ));
             }
@@ -1857,7 +1857,7 @@ fn validate_web_command(method: &Method) -> Result<(), BridgeError> {
             }
             if !params.focus {
                 return Err(BridgeError::BadRequest(
-                    "pane.move must focus the moved pane through herdr-web".to_string(),
+                    "pane.move must focus the moved pane through Herdr World".to_string(),
                 ));
             }
             match &params.destination {
@@ -1870,7 +1870,8 @@ fn validate_web_command(method: &Method) -> Result<(), BridgeError> {
                         .is_none_or(|workspace_id| workspace_id.trim().is_empty())
                     {
                         return Err(BridgeError::BadRequest(
-                            "pane.move new_tab requires workspace_id through herdr-web".to_string(),
+                            "pane.move new_tab requires workspace_id through Herdr World"
+                                .to_string(),
                         ));
                     }
                     validate_optional_label(label, "pane.move new_tab label")?;
@@ -1881,7 +1882,7 @@ fn validate_web_command(method: &Method) -> Result<(), BridgeError> {
                 }
                 PaneMoveDestination::Tab { .. } => {
                     return Err(BridgeError::BadRequest(
-                        "pane.move to existing tabs is not exposed through herdr-web".to_string(),
+                        "pane.move to existing tabs is not exposed through Herdr World".to_string(),
                     ));
                 }
             }
@@ -2923,7 +2924,7 @@ async fn upload_handler(
         bytes = body.len(),
         mime = ?mime,
         overwrite = query.overwrite,
-        "herdr-web-bridge upload request"
+        "Herdr World bridge upload request"
     );
     let name = match query.name.as_deref().and_then(sanitize_upload_file_name) {
         Some(name) => name,
@@ -2940,7 +2941,7 @@ async fn upload_handler(
         if !query.overwrite {
             info!(
                 name = %name,
-                "herdr-web-bridge upload conflict"
+                "Herdr World bridge upload conflict"
             );
             return Err(UploadError::Conflict {
                 name,
@@ -3000,7 +3001,7 @@ async fn upload_handler(
             mime,
         },
     };
-    info!(bytes = body.len(), "herdr-web-bridge upload saved");
+    info!(bytes = body.len(), "Herdr World bridge upload saved");
     Ok(Json(response))
 }
 
@@ -4092,13 +4093,13 @@ fn spawn_agent_activity_watcher(state: BridgeState) {
         .name("herdr-web-activity-structural".to_string())
         .spawn(move || agent_activity_structural_watcher_loop(structural_state, resubscribe_tx))
     {
-        warn!(error = %err, "failed to start herdr-web activity structural watcher");
+        warn!(error = %err, "failed to start Herdr World activity structural watcher");
     }
     if let Err(err) = thread::Builder::new()
         .name("herdr-web-activity".to_string())
         .spawn(move || agent_activity_watcher_loop(state, resubscribe_rx))
     {
-        warn!(error = %err, "failed to start herdr-web activity watcher");
+        warn!(error = %err, "failed to start Herdr World activity watcher");
     }
 }
 
@@ -4110,7 +4111,7 @@ fn agent_activity_structural_watcher_loop(state: BridgeState, resubscribe_tx: mp
                 backoff = ACTIVITY_WATCHER_INITIAL_BACKOFF;
             }
             Err(err) => {
-                warn!(error = %err, "herdr-web activity structural watcher will retry");
+                warn!(error = %err, "Herdr World activity structural watcher will retry");
                 thread::sleep(backoff);
                 backoff = (backoff * 2).min(ACTIVITY_WATCHER_MAX_BACKOFF);
             }
@@ -4127,7 +4128,7 @@ fn agent_activity_watcher_loop(state: BridgeState, resubscribe_rx: mpsc::Receive
                 thread::sleep(ACTIVITY_RESUBSCRIBE_DEBOUNCE);
             }
             Err(err) => {
-                warn!(error = %err, "herdr-web activity watcher will retry");
+                warn!(error = %err, "Herdr World activity watcher will retry");
                 thread::sleep(backoff);
                 backoff = (backoff * 2).min(ACTIVITY_WATCHER_MAX_BACKOFF);
             }
@@ -4656,7 +4657,7 @@ fn validated_daemon_protocol(status: herdr_compat::api::RuntimeStatus) -> Result
     })?;
     if version_triplet < MIN_HERDR_VERSION {
         return Err(BridgeError::Protocol(format!(
-            "Herdr daemon version is too old for herdr-web; need Herdr {MIN_HERDR_VERSION_LABEL} or newer with protocol {PROTOCOL_VERSION}"
+            "Herdr daemon version is too old for Herdr World; need Herdr {MIN_HERDR_VERSION_LABEL} or newer with protocol {PROTOCOL_VERSION}"
         )));
     }
 
@@ -4669,7 +4670,7 @@ fn validated_daemon_protocol(status: herdr_compat::api::RuntimeStatus) -> Result
         Ok(protocol)
     } else {
         Err(BridgeError::Protocol(format!(
-            "Herdr daemon protocol {protocol} is incompatible with herdr-web; need Herdr {MIN_HERDR_VERSION_LABEL} or newer with protocol {PROTOCOL_VERSION}"
+            "Herdr daemon protocol {protocol} is incompatible with Herdr World; need Herdr {MIN_HERDR_VERSION_LABEL} or newer with protocol {PROTOCOL_VERSION}"
         )))
     }
 }
@@ -4718,7 +4719,7 @@ fn startup_daemon_error(err: BridgeError) -> io::Error {
     io::Error::new(
         ErrorKind::ConnectionRefused,
         format!(
-            "unable to start herdr-web bridge: {err}. Start or update Herdr, then restart herdr-web-bridge."
+            "unable to start Herdr World bridge: {err}. Start or update Herdr, then restart herdr-world-bridge."
         ),
     )
 }
@@ -7021,18 +7022,18 @@ mod tests {
 
         assert_eq!(io_err.kind(), ErrorKind::ConnectionRefused);
         let message = io_err.to_string();
-        assert!(message.contains("unable to start herdr-web bridge"));
+        assert!(message.contains("unable to start Herdr World bridge"));
         assert!(message.contains("unexpected api result"));
         assert!(message.contains("Start or update Herdr"));
-        assert!(message.contains("restart herdr-web-bridge"));
+        assert!(message.contains("restart herdr-world-bridge"));
     }
 
     #[test]
     fn help_text_is_bridge_specific() {
         let help = help_text();
 
-        assert!(help.contains("herdr-web-bridge"));
-        assert!(help.contains("Usage: herdr-web-bridge"));
+        assert!(help.contains("herdr-world-bridge"));
+        assert!(help.contains("Usage: herdr-world-bridge"));
         assert!(help.contains("--session NAME"));
         assert!(help.contains("terminal-equivalent access"));
         assert!(help.contains("not authentication"));

--- a/capacitor.config.ts
+++ b/capacitor.config.ts
@@ -1,8 +1,8 @@
 import type { CapacitorConfig } from "@capacitor/cli";
 
 const config: CapacitorConfig = {
-  appId: "dev.herdr.web",
-  appName: "Herdr Web",
+  appId: "dev.herdr.world",
+  appName: "Herdr World",
   webDir: "web/dist",
   server: {
     androidScheme: "http",

--- a/docs/agent-activity-efficiency-design.md
+++ b/docs/agent-activity-efficiency-design.md
@@ -1,13 +1,13 @@
 # Agent Activity Efficiency Design
 
-`herdr-web` keeps full snapshots as the coherent model for workspace, tab, pane, layout, and
+`herdr-world` keeps full snapshots as the coherent model for workspace, tab, pane, layout, and
 selection state. Agent activity is different: status and presentation fields can change frequently,
 and those changes are small. The implemented design streams those frequent activity changes as
 bridge-owned deltas while retaining full snapshots for initial load, structural state, and recovery.
 
 This implementation was influenced by efficiency concepts from the `roy-levi-amazon` fork:
 https://github.com/roy-levi-amazon/herdr-web. The implemented design keeps the final subscription
-ownership in the Herdr Web bridge and preserves full snapshots as the recovery path.
+ownership in the Herdr World bridge and preserves full snapshots as the recovery path.
 
 ## Goals
 
@@ -43,7 +43,7 @@ flowchart LR
     StructuralEvents["events.subscribe<br/>workspace/tab/pane/worktree events"]
   end
 
-  subgraph Bridge["herdr-web bridge"]
+  subgraph Bridge["herdr-world bridge"]
     StructuralWatcher["Structural watcher"]
     ActivityWatcher["Activity watcher"]
     ActivityBus["Broadcast channel<br/>ActivityMessage"]

--- a/docs/android.md
+++ b/docs/android.md
@@ -1,6 +1,6 @@
 # Android App
 
-`herdr-web` includes a Capacitor Android shell that bundles the React/Vite app from
+`herdr-world` includes a Capacitor Android shell that bundles the React/Vite app from
 `web/dist` and connects only API/WebSocket traffic to a configured Herdr bridge.
 
 The Android app does not run Herdr and does not fetch the web UI from a bridge. A bridge must
@@ -10,7 +10,7 @@ already be running on another machine or on the same network.
 
 - Capacitor config: `capacitor.config.ts`
 - Android project: `android/`
-- Android application id: `dev.herdr.web`
+- Android application id: `dev.herdr.world`
 - Bundled web assets source: `web/dist`
 - Runtime profile storage: Capacitor Preferences on Android, browser `localStorage` elsewhere
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,6 +1,6 @@
 # Federated client architecture
 
-Herdr is the sole runtime authority. Herdr Web does not maintain a competing topology, terminal
+Herdr is the sole runtime authority. Herdr World does not maintain a competing topology, terminal
 multiplexer, fleet database, or central gateway. The browser caches admitted snapshots for display,
 routes each action back to the owning host, and treats a failed cache as stale and non-controllable.
 
@@ -21,7 +21,8 @@ browser. A bridge never discovers, proxies, routes to, or controls another bridg
 - `AppShell` composes the host registry, core navigation, and static surface outlet.
 - `SurfaceRegistry` describes statically bundled internal surfaces by stable ID, route, semantic
   icon, host scope, required capabilities, and lazy component loader. This is an internal seam, not
-  a public or dynamic plugin SDK. Only the core `spaces` surface ships in this increment.
+  a public or dynamic plugin SDK. The core `spaces` and downstream `world` surfaces ship in the
+  same application.
 - `HostRegistryProvider` owns the bridge-profile manager. Profiles have opaque stable IDs, labels,
   base URLs, enablement, and display order; credentials and SSH keys are not profile fields.
 - `QualifiedTarget` identifies a Herdr workspace, tab, pane, terminal, or agent as the tuple of host

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,14 +1,14 @@
 # Local development
 
-Work from the `herdr-web` repository root:
+Work from the `herdr-world` repository root:
 
 ```bash
-cd /home/ny/Forge/ai-palace/herdr-web
+cd /home/ny/Forge/ai-palace/herdr-world
 ```
 
 ## Quick start
 
-Herdr Web is a client of a running Herdr server. Start or attach to the normal
+Herdr World is a client of a running Herdr server. Start or attach to the normal
 Herdr session first:
 
 ```bash
@@ -82,7 +82,7 @@ discarded before terminal input is sent.
 | Layer | Required | Purpose | Default endpoint |
 | --- | --- | --- | --- |
 | Herdr server/session | Yes | Owns workspaces, tabs, panes, agents, and terminals | `~/.config/herdr/herdr.sock` |
-| `herdr-web-bridge` | Yes | Converts browser HTTP/WebSocket traffic to Herdr protocol traffic | `http://127.0.0.1:8787` |
+| `herdr-world-bridge` | Yes | Converts browser HTTP/WebSocket traffic to Herdr protocol traffic | `http://127.0.0.1:8787` |
 | Vite frontend | Only for HMR | Serves current React/TypeScript source during development | `http://127.0.0.1:5173` or next free port |
 | OTEL/Prometheus stack | Optional | Supplies the Office `Economy` metrics board | Prometheus `http://127.0.0.1:9101` |
 
@@ -95,10 +95,10 @@ the Herdr state and Office rooms remain usable.
 Use two terminals when debugging a layer independently:
 
 ```bash
-# Terminal 1: from herdr-web/
+# Terminal 1: from herdr-world/
 scripts/run-bridge.sh
 
-# Terminal 2: from herdr-web/
+# Terminal 2: from herdr-world/
 npm run dev:web
 ```
 
@@ -125,15 +125,15 @@ HERDR_SOCKET_PATH=/absolute/path/to/herdr.sock scripts/run-bridge.sh
 
 The Office `Economy` board can read from any operator-managed Prometheus-
 compatible HTTP API. The telemetry service is optional and is not required for
-Herdr Web sessions, the live Office roster, or room interactions. Herdr Web
+Herdr World sessions, the live Office roster, or room interactions. Herdr World
 does not assume ownership of the collector, storage, dashboards, or their
 deployment lifecycle.
 
-When a Prometheus-compatible service is available, restart the Herdr Web
+When a Prometheus-compatible service is available, restart the Herdr World
 bridge with its API URL:
 
 ```bash
-cd /home/ny/Forge/ai-palace/herdr-web
+cd /home/ny/Forge/ai-palace/herdr-world
 # Stop an existing bridge on 8787 first if dev:local reports that it is healthy.
 HERDR_WORLD_OTEL_PROMETHEUS_URL=http://127.0.0.1:9101 npm run dev:local
 ```
@@ -143,9 +143,9 @@ new bridge environment variables to a process that is already running.
 
 The URL above is only an example. Use the endpoint exposed by the telemetry
 deployment in your environment; OTLP receiver, log-storage, and dashboard
-endpoints are outside the Herdr Web startup contract.
+endpoints are outside the Herdr World startup contract.
 
-To configure the Office provider without restarting the bridge, open Herdr Web
+To configure the Office provider without restarting the bridge, open Herdr World
 Settings, choose `Office`, and save the Prometheus URL. An invalid URL is
 reported through the Office provider health state; correcting it applies the
 configuration again and returns the provider to its available state. The

--- a/docs/federation.md
+++ b/docs/federation.md
@@ -1,6 +1,6 @@
-# Operating federated Herdr Web
+# Operating federated Herdr World
 
-Herdr Web uses one host-local bridge per Herdr runtime and direct browser federation. It has no
+Herdr World uses one host-local bridge per Herdr runtime and direct browser federation. It has no
 central gateway, fleet controller, SSH manager, authentication layer, or RBAC. Every browser that a
 bridge admits has terminal-equivalent access to that Herdr runtime.
 
@@ -69,7 +69,7 @@ configuration.
 
 ## Operator-managed SSH forwarding
 
-Keep both bridges on loopback and create two tunnels using normal OpenSSH configuration. Herdr Web
+Keep both bridges on loopback and create two tunnels using normal OpenSSH configuration. Herdr World
 never reads, generates, stores, rotates, or invokes SSH keys:
 
 ```bash

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -24,7 +24,7 @@ GET /api/extensions/observability/snapshot
 WS  /ws/extensions/observability
 ```
 
-The default provider is explicitly `unavailable`, so normal Herdr Web
+The default provider is explicitly `unavailable`, so normal Herdr World
 snapshot, terminal, Spaces, and Office behaviour does not depend on an
 observability backend. A provider failure becomes `degraded` with an empty
 bounded snapshot rather than a page-level failure. Event gaps produce a
@@ -42,7 +42,7 @@ HERDR_WORLD_OTEL_PROMETHEUS_URL=http://127.0.0.1:9101 \
 ```
 
 The Office-only Settings surface can also configure this endpoint while the
-bridge is running. Open Herdr Web Settings, choose `Office`, and save the
+bridge is running. Open Herdr World Settings, choose `Office`, and save the
 optional Prometheus URL. The browser sends the value only to the selected
 bridge's configuration route; it never queries Prometheus directly. The
 setting is stored in browser local storage per bridge profile under the
@@ -148,8 +148,6 @@ operator-managed SSH, VPN, TLS, firewall, or authenticated reverse proxy.
 
 ## Naming note
 
-The broader product direction is a `World` family with projections such as
-`Office`, `Graph`, and `City`. This repository still uses its current
-`herdr-web` package/repository identity until a separate naming and packaging
-change is approved; Spec 002 deliberately keeps the contract independent of
-that branding decision.
+The product is Herdr World, with projections such as `Office`, `Graph`, and
+`City`. Spec 002's observability contract remains independent of product
+branding so a compatible provider can be implemented elsewhere.

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -1,6 +1,6 @@
 # Packaging
 
-`herdr-web` ships as separate desktop bridge/web tarballs and an Android APK.
+`herdr-world` ships as separate desktop bridge/web tarballs and an Android APK.
 
 The desktop tarball does not include Herdr itself. Users still need a running Herdr `v0.8.2` or
 newer session or daemon that reports terminal protocol `20`; the bundled bridge connects to the
@@ -11,13 +11,13 @@ normal Herdr socket.
 Recommended GitHub release assets:
 
 ```text
-herdr-web-vX.Y.Z-linux-x86_64.tar.gz
-herdr-web-vX.Y.Z-linux-x86_64.tar.gz.sha256
-herdr-web-vX.Y.Z-macos-arm64.tar.gz
-herdr-web-vX.Y.Z-macos-arm64.tar.gz.sha256
-herdr-web-vX.Y.Z-macos-x86_64.tar.gz
-herdr-web-vX.Y.Z-macos-x86_64.tar.gz.sha256
-herdr-web-vX.Y.Z-android-debug.apk
+herdr-world-vX.Y.Z-linux-x86_64.tar.gz
+herdr-world-vX.Y.Z-linux-x86_64.tar.gz.sha256
+herdr-world-vX.Y.Z-macos-arm64.tar.gz
+herdr-world-vX.Y.Z-macos-arm64.tar.gz.sha256
+herdr-world-vX.Y.Z-macos-x86_64.tar.gz
+herdr-world-vX.Y.Z-macos-x86_64.tar.gz.sha256
+herdr-world-vX.Y.Z-android-debug.apk
 ```
 
 Build or provide Linux artifacts from a Linux environment, macOS ARM artifacts from an Apple Silicon
@@ -29,14 +29,20 @@ the source of truth.
 ## Desktop Tarball Shape
 
 ```text
-herdr-web-vX.Y.Z-PLATFORM/
-  bin/herdr-web
-  bin/herdr-web-bridge
-  share/herdr-web/web/
+herdr-world-vX.Y.Z-PLATFORM/
+  bin/herdr-world
+  bin/herdr-world-bridge
+  share/herdr-world/web/
+  third_party/licenses/
+  docs/world-assets.md
+  vendor/herdr-compat/VENDOR-MANIFEST.toml
+  LICENSE
+  THIRD_PARTY_NOTICES.md
+  UPSTREAM.md
   README.md
 ```
 
-`bin/herdr-web` is a small wrapper that runs `herdr-web-bridge` with `--static-dir` pointed at the
+`bin/herdr-world` is a small wrapper that runs `herdr-world-bridge` with `--static-dir` pointed at the
 bundled web assets.
 
 ## Build A Desktop Tarball
@@ -74,19 +80,21 @@ scripts/package-tarball.sh vX.Y.Z macos-x86_64
 The output is written under `dist-packages/`:
 
 ```text
-dist-packages/herdr-web-vX.Y.Z-PLATFORM.tar.gz
-dist-packages/herdr-web-vX.Y.Z-PLATFORM.tar.gz.sha256
+dist-packages/herdr-world-vX.Y.Z-PLATFORM.tar.gz
+dist-packages/herdr-world-vX.Y.Z-PLATFORM.tar.gz.sha256
 ```
 
 Before uploading or distributing a desktop tarball, inspect it:
 
 ```bash
-tar -tzf dist-packages/herdr-web-vX.Y.Z-PLATFORM.tar.gz
-cat dist-packages/herdr-web-vX.Y.Z-PLATFORM.tar.gz.sha256
+tar -tzf dist-packages/herdr-world-vX.Y.Z-PLATFORM.tar.gz
+cat dist-packages/herdr-world-vX.Y.Z-PLATFORM.tar.gz.sha256
 ```
 
-Confirm the archive contains the expected root directory, `bin/herdr-web`,
-`bin/herdr-web-bridge`, bundled `share/herdr-web/web/` assets, and `README.md`.
+Confirm the archive contains the expected root directory, `bin/herdr-world`,
+`bin/herdr-world-bridge`, bundled `share/herdr-world/web/` assets, `LICENSE`,
+`THIRD_PARTY_NOTICES.md`, `UPSTREAM.md`, the Apache/PixiJS license texts, the World asset
+record, the Herdr vendor manifest, and `README.md`.
 
 Before release, run the unpacked wrapper against a Herdr `v0.8.2` or newer daemon reporting protocol
 `20`. Confirm the bridge accepts that combination and rejects a daemon reporting any other terminal
@@ -121,13 +129,13 @@ To stage the current debug APK under the release asset name for private testing:
 
 ```bash
 mkdir -p dist-packages
-cp android/app/build/outputs/apk/debug/app-debug.apk dist-packages/herdr-web-vX.Y.Z-android-debug.apk
+cp android/app/build/outputs/apk/debug/app-debug.apk dist-packages/herdr-world-vX.Y.Z-android-debug.apk
 ```
 
 For a public release, build a signed release APK instead and use the non-debug release asset name:
 
 ```text
-dist-packages/herdr-web-vX.Y.Z-android.apk
+dist-packages/herdr-world-vX.Y.Z-android.apk
 ```
 
 ## User Quick Start From Tarball
@@ -141,9 +149,9 @@ herdr
 Unpack and run:
 
 ```bash
-tar -xzf herdr-web-vX.Y.Z-linux-x86_64.tar.gz
-cd herdr-web-vX.Y.Z-linux-x86_64
-bin/herdr-web
+tar -xzf herdr-world-vX.Y.Z-linux-x86_64.tar.gz
+cd herdr-world-vX.Y.Z-linux-x86_64
+bin/herdr-world
 ```
 
 Open:
@@ -155,13 +163,13 @@ http://127.0.0.1:8787
 For LAN or Android testing:
 
 ```bash
-bin/herdr-web --host 0.0.0.0 --port 4000 --allow-origin http://localhost
+bin/herdr-world --host 0.0.0.0 --port 4000 --allow-origin http://localhost
 ```
 
 If using a DNS hostname from Android, also allow it:
 
 ```bash
-bin/herdr-web --host 0.0.0.0 --port 4000 \
+bin/herdr-world --host 0.0.0.0 --port 4000 \
   --allow-origin http://localhost \
   --allow-host herdr-host.local
 ```
@@ -173,13 +181,13 @@ called. If a page opened from `http://host-a:8787` should connect to `http://hos
 A with:
 
 ```bash
-bin/herdr-web --host 0.0.0.0 --allow-host host-a --allow-connect-origin http://host-b:8787
+bin/herdr-world --host 0.0.0.0 --allow-host host-a --allow-connect-origin http://host-b:8787
 ```
 
 Run host B with:
 
 ```bash
-bin/herdr-web --host 0.0.0.0 --allow-host host-b --allow-origin http://host-a:8787
+bin/herdr-world --host 0.0.0.0 --allow-host host-b --allow-origin http://host-a:8787
 ```
 
 `--allow-origin` accepts inbound browser calls to a bridge. `--allow-connect-origin` expands the
@@ -195,8 +203,8 @@ Upload the Linux tarball from the Linux build host:
 
 ```bash
 gh release upload vX.Y.Z \
-  dist-packages/herdr-web-vX.Y.Z-linux-x86_64.tar.gz \
-  dist-packages/herdr-web-vX.Y.Z-linux-x86_64.tar.gz.sha256
+  dist-packages/herdr-world-vX.Y.Z-linux-x86_64.tar.gz \
+  dist-packages/herdr-world-vX.Y.Z-linux-x86_64.tar.gz.sha256
 ```
 
 Upload the macOS ARM tarball from the Apple Silicon Mac build host, or copy it to the release
@@ -204,8 +212,8 @@ operator machine first:
 
 ```bash
 gh release upload vX.Y.Z \
-  dist-packages/herdr-web-vX.Y.Z-macos-arm64.tar.gz \
-  dist-packages/herdr-web-vX.Y.Z-macos-arm64.tar.gz.sha256
+  dist-packages/herdr-world-vX.Y.Z-macos-arm64.tar.gz \
+  dist-packages/herdr-world-vX.Y.Z-macos-arm64.tar.gz.sha256
 ```
 
 Upload the macOS Intel tarball from the Intel Mac build host, or copy it to the release operator
@@ -213,14 +221,14 @@ machine first:
 
 ```bash
 gh release upload vX.Y.Z \
-  dist-packages/herdr-web-vX.Y.Z-macos-x86_64.tar.gz \
-  dist-packages/herdr-web-vX.Y.Z-macos-x86_64.tar.gz.sha256
+  dist-packages/herdr-world-vX.Y.Z-macos-x86_64.tar.gz \
+  dist-packages/herdr-world-vX.Y.Z-macos-x86_64.tar.gz.sha256
 ```
 
 Upload the Android debug APK after it has the final debug asset name:
 
 ```bash
-gh release upload vX.Y.Z dist-packages/herdr-web-vX.Y.Z-android-debug.apk
+gh release upload vX.Y.Z dist-packages/herdr-world-vX.Y.Z-android-debug.apk
 ```
 
 If every artifact has been copied to one machine, the same paths can be uploaded in one

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,6 +1,6 @@
 # Release Process
 
-`herdr-web` is a private, vendored web app release. Releases create Git tags and GitHub releases.
+`herdr-world` is a public downstream application. Releases create Git tags and GitHub releases.
 They do not publish npm packages, and the package versions are not release versions.
 
 ## Prerequisites
@@ -78,20 +78,22 @@ The desktop tarballs are written to `dist-packages/`. The debug APK is written t
 
 Before uploading or distributing any tarball or APK, inspect the artifact and confirm it matches the
 documented release layout, platform, version, and source commit/tag. For desktop tarballs, list the
-archive contents and verify the wrapper, bridge binary, bundled `web/dist`, and README are present.
+archive contents and verify the wrapper, bridge binary, bundled `web/dist`, README, root license,
+third-party notices, upstream record, Apache/PixiJS license texts, World asset record, and Herdr
+vendor manifest are present.
 For APKs, inspect the package listing or metadata with available local tools.
 
 To stage the current debug APK under the release asset name for private testing:
 
 ```bash
 mkdir -p dist-packages
-cp android/app/build/outputs/apk/debug/app-debug.apk dist-packages/herdr-web-vX.Y.Z-android-debug.apk
+cp android/app/build/outputs/apk/debug/app-debug.apk dist-packages/herdr-world-vX.Y.Z-android-debug.apk
 ```
 
 For a public release, build a signed release APK instead and use the non-debug release asset name:
 
 ```text
-dist-packages/herdr-web-vX.Y.Z-android.apk
+dist-packages/herdr-world-vX.Y.Z-android.apk
 ```
 
 ## Browser And Federation Smoke
@@ -182,8 +184,8 @@ Upload the Linux tarball from the Linux build host:
 
 ```bash
 gh release upload vX.Y.Z \
-  dist-packages/herdr-web-vX.Y.Z-linux-x86_64.tar.gz \
-  dist-packages/herdr-web-vX.Y.Z-linux-x86_64.tar.gz.sha256
+  dist-packages/herdr-world-vX.Y.Z-linux-x86_64.tar.gz \
+  dist-packages/herdr-world-vX.Y.Z-linux-x86_64.tar.gz.sha256
 ```
 
 Upload the macOS ARM tarball from the Apple Silicon Mac build host, or copy it to the release
@@ -191,8 +193,8 @@ operator machine first:
 
 ```bash
 gh release upload vX.Y.Z \
-  dist-packages/herdr-web-vX.Y.Z-macos-arm64.tar.gz \
-  dist-packages/herdr-web-vX.Y.Z-macos-arm64.tar.gz.sha256
+  dist-packages/herdr-world-vX.Y.Z-macos-arm64.tar.gz \
+  dist-packages/herdr-world-vX.Y.Z-macos-arm64.tar.gz.sha256
 ```
 
 Upload the macOS Intel tarball from the Intel Mac build host, or copy it to the release operator
@@ -200,14 +202,14 @@ machine first:
 
 ```bash
 gh release upload vX.Y.Z \
-  dist-packages/herdr-web-vX.Y.Z-macos-x86_64.tar.gz \
-  dist-packages/herdr-web-vX.Y.Z-macos-x86_64.tar.gz.sha256
+  dist-packages/herdr-world-vX.Y.Z-macos-x86_64.tar.gz \
+  dist-packages/herdr-world-vX.Y.Z-macos-x86_64.tar.gz.sha256
 ```
 
 Upload the Android debug APK after it has the final debug asset name:
 
 ```bash
-gh release upload vX.Y.Z dist-packages/herdr-web-vX.Y.Z-android-debug.apk
+gh release upload vX.Y.Z dist-packages/herdr-world-vX.Y.Z-android-debug.apk
 ```
 
 If every artifact has been copied to one machine, the same paths can be uploaded in one

--- a/docs/tarball-readme.md
+++ b/docs/tarball-readme.md
@@ -1,6 +1,8 @@
-# herdr-web Desktop Bundle
+# herdr-world Desktop Bundle
 
-This bundle contains the `herdr-web` browser UI assets and the `herdr-web-bridge` executable.
+This bundle contains the `herdr-world` browser UI assets and the `herdr-world-bridge` executable.
+The bundle's root `LICENSE`, `THIRD_PARTY_NOTICES.md`, `UPSTREAM.md`, and files under
+`third_party/licenses/` describe the retained upstream and asset terms.
 
 It does not include Herdr itself. Start or attach a Herdr `v0.8.2` or newer session that reports
 terminal protocol `20` separately before running this bundle.
@@ -10,7 +12,7 @@ terminal protocol `20` separately before running this bundle.
 From the unpacked bundle directory:
 
 ```bash
-bin/herdr-web
+bin/herdr-world
 ```
 
 Open:
@@ -24,13 +26,13 @@ http://127.0.0.1:8787
 To expose the bridge to another device on a trusted local network:
 
 ```bash
-bin/herdr-web --host 0.0.0.0 --port 4000 --allow-origin http://localhost
+bin/herdr-world --host 0.0.0.0 --port 4000 --allow-origin http://localhost
 ```
 
 If Android connects through a DNS hostname, allow that hostname too:
 
 ```bash
-bin/herdr-web --host 0.0.0.0 --port 4000 \
+bin/herdr-world --host 0.0.0.0 --port 4000 \
   --allow-origin http://localhost \
   --allow-host herdr-host.local
 ```
@@ -44,10 +46,10 @@ connects to `http://host-b:8787` needs:
 
 ```bash
 # host A, serving the web page
-bin/herdr-web --host 0.0.0.0 --allow-host host-a --allow-connect-origin http://host-b:8787
+bin/herdr-world --host 0.0.0.0 --allow-host host-a --allow-connect-origin http://host-b:8787
 
 # host B, serving the backend being called
-bin/herdr-web --host 0.0.0.0 --allow-host host-b --allow-origin http://host-a:8787
+bin/herdr-world --host 0.0.0.0 --allow-host host-b --allow-origin http://host-a:8787
 ```
 
 Only bind to non-loopback interfaces on networks you trust.

--- a/docs/vendoring.md
+++ b/docs/vendoring.md
@@ -1,12 +1,13 @@
 # Vendoring Herdr Compatibility
 
-`herdr-web` vendors a small Herdr compatibility crate because the bridge depends on private API and
+`herdr-world` vendors a small Herdr compatibility crate because the bridge depends on private API and
 wire protocol details that are not exposed as a stable Herdr library or daemon API.
 
 ## What Is Vendored
 
 `vendor/herdr-compat/` is the only vendored Herdr source in this repository. It is a minimal local
-Rust crate containing copied or lightly pruned compatibility code needed by `herdr-web-bridge`:
+Rust crate containing copied or lightly pruned compatibility code needed by the packaged
+`herdr-world-bridge`:
 
 - JSON API client, status, request, response, and event schema types.
 - Terminal attach wire protocol messages, framing, protocol constants, and frame data types.
@@ -17,7 +18,8 @@ Rust crate containing copied or lightly pruned compatibility code needed by `her
 
 `bridge/` remains the repo-owned executable:
 
-- `bridge/src/main.rs` exposes the `herdr-web-bridge` command.
+- `bridge/src/main.rs` exposes the upstream-aligned Cargo target `herdr-web-bridge`; release
+  assembly installs the same executable as `herdr-world-bridge`.
 - `bridge/src/session.rs` owns active Herdr session, config directory, and socket path selection.
 - `bridge/src/web_bridge.rs` owns the HTTP/WebSocket bridge implementation and browser command
   allow-list.
@@ -26,8 +28,8 @@ Rust crate containing copied or lightly pruned compatibility code needed by `her
 The full upstream Herdr source tree is intentionally not vendored. Do not recreate `vendor/herdr/`
 or path-import files from an upstream checkout at build time.
 
-The browser app is not vendored into Herdr. It lives at `web/`, and `herdr-web-bridge` serves
-`web/dist` through `--static-dir`.
+The browser app is not vendored into Herdr. It lives at `web/`, and the bridge serves `web/dist`
+through `--static-dir`.
 
 ## Current Reference
 
@@ -42,7 +44,7 @@ Herdr `v0.8.2` release commit and protocol `20`. The bridge keeps only the narro
 surface it needs; the full Herdr source tree remains an external audit reference.
 
 Use the upstream checkout as an external reference for audits and refreshes. It is not required to
-build `herdr-web`.
+build `herdr-world`.
 
 ## Why This Shape
 
@@ -62,7 +64,7 @@ intentional and reviewed.
 
 The compatibility crate currently keeps `ratatui` and `crossterm` because upstream
 `protocol::wire` includes semantic frame and input conversion types next to the terminal attach
-messages used by the bridge. `herdr-web-bridge` requests terminal ANSI rendering, but keeping the
+messages used by the bridge. `herdr-world-bridge` requests terminal ANSI rendering, but keeping the
 wire module broad makes protocol drift reviewable against upstream. Revisit this tradeoff if the
 bridge narrows the drift check to only the terminal attach message regions.
 
@@ -75,7 +77,7 @@ the external checkout or recreate a full upstream vendor snapshot.
 
 ```bash
 HERDR_SRC=/path/to/herdr
-HERDR_WEB=/path/to/herdr-web
+HERDR_WORLD=/path/to/herdr-world
 ```
 
 1. Verify the source checkout is clean and pinned to the reviewed release:

--- a/docs/world-assets.md
+++ b/docs/world-assets.md
@@ -1,16 +1,16 @@
 # Pixel Office asset provenance
 
-The Herdr Web Pixel Office port uses character assets traceable to the
+The Herdr World Pixel Office port uses character assets traceable to the
 Claw-Empire repository at revision
 `66a24ea7df2435ef897c48c147deb7ec572c01c2`, under `public/sprites/`. The
 tracked PNGs are byte-identical to those source files. That source carries the
 Apache License 2.0 and the copyright notice `Copyright 2026 GreenSheep01201
-(seowongil@gmail.com)`. Herdr Web has no build or runtime dependency on the
+(seowongil@gmail.com)`. Herdr World has no build or runtime dependency on the
 reference workspace. The copied character sprites now live under
 `web/public/world/characters/`.
 
 The reference workspace is historical provenance only; contributors do not
-need to clone or start another repository to build, test, or run Herdr Web.
+need to clone or start another repository to build, test, or run Herdr World.
 The release notice bundle MUST include the Apache-2.0 license and this
 attribution. The adapted TypeScript geometry/drawing files are modified files
 and MUST carry a prominent modification notice as required by Apache-2.0

--- a/scripts/e2e-fixture.mjs
+++ b/scripts/e2e-fixture.mjs
@@ -38,7 +38,7 @@ for (const fixture of fixtures) {
   servers.push(await startFixture(fixture));
 }
 
-process.stdout.write("Herdr Web browser fixtures listening on 4173-4176\n");
+process.stdout.write("Herdr World browser fixtures listening on 4173-4176\n");
 
 for (const signal of ["SIGINT", "SIGTERM"]) {
   process.on(signal, () => {

--- a/scripts/independence-audit.sh
+++ b/scripts/independence-audit.sh
@@ -4,8 +4,8 @@ set -euo pipefail
 if rg -n --glob '*.{ts,tsx,js,mjs,rs}' \
   '(dynamic plugin|plugin marketplace|fleet database|central gateway|second multiplexer)' \
   web/src bridge/src vendor/herdr-compat/src; then
-  echo "Herdr Web core contains a prohibited control-plane or dynamic-loader implementation" >&2
+  echo "Herdr World core contains a prohibited control-plane or dynamic-loader implementation" >&2
   exit 1
 fi
 
-echo "Herdr Web independence audit passed"
+echo "Herdr World independence audit passed"

--- a/scripts/package-tarball.sh
+++ b/scripts/package-tarball.sh
@@ -12,6 +12,11 @@ fi
 VERSION="$1"
 PLATFORM="${2:-}"
 
+if [[ ! "$VERSION" =~ ^v?[0-9A-Za-z][0-9A-Za-z._+-]*$ ]]; then
+  echo "invalid VERSION: use only letters, numbers, dots, underscores, plus signs, and hyphens" >&2
+  exit 2
+fi
+
 if [[ -z "$PLATFORM" ]]; then
   os="$(uname -s | tr '[:upper:]' '[:lower:]')"
   arch="$(uname -m)"
@@ -26,31 +31,56 @@ if [[ -z "$PLATFORM" ]]; then
   esac
 fi
 
+if [[ ! "$PLATFORM" =~ ^[0-9A-Za-z][0-9A-Za-z._+-]*$ ]]; then
+  echo "invalid PLATFORM: use only letters, numbers, dots, underscores, plus signs, and hyphens" >&2
+  exit 2
+fi
+
 PKG_ROOT="$ROOT/dist-packages"
-NAME="herdr-web-${VERSION}-${PLATFORM}"
+NAME="herdr-world-${VERSION}-${PLATFORM}"
 STAGE="$PKG_ROOT/$NAME"
 ARCHIVE="$PKG_ROOT/$NAME.tar.gz"
+CARGO_BUILD_DIR="${CARGO_TARGET_DIR:-$ROOT/bridge/target}"
+if [[ "$CARGO_BUILD_DIR" != /* ]]; then
+  CARGO_BUILD_DIR="$ROOT/$CARGO_BUILD_DIR"
+fi
 
 npm --prefix "$ROOT" run build:web
-cargo build --release --manifest-path "$ROOT/bridge/Cargo.toml" --bin herdr-web-bridge
+cargo build \
+  --release \
+  --target-dir "$CARGO_BUILD_DIR" \
+  --manifest-path "$ROOT/bridge/Cargo.toml" \
+  --bin herdr-web-bridge
 
 rm -rf "$STAGE" "$ARCHIVE"
-mkdir -p "$STAGE/bin" "$STAGE/share/herdr-web/web"
+mkdir -p \
+  "$STAGE/bin" \
+  "$STAGE/share/herdr-world/web" \
+  "$STAGE/third_party/licenses" \
+  "$STAGE/docs" \
+  "$STAGE/vendor/herdr-compat"
 
-cp "$ROOT/bridge/target/release/herdr-web-bridge" "$STAGE/bin/herdr-web-bridge"
-cp -R "$ROOT/web/dist/." "$STAGE/share/herdr-web/web/"
+cp "$CARGO_BUILD_DIR/release/herdr-web-bridge" "$STAGE/bin/herdr-world-bridge"
+cp -R "$ROOT/web/dist/." "$STAGE/share/herdr-world/web/"
 cp "$ROOT/docs/tarball-readme.md" "$STAGE/README.md"
+cp "$ROOT/LICENSE" "$STAGE/LICENSE"
+cp "$ROOT/THIRD_PARTY_NOTICES.md" "$STAGE/THIRD_PARTY_NOTICES.md"
+cp "$ROOT/UPSTREAM.md" "$STAGE/UPSTREAM.md"
+cp "$ROOT/third_party/licenses/Apache-2.0.txt" "$STAGE/third_party/licenses/Apache-2.0.txt"
+cp "$ROOT/third_party/licenses/PixiJS-MIT.txt" "$STAGE/third_party/licenses/PixiJS-MIT.txt"
+cp "$ROOT/docs/world-assets.md" "$STAGE/docs/world-assets.md"
+cp "$ROOT/vendor/herdr-compat/VENDOR-MANIFEST.toml" "$STAGE/vendor/herdr-compat/VENDOR-MANIFEST.toml"
 
-cat > "$STAGE/bin/herdr-web" <<'WRAPPER'
+cat > "$STAGE/bin/herdr-world" <<'WRAPPER'
 #!/usr/bin/env bash
 set -euo pipefail
 
 BIN_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT="$(cd "$BIN_DIR/.." && pwd)"
 
-exec "$BIN_DIR/herdr-web-bridge" --static-dir "$ROOT/share/herdr-web/web" "$@"
+exec "$BIN_DIR/herdr-world-bridge" --static-dir "$ROOT/share/herdr-world/web" "$@"
 WRAPPER
-chmod +x "$STAGE/bin/herdr-web" "$STAGE/bin/herdr-web-bridge"
+chmod +x "$STAGE/bin/herdr-world" "$STAGE/bin/herdr-world-bridge"
 
 (
   cd "$PKG_ROOT"

--- a/scripts/security-audit.sh
+++ b/scripts/security-audit.sh
@@ -33,4 +33,4 @@ if rg -n --glob '*.{ts,tsx,js,mjs,rs}' \
   exit 1
 fi
 
-echo "Herdr Web security audit passed"
+echo "Herdr World security audit passed"

--- a/third_party/licenses/Apache-2.0.txt
+++ b/third_party/licenses/Apache-2.0.txt
@@ -1,0 +1,190 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to the Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by the Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding any notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright 2026 GreenSheep01201 (seowongil@gmail.com)
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/third_party/licenses/PixiJS-MIT.txt
+++ b/third_party/licenses/PixiJS-MIT.txt
@@ -1,7 +1,6 @@
-MIT License
+The MIT License
 
-Copyright (c) 2026 Kevin
-Copyright (c) 2026 IvoryHeart contributors
+Copyright (c) 2013-2023 Mathew Groves, Chad Engler
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -10,13 +9,13 @@ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 copies of the Software, and to permit persons to whom the Software is
 furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/web/README.md
+++ b/web/README.md
@@ -1,6 +1,6 @@
 # @herdr-world/web
 
-React + Vite frontend for `herdr-web`.
+React + Vite frontend for `herdr-world`.
 
 Run from this directory:
 
@@ -12,7 +12,7 @@ npm run test
 npm run build
 ```
 
-For the supervised complete local Herdr Web run, use the repository root:
+For the supervised complete local Herdr World run, use the repository root:
 
 ```bash
 cd ..
@@ -23,8 +23,9 @@ Open the printed Vite URL for frontend HMR. It proxies API/WebSocket traffic to
 the managed loopback bridge. `npm run dev:local` remains available when an
 existing bridge should be reused.
 
-The production build is written to `web/dist/` and served by `herdr-web-bridge` through
-`scripts/run-bridge.sh`.
+The production build is written to `web/dist/` and served through `scripts/run-bridge.sh`. The
+upstream-aligned development Cargo target is `herdr-web-bridge`; release bundles install that
+executable as `herdr-world-bridge`.
 
 To manage the two processes separately instead:
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -7880,7 +7880,7 @@ function Switcher({
             <img className="brand-logo" src="/herdr-logo.svg" alt="" aria-hidden="true" />
             <span className="brand-title">
               <span className="brand-dot dot" data-status={roll} />
-              herdr-web
+              herdr-world
             </span>
           </span>
           {headerSummary ? (

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1,5 +1,5 @@
 /* ========================================================================
-   herdr-web - Catppuccin Mocha, Geist UI with system terminal mono
+   herdr-world - Catppuccin Mocha, Geist UI with system terminal mono
    A compact "command deck" for your agents: one scrollable column of
    scoped sections (spaces -> panes), terminal on the side / in front.
    ======================================================================== */


### PR DESCRIPTION
## Summary

- complete visible Herdr World naming across the shell, Android application ID, documentation, and release artifacts
- retain upstream-aligned Cargo and legacy state identifiers where changing them would impede upstream comparison or break existing users
- ship explicit license, third-party notice, upstream, asset, and vendored-source provenance in desktop bundles
- make tarball assembly honor `CARGO_TARGET_DIR` and reject unsafe version/platform path input

## Validation

- `npm run check` — passed (439 web, 116 compatibility + 3 fixture, 162 bridge tests)
- `npm run android:sync` — passed
- `npm run test:security` — passed
- `npm run test:independence` — passed
- desktop tarball build, checksum, inventory, `--help`, and live protocol-20 smoke — passed
- full Playwright suite — 43 passed, 2 documented skips, and only the known timing failure tracked in #5; no assertion/test/product workaround was added
- `git diff --check` — passed

Native Gradle unit tests were not run because this machine has no Android SDK installed; Capacitor synchronization and the web bundle completed successfully.

Closes the remaining product-identity/package naming tranche. Issue #5 is explicitly non-blocking by owner decision.
