### PR TITLE
fix: pin releases to Herdr World

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 ### Fixed
 
+- Made release creation fail closed unless both `origin` URLs and the explicit GitHub CLI target
+  resolve to `IvoryHeart/herdr-world`, preventing a checkout's default upstream from receiving a
+  Herdr World release.
+
 ### Removed
 
 ## [0.1.0-rc.1] - 2026-08-26

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 - Made release creation fail closed unless both `origin` URLs and the explicit GitHub CLI target
   resolve to `IvoryHeart/herdr-world`, preventing a checkout's default upstream from receiving a
-  Herdr World release.
+  Herdr World release. [Herdr World PR #10](https://github.com/IvoryHeart/herdr-world/pull/10)
 
 ### Removed
 

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -210,7 +210,8 @@ Upload the Linux tarball from the Linux build host:
 ```bash
 gh release upload vX.Y.Z \
   dist-packages/herdr-world-vX.Y.Z-linux-x86_64.tar.gz \
-  dist-packages/herdr-world-vX.Y.Z-linux-x86_64.tar.gz.sha256
+  dist-packages/herdr-world-vX.Y.Z-linux-x86_64.tar.gz.sha256 \
+  --repo IvoryHeart/herdr-world
 ```
 
 Upload the macOS ARM tarball from the Apple Silicon Mac build host, or copy it to the release
@@ -219,7 +220,8 @@ operator machine first:
 ```bash
 gh release upload vX.Y.Z \
   dist-packages/herdr-world-vX.Y.Z-macos-arm64.tar.gz \
-  dist-packages/herdr-world-vX.Y.Z-macos-arm64.tar.gz.sha256
+  dist-packages/herdr-world-vX.Y.Z-macos-arm64.tar.gz.sha256 \
+  --repo IvoryHeart/herdr-world
 ```
 
 Upload the macOS Intel tarball from the Intel Mac build host, or copy it to the release operator
@@ -228,13 +230,15 @@ machine first:
 ```bash
 gh release upload vX.Y.Z \
   dist-packages/herdr-world-vX.Y.Z-macos-x86_64.tar.gz \
-  dist-packages/herdr-world-vX.Y.Z-macos-x86_64.tar.gz.sha256
+  dist-packages/herdr-world-vX.Y.Z-macos-x86_64.tar.gz.sha256 \
+  --repo IvoryHeart/herdr-world
 ```
 
 Upload the Android debug APK after it has the final debug asset name:
 
 ```bash
-gh release upload vX.Y.Z dist-packages/herdr-world-vX.Y.Z-android-debug.apk
+gh release upload vX.Y.Z dist-packages/herdr-world-vX.Y.Z-android-debug.apk \
+  --repo IvoryHeart/herdr-world
 ```
 
 If every artifact has been copied to one machine, the same paths can be uploaded in one

--- a/docs/release.md
+++ b/docs/release.md
@@ -11,6 +11,8 @@ They do not publish npm packages, and the package versions are not release versi
 - `cargo-about` 0.9.2 (`cargo install cargo-about --version 0.9.2 --locked --features cli`).
 - JDK 21 and Android SDK when validating the Android shell.
 - GitHub CLI authenticated as a user that can create releases.
+- `origin` fetch and push URLs both resolve to `IvoryHeart/herdr-world`. The release helper rejects
+  upstream, fork, local-path, and unsupported remote URLs before making any release mutation.
 - A local Herdr `v0.8.2` or newer session reporting terminal protocol `20` for browser and packaged
   bridge smoke testing.
 
@@ -157,6 +159,7 @@ node scripts/release.mjs v0.1.0
 The script:
 
 - requires a clean `main` branch
+- verifies both `origin` URLs and GitHub CLI access against `IvoryHeart/herdr-world`
 - promotes `CHANGELOG.md` from `Unreleased` to the release version/date
 - removes empty unused subsections from the released version notes
 - runs `npm run check`
@@ -164,6 +167,7 @@ The script:
 - tags `vX.Y.Z`
 - pushes `main` and the tag atomically
 - creates a GitHub release with notes extracted from `CHANGELOG.md`
+- passes `--repo IvoryHeart/herdr-world` and `--verify-tag` explicitly when creating the release
 - opens the next `## [Unreleased]` changelog section and pushes it
 
 The release script does not upload binary artifacts. Upload separately packaged tarballs and APKs
@@ -187,7 +191,8 @@ Upload the Linux tarball from the Linux build host:
 ```bash
 gh release upload vX.Y.Z \
   dist-packages/herdr-world-vX.Y.Z-linux-x86_64.tar.gz \
-  dist-packages/herdr-world-vX.Y.Z-linux-x86_64.tar.gz.sha256
+  dist-packages/herdr-world-vX.Y.Z-linux-x86_64.tar.gz.sha256 \
+  --repo IvoryHeart/herdr-world
 ```
 
 Upload the macOS ARM tarball from the Apple Silicon Mac build host, or copy it to the release
@@ -196,7 +201,8 @@ operator machine first:
 ```bash
 gh release upload vX.Y.Z \
   dist-packages/herdr-world-vX.Y.Z-macos-arm64.tar.gz \
-  dist-packages/herdr-world-vX.Y.Z-macos-arm64.tar.gz.sha256
+  dist-packages/herdr-world-vX.Y.Z-macos-arm64.tar.gz.sha256 \
+  --repo IvoryHeart/herdr-world
 ```
 
 Upload the macOS Intel tarball from the Intel Mac build host, or copy it to the release operator
@@ -205,13 +211,15 @@ machine first:
 ```bash
 gh release upload vX.Y.Z \
   dist-packages/herdr-world-vX.Y.Z-macos-x86_64.tar.gz \
-  dist-packages/herdr-world-vX.Y.Z-macos-x86_64.tar.gz.sha256
+  dist-packages/herdr-world-vX.Y.Z-macos-x86_64.tar.gz.sha256 \
+  --repo IvoryHeart/herdr-world
 ```
 
 Upload the Android debug APK after it has the final debug asset name:
 
 ```bash
-gh release upload vX.Y.Z dist-packages/herdr-world-vX.Y.Z-android-debug.apk
+gh release upload vX.Y.Z dist-packages/herdr-world-vX.Y.Z-android-debug.apk \
+  --repo IvoryHeart/herdr-world
 ```
 
 If every artifact has been copied to one machine, the same paths can be uploaded in one

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "notices:generate": "node scripts/dependency-notices.mjs --generate",
     "notices:check": "node scripts/dependency-notices.mjs --check",
     "test:dev": "node --test scripts/dev.test.mjs",
+    "test:release": "node --test scripts/release-target.test.mjs",
     "test:web": "npm run test --prefix web",
     "test:observability": "npm run test --prefix web -- observability.test.ts && cargo test --manifest-path bridge/Cargo.toml --bin herdr-web-bridge observability",
     "test:e2e": "npm run build:web && playwright test",
@@ -27,7 +28,7 @@
     "android:open": "cap open android",
     "package:tarball": "scripts/package-tarball.sh",
     "build": "npm run build:web && npm run bridge:build",
-    "test": "npm run test:dev && npm run test:web && npm run bridge:test",
+    "test": "npm run test:dev && npm run test:release && npm run test:web && npm run bridge:test",
     "lint": "npm run lint:web && npm run bridge:fmt",
     "check": "npm run vendor:check && npm run notices:check && npm run lint && npm run test && npm run build",
     "check:acceptance": "npm run check && npm run test:e2e && npm run test:security && npm run test:independence"

--- a/scripts/release-target.mjs
+++ b/scripts/release-target.mjs
@@ -1,0 +1,42 @@
+export const RELEASE_REMOTE = "origin";
+export const RELEASE_REPOSITORY = "IvoryHeart/herdr-world";
+
+const GITHUB_REMOTE_PREFIXES = [
+  "git@github.com:",
+  "ssh://git@github.com/",
+  "https://github.com/",
+];
+
+export function githubRepositoryFromRemoteUrl(remoteUrl) {
+  const normalized = remoteUrl.trim().replace(/\/+$/, "").replace(/\.git$/i, "");
+  const lowercase = normalized.toLowerCase();
+  const prefix = GITHUB_REMOTE_PREFIXES.find((candidate) =>
+    lowercase.startsWith(candidate),
+  );
+  if (!prefix) {
+    return null;
+  }
+
+  const repository = normalized.slice(prefix.length);
+  return repository.split("/").length === 2 ? repository : null;
+}
+
+export function assertReleaseRemoteUrls(remoteUrls, direction) {
+  if (remoteUrls.length === 0) {
+    throw new Error(`${RELEASE_REMOTE} has no ${direction} URL`);
+  }
+
+  for (const remoteUrl of remoteUrls) {
+    const repository = githubRepositoryFromRemoteUrl(remoteUrl);
+    if (repository?.toLowerCase() !== RELEASE_REPOSITORY.toLowerCase()) {
+      const resolved = repository ?? "an unsupported or non-GitHub remote";
+      throw new Error(
+        `${RELEASE_REMOTE} ${direction} must resolve to ${RELEASE_REPOSITORY}; resolved ${resolved}`,
+      );
+    }
+  }
+}
+
+export function withReleaseRepository(args) {
+  return [...args, "--repo", RELEASE_REPOSITORY];
+}

--- a/scripts/release-target.test.mjs
+++ b/scripts/release-target.test.mjs
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  RELEASE_REPOSITORY,
+  assertReleaseRemoteUrls,
+  githubRepositoryFromRemoteUrl,
+  withReleaseRepository,
+} from "./release-target.mjs";
+
+test("recognizes canonical Herdr World GitHub remote forms", () => {
+  assert.equal(
+    githubRepositoryFromRemoteUrl("git@github.com:IvoryHeart/herdr-world.git"),
+    RELEASE_REPOSITORY,
+  );
+  assert.equal(
+    githubRepositoryFromRemoteUrl("ssh://git@github.com/IvoryHeart/herdr-world.git"),
+    RELEASE_REPOSITORY,
+  );
+  assert.equal(
+    githubRepositoryFromRemoteUrl("https://github.com/IvoryHeart/herdr-world.git"),
+    RELEASE_REPOSITORY,
+  );
+});
+
+test("rejects an upstream or unsupported release remote", () => {
+  assert.throws(
+    () => assertReleaseRemoteUrls(["git@github.com:kcosr/herdr-web.git"], "push"),
+    /must resolve to IvoryHeart\/herdr-world; resolved kcosr\/herdr-web/,
+  );
+  assert.throws(
+    () => assertReleaseRemoteUrls(["/tmp/not-a-github-repository"], "fetch"),
+    /unsupported or non-GitHub remote/,
+  );
+});
+
+test("requires every configured URL to resolve to Herdr World", () => {
+  assert.doesNotThrow(() =>
+    assertReleaseRemoteUrls(
+      [
+        "git@github.com:IvoryHeart/herdr-world.git",
+        "https://github.com/IvoryHeart/herdr-world.git",
+      ],
+      "push",
+    ),
+  );
+  assert.throws(
+    () =>
+      assertReleaseRemoteUrls(
+        [
+          "git@github.com:IvoryHeart/herdr-world.git",
+          "git@github.com:kcosr/herdr-web.git",
+        ],
+        "push",
+      ),
+    /resolved kcosr\/herdr-web/,
+  );
+});
+
+test("adds an explicit repository to GitHub CLI release commands", () => {
+  assert.deepEqual(withReleaseRepository(["release", "view", "v1.2.3"]), [
+    "release",
+    "view",
+    "v1.2.3",
+    "--repo",
+    "IvoryHeart/herdr-world",
+  ]);
+});

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -3,6 +3,13 @@ import { execFileSync } from "node:child_process";
 import { readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
+import {
+  RELEASE_REMOTE,
+  RELEASE_REPOSITORY,
+  assertReleaseRemoteUrls,
+  withReleaseRepository,
+} from "./release-target.mjs";
+
 const RELEASE_BRANCH = "main";
 const RELEASE_ARG = process.argv[2];
 const VERSION_ARG = /^v?(\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?)$/;
@@ -54,18 +61,56 @@ function validatePreflight() {
     fail(`release must run from ${RELEASE_BRANCH}; current branch is ${branch || "(detached)"}`);
   }
 
-  run("git", ["fetch", "origin", RELEASE_BRANCH, "--tags"]);
+  try {
+    const fetchUrls = output("git", ["remote", "get-url", "--all", RELEASE_REMOTE])
+      .split("\n")
+      .filter(Boolean);
+    const pushUrls = output("git", ["remote", "get-url", "--push", "--all", RELEASE_REMOTE])
+      .split("\n")
+      .filter(Boolean);
+    assertReleaseRemoteUrls(fetchUrls, "fetch");
+    assertReleaseRemoteUrls(pushUrls, "push");
+  } catch (error) {
+    fail(error instanceof Error ? error.message : String(error));
+  }
+
+  let accessibleRepository;
+  try {
+    accessibleRepository = output("gh", [
+      "repo",
+      "view",
+      RELEASE_REPOSITORY,
+      "--json",
+      "nameWithOwner",
+      "--jq",
+      ".nameWithOwner",
+    ]);
+  } catch {
+    fail(`GitHub CLI cannot access ${RELEASE_REPOSITORY}`);
+  }
+  if (accessibleRepository.toLowerCase() !== RELEASE_REPOSITORY.toLowerCase()) {
+    fail(`GitHub CLI resolved the release repository as ${accessibleRepository}`);
+  }
+
+  run("git", ["fetch", RELEASE_REMOTE, RELEASE_BRANCH, "--tags"]);
   const local = output("git", ["rev-parse", RELEASE_BRANCH]);
-  const remote = output("git", ["rev-parse", `origin/${RELEASE_BRANCH}`]);
+  const remote = output("git", ["rev-parse", `${RELEASE_REMOTE}/${RELEASE_BRANCH}`]);
   if (local !== remote) {
-    fail(`${RELEASE_BRANCH} must match origin/${RELEASE_BRANCH}; run git pull --ff-only first`);
+    fail(
+      `${RELEASE_BRANCH} must match ${RELEASE_REMOTE}/${RELEASE_BRANCH}; run git pull --ff-only first`,
+    );
   }
 
   if (commandSucceeds("git", ["rev-parse", "--verify", "--quiet", tag])) {
     fail(`tag already exists locally: ${tag}`);
   }
-  if (commandSucceeds("git", ["ls-remote", "--exit-code", "--tags", "origin", tag])) {
-    fail(`tag already exists on origin: ${tag}`);
+  if (
+    commandSucceeds("git", ["ls-remote", "--exit-code", "--tags", RELEASE_REMOTE, tag])
+  ) {
+    fail(`tag already exists on ${RELEASE_REMOTE}: ${tag}`);
+  }
+  if (commandSucceeds("gh", withReleaseRepository(["release", "view", tag]))) {
+    fail(`GitHub release already exists in ${RELEASE_REPOSITORY}: ${tag}`);
   }
 }
 
@@ -147,14 +192,24 @@ try {
   run("git", ["add", "CHANGELOG.md"]);
   run("git", ["commit", "-m", `Release ${tag}`]);
   run("git", ["tag", tag]);
-  run("git", ["push", "--atomic", "origin", RELEASE_BRANCH, tag]);
+  run("git", ["push", "--atomic", RELEASE_REMOTE, RELEASE_BRANCH, tag]);
 
-  run("gh", ["release", "create", tag, "--notes-file", notesFile]);
+  run(
+    "gh",
+    withReleaseRepository([
+      "release",
+      "create",
+      tag,
+      "--verify-tag",
+      "--notes-file",
+      notesFile,
+    ]),
+  );
 
   openNextUnreleased(released);
   run("git", ["add", "CHANGELOG.md"]);
   run("git", ["commit", "-m", "Prepare for next release"]);
-  run("git", ["push", "origin", RELEASE_BRANCH]);
+  run("git", ["push", RELEASE_REMOTE, RELEASE_BRANCH]);
 } finally {
   rmSync(notesFile, { force: true });
 }


### PR DESCRIPTION
## Summary

- fail closed unless both origin fetch/push URLs resolve to IvoryHeart/herdr-world
- verify GitHub CLI access before any release mutation and pass the repository explicitly
- document explicit repository arguments for manual artifact uploads
- add regression coverage for the upstream-remote accident

## Validation

- npm run check
- disposable wrong-origin release rehearsal
- git diff --check