### PR TITLE
docs: add public contribution and security guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 ### Added
 
+- Added focused contribution guidance and a private vulnerability-reporting
+  policy for the public Herdr World repository.
+  [Herdr World PR #8](https://github.com/IvoryHeart/herdr-world/pull/8)
 - Added Spec 015 work unit 2's focused Herdr Web v0.4.2/v0.4.3 replay: a supervised loopback
   `npm run dev` workflow with child-process tests, and an opt-in bounded terminal screen-reader
   text mirror. The replay preserves downstream World and multi-bridge behavior; Web v0.4.2/v0.4.3

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,46 @@
+# Contributing
+
+Herdr World is an independent downstream application. Contributions are
+welcome when they improve its existing terminal, federation, World surface,
+observability, packaging, or maintenance workflows.
+
+## Before You Start
+
+- Search the existing issues and pull requests first.
+- Open an issue before a large new visualization, integration, protocol change,
+  or architectural redesign so the intended scope can be agreed early.
+- Small fixes, tests, documentation improvements, and dependency maintenance
+  can go directly to a pull request.
+
+Generic changes that could also benefit Herdr Web may be implemented here.
+Herdr World maintainers can separately propose a focused upstream patch;
+contributors do not need upstream approval or coordination before helping this
+project.
+
+## Source Boundaries
+
+- Keep World presentation and behavior under `web/src/world/` and World assets
+  under `web/public/world/` where practical.
+- Keep generic Herdr Web-aligned changes close to their upstream paths.
+- Keep the bridge allow-list narrow and preserve one bridge manager, one runtime
+  cache, and one terminal-session owner.
+- Read `docs/vendoring.md` before changing `vendor/herdr-compat/`.
+- Do not add credentials, private machine paths, generated build output, or
+  untracked third-party assets.
+
+The current boundary and upstream-sync contract is documented in
+`docs/specs/004-world-packaging-and-upstream-boundaries-spec.md`.
+
+## Pull Requests
+
+- Keep one pull request focused on one coherent concern.
+- Explain the problem, the chosen approach, and any user-visible trade-offs.
+- Add or update proportionate tests.
+- Add user-visible changes to `CHANGELOG.md` under `Unreleased`.
+- Preserve applicable attribution and update `THIRD_PARTY_NOTICES.md` or the
+  relevant provenance manifest when adding third-party material.
+- Run `npm run check`; use `npm run check:acceptance` when browser behavior or
+  runtime integration changes.
+
+Contributions are submitted under the repository's MIT license unless a file
+or directory carries an explicit third-party license notice.

--- a/README.md
+++ b/README.md
@@ -463,6 +463,14 @@ See [docs/packaging.md](docs/packaging.md) for desktop tarball and APK artifact 
 See [docs/release.md](docs/release.md) for release validation, browser smoke testing, tagging,
 GitHub release creation, and manual artifact upload.
 
+## Contributing And Support
+
+Focused contributions are welcome; see [`CONTRIBUTING.md`](CONTRIBUTING.md).
+Use [GitHub Issues](https://github.com/IvoryHeart/herdr-world/issues) for bugs
+and scoped feature proposals. Security issues should follow
+[`SECURITY.md`](SECURITY.md) and must not be disclosed publicly before a fix is
+available. Community support is best-effort and has no SLA.
+
 ## License And Attribution
 
 Herdr World's MIT license retains the Herdr Web copyright notice and adds the

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,28 @@
+# Security Policy
+
+## Supported Versions
+
+Security fixes target the latest release and current `main`. Older commits,
+prereleases, and locally modified builds are supported only on a best-effort
+basis; this personal open-source project does not provide an SLA.
+
+## Reporting A Vulnerability
+
+Use [GitHub private vulnerability reporting](https://github.com/IvoryHeart/herdr-world/security/advisories/new).
+Please do not disclose exploitable details in a public issue.
+
+Include the affected revision or release, deployment shape, reproduction steps,
+impact, and any suggested mitigation. Reports and fixes are handled on a
+best-effort basis. Acknowledgement or publication timing depends on severity
+and maintainer availability.
+
+Report vulnerabilities in Herdr itself to `herdrdev/herdr` and vulnerabilities
+specific to the upstream browser application to `kcosr/herdr-web`.
+
+## Deployment Boundary
+
+The Herdr World bridge grants admitted browsers terminal-equivalent access to
+the connected Herdr runtime. It is local-first and does not provide a complete
+authentication or authorization layer. Keep it on loopback unless access is
+restricted by a trusted network, firewall, VPN, or authenticated reverse proxy,
+and configure allowed hosts and origins explicitly.


### PR DESCRIPTION
## Summary

- add lightweight contribution guidance that keeps World velocity independent from upstream review
- document the existing source boundaries and proportionate validation expectations
- add best-effort security support and a private reporting path
- link contribution, support, and security guidance from the README

GitHub private vulnerability reporting is now enabled for `IvoryHeart/herdr-world`, so the documented reporting URL is active.

This intentionally adds no CLA, DCO, governance framework, support SLA, product code, packaging system, or new specification.

## Validation

- `git diff --check` — passed
- private vulnerability reporting API — enabled
- documentation-only change; product/runtime tests are left to the normal exact-head CI
