### PR TITLE
feat: guide Herdr installation and startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 
 ### Changed
 
+- Made the desktop launcher detect a missing default Herdr session and offer an explicit,
+  consent-based path to install Herdr from its official installer and start it in a user-selected
+  workspace. Non-interactive, custom-session, and custom-socket launches remain fail-safe.
 - Added a direct, checksum-verified Linux release quick start, an explicit public-platform matrix,
   a minimalist Pixel Office-themed GitHub Pages site, and launch-ready social artwork for the
   Herdr World public preview.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Made the desktop launcher detect a missing default Herdr session and offer an explicit,
   consent-based path to install Herdr from its official installer and start it in a user-selected
   workspace. Non-interactive, custom-session, and custom-socket launches remain fail-safe.
+  [Herdr World PR #14](https://github.com/IvoryHeart/herdr-world/pull/14)
 - Added a direct, checksum-verified Linux release quick start, an explicit public-platform matrix,
   a minimalist Pixel Office-themed GitHub Pages site, and launch-ready social artwork for the
   Herdr World public preview.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ navigation, multi-client viewing, mobile input controls, synchronized pane selec
 visualizations. The upstream relationship and synchronization record are documented in
 [`UPSTREAM.md`](UPSTREAM.md).
 
-> **Public preview:** [`v0.1.0-rc.1`](https://github.com/IvoryHeart/herdr-world/releases/tag/v0.1.0-rc.1)
+> **Public preview:** [`v0.1.0-rc.2`](https://github.com/IvoryHeart/herdr-world/releases/tag/v0.1.0-rc.2)
 > is available for Linux x86-64. Herdr World currently requires Herdr `v0.8.2` or newer reporting
 > terminal protocol `20`.
 
@@ -110,7 +110,7 @@ Android development also needs a JDK and Android SDK. See [docs/android.md](docs
 
 | Platform | Status |
 | --- | --- |
-| Linux x86-64 | Available in [`v0.1.0-rc.1`](https://github.com/IvoryHeart/herdr-world/releases/tag/v0.1.0-rc.1) |
+| Linux x86-64 | Available in [`v0.1.0-rc.2`](https://github.com/IvoryHeart/herdr-world/releases/tag/v0.1.0-rc.2) |
 | macOS ARM64 / x86-64 | Packaging is supported; public binaries are not published yet |
 | Android | Source and debug build workflow are available; no signed public APK yet |
 
@@ -119,7 +119,7 @@ Android development also needs a JDK and Android SDK. See [docs/android.md](docs
 Download and verify the current Linux release candidate:
 
 ```bash
-VERSION=v0.1.0-rc.1
+VERSION=v0.1.0-rc.2
 curl -fLO "https://github.com/IvoryHeart/herdr-world/releases/download/${VERSION}/herdr-world-${VERSION}-linux-x86_64.tar.gz"
 curl -fLO "https://github.com/IvoryHeart/herdr-world/releases/download/${VERSION}/herdr-world-${VERSION}-linux-x86_64.tar.gz.sha256"
 sha256sum --check "herdr-world-${VERSION}-linux-x86_64.tar.gz.sha256"

--- a/README.md
+++ b/README.md
@@ -116,13 +116,7 @@ Android development also needs a JDK and Android SDK. See [docs/android.md](docs
 
 ## Quick Start From Release
 
-Start or attach Herdr first:
-
-```bash
-herdr
-```
-
-In another terminal, download and verify the current Linux release candidate:
+Download and verify the current Linux release candidate:
 
 ```bash
 VERSION=v0.1.0-rc.1
@@ -141,8 +135,17 @@ http://127.0.0.1:8787
 ```
 
 The desktop tarball includes the web assets and `herdr-world-bridge`; it does not include Herdr.
-Start or attach Herdr `v0.8.2` or newer with terminal protocol `20` separately before running the
-bridge.
+If the default Herdr session is not running, an interactive `bin/herdr-world` launch explains the
+requirement and asks separately before downloading the [official Herdr
+installer](https://herdr.dev/docs/install/) or starting Herdr. Before starting Herdr, it asks for
+the directory containing the work you want Herdr to manage. Declining either action leaves the
+system unchanged and prints manual instructions.
+
+The launcher never performs guided setup in a non-interactive environment or when `--session`,
+`HERDR_SESSION`, or a socket override selects an operator-managed target. Pass
+`--no-herdr-setup` or set `HERDR_WORLD_SETUP=never` to disable prompts explicitly. You can always
+start Herdr yourself from a project directory, detach with <kbd>Ctrl</kbd>+<kbd>B</kbd> then
+<kbd>Q</kbd>, and rerun Herdr World.
 
 Use another unused port when needed:
 

--- a/bridge/src/web_bridge.rs
+++ b/bridge/src/web_bridge.rs
@@ -4719,7 +4719,7 @@ fn startup_daemon_error(err: BridgeError) -> io::Error {
     io::Error::new(
         ErrorKind::ConnectionRefused,
         format!(
-            "unable to start Herdr World bridge: {err}. Start or update Herdr, then restart herdr-world-bridge."
+            "unable to start Herdr World bridge: {err}. Install, update, or start Herdr v0.8.2 or newer, then retry. Packaged users can run bin/herdr-world for consent-based setup; custom sessions must use --session NAME or HERDR_SOCKET_PATH."
         ),
     )
 }
@@ -7024,8 +7024,9 @@ mod tests {
         let message = io_err.to_string();
         assert!(message.contains("unable to start Herdr World bridge"));
         assert!(message.contains("unexpected api result"));
-        assert!(message.contains("Start or update Herdr"));
-        assert!(message.contains("restart herdr-world-bridge"));
+        assert!(message.contains("Install, update, or start Herdr v0.8.2 or newer"));
+        assert!(message.contains("consent-based setup"));
+        assert!(message.contains("--session NAME or HERDR_SOCKET_PATH"));
     }
 
     #[test]

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -2,9 +2,9 @@
 
 `herdr-world` ships as separate desktop bridge/web tarballs and an Android APK.
 
-The desktop tarball does not include Herdr itself. Users still need a running Herdr `v0.8.2` or
-newer session or daemon that reports terminal protocol `20`; the bundled bridge connects to the
-normal Herdr socket.
+The desktop tarball does not include Herdr itself. Users still need Herdr `v0.8.2` or newer with
+terminal protocol `20`; the packaged launcher can guide an interactive user through consent-based
+installation and startup of the default local session.
 
 ## Release Artifacts
 
@@ -43,8 +43,11 @@ herdr-world-vX.Y.Z-PLATFORM/
   README.md
 ```
 
-`bin/herdr-world` is a small wrapper that runs `herdr-world-bridge` with `--static-dir` pointed at the
-bundled web assets.
+`bin/herdr-world` points `herdr-world-bridge` at the bundled web assets. When the default Herdr
+socket is absent, it can run Herdr's official installer and start Herdr only after separate explicit
+consent. It asks for a Herdr workspace directory rather than using the unpacked bundle by accident.
+It fails with manual instructions instead of prompting in automation, and it leaves explicit
+session and socket targets under operator control.
 
 ## Build A Desktop Tarball
 
@@ -146,18 +149,19 @@ dist-packages/herdr-world-vX.Y.Z-android.apk
 
 ## User Quick Start From Tarball
 
-Start or attach Herdr `v0.8.2` or newer with terminal protocol `20` first:
-
-```bash
-herdr
-```
-
-Unpack and run:
+Unpack and run. If necessary, the interactive launcher offers consent-based Herdr installation and
+startup:
 
 ```bash
 tar -xzf herdr-world-vX.Y.Z-linux-x86_64.tar.gz
 cd herdr-world-vX.Y.Z-linux-x86_64
 bin/herdr-world
+```
+
+To manage Herdr yourself or run from automation, start Herdr first and disable launcher prompts:
+
+```bash
+HERDR_WORLD_SETUP=never bin/herdr-world
 ```
 
 Open:

--- a/docs/release.md
+++ b/docs/release.md
@@ -87,6 +87,12 @@ licence inventories, World asset record, and Herdr vendor manifest are present.
 For APKs, inspect the package listing or metadata and verify the bundled
 `public/legal/manifest.json` and every file it names.
 
+For the desktop launcher, verify `bin/herdr-world --help` never starts onboarding, a
+non-interactive launch with no default Herdr socket fails with manual instructions, and an
+interactive missing-session launch asks independently before installation and startup. Do not
+exercise the live installer during release verification; the launcher tests replace its network and
+process boundaries with deterministic fakes.
+
 To stage the current debug APK under the release asset name for private testing:
 
 ```bash

--- a/docs/tarball-readme.md
+++ b/docs/tarball-readme.md
@@ -5,8 +5,8 @@ The bundle's root `LICENSE`, `THIRD_PARTY_NOTICES.md`, `UPSTREAM.md`, and files 
 `third_party/licenses/` and `third_party/dependencies/` describe the retained
 upstream, asset, npm, and Cargo terms.
 
-It does not include Herdr itself. Start or attach a Herdr `v0.8.2` or newer session that reports
-terminal protocol `20` separately before running this bundle.
+It does not include Herdr itself. Herdr World requires Herdr `v0.8.2` or newer with terminal
+protocol `20`.
 
 ## Run
 
@@ -15,6 +15,17 @@ From the unpacked bundle directory:
 ```bash
 bin/herdr-world
 ```
+
+If the default Herdr session is not running, an interactive launch offers to download and run the
+[official Herdr installer](https://herdr.dev/docs/install/), then separately offers to start Herdr
+in a directory you select. Nothing is installed or started without an affirmative answer. Starting
+Herdr opens its terminal UI; detach with <kbd>Ctrl</kbd>+<kbd>B</kbd> then <kbd>Q</kbd> so this
+launcher can continue.
+
+Guided setup is disabled for non-interactive launches, explicit `--session`/`HERDR_SESSION` targets,
+and socket overrides. Use `--no-herdr-setup` or `HERDR_WORLD_SETUP=never` to disable it for a
+default interactive launch as well. In all of those cases, install/start Herdr separately and rerun
+the bundle.
 
 Open:
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "notices:generate": "node scripts/dependency-notices.mjs --generate",
     "notices:check": "node scripts/dependency-notices.mjs --check",
     "test:dev": "node --test scripts/dev.test.mjs",
-    "test:release": "node --test scripts/release-target.test.mjs",
+    "test:release": "node --test scripts/release-target.test.mjs scripts/herdr-world-launcher.test.mjs",
     "test:pages": "node --test scripts/pages.test.mjs",
     "test:web": "npm run test --prefix web",
     "test:observability": "npm run test --prefix web -- observability.test.ts && cargo test --manifest-path bridge/Cargo.toml --bin herdr-web-bridge observability",

--- a/scripts/herdr-world-launcher.sh
+++ b/scripts/herdr-world-launcher.sh
@@ -1,0 +1,275 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BIN_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BUNDLE_ROOT="$(cd "$BIN_DIR/.." && pwd)"
+BRIDGE_BIN="$BIN_DIR/herdr-world-bridge"
+STATIC_DIR="$BUNDLE_ROOT/share/herdr-world/web"
+
+HERDR_INSTALLER_URL="https://herdr.dev/install.sh"
+HERDR_INSTALL_DOCS_URL="https://herdr.dev/docs/install/"
+HERDR_MINIMUM_VERSION="v0.8.2"
+HERDR_TERMINAL_PROTOCOL="20"
+
+herdr_world_default_socket() {
+  local config_home="${XDG_CONFIG_HOME:-}"
+  if [[ -z "$config_home" ]]; then
+    [[ -n "${HOME:-}" ]] || return 1
+    config_home="$HOME/.config"
+  fi
+  printf '%s/herdr/herdr.sock\n' "$config_home"
+}
+
+herdr_world_socket_ready() {
+  [[ -S "$1" ]]
+}
+
+herdr_world_find_binary() {
+  local found=""
+  if found="$(command -v herdr 2>/dev/null)" && [[ -n "$found" ]]; then
+    printf '%s\n' "$found"
+    return 0
+  fi
+
+  if [[ -n "${HERDR_INSTALL_DIR:-}" && -x "$HERDR_INSTALL_DIR/herdr" ]]; then
+    printf '%s/herdr\n' "$HERDR_INSTALL_DIR"
+    return 0
+  fi
+
+  if [[ -n "${HOME:-}" && -x "$HOME/.local/bin/herdr" ]]; then
+    printf '%s/.local/bin/herdr\n' "$HOME"
+    return 0
+  fi
+
+  return 1
+}
+
+herdr_world_is_interactive() {
+  [[ -t 0 && -t 2 ]]
+}
+
+herdr_world_confirm() {
+  local prompt="$1"
+  local answer=""
+  printf '%s [y/N] ' "$prompt" >&2
+  IFS= read -r answer || return 1
+  case "$answer" in
+    y | Y | yes | YES | Yes) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+herdr_world_manual_instructions() {
+  cat >&2 <<EOF
+Herdr World needs a running Herdr ${HERDR_MINIMUM_VERSION} or newer session using terminal protocol ${HERDR_TERMINAL_PROTOCOL}.
+
+Install Herdr using the official instructions:
+  ${HERDR_INSTALL_DOCS_URL}
+
+Then start it from the directory containing the work you want Herdr to manage:
+  cd /path/to/your/project
+  herdr
+
+Detach from Herdr with Ctrl+B, then Q, and run bin/herdr-world again.
+EOF
+}
+
+herdr_world_install() {
+  if ! command -v curl >/dev/null 2>&1; then
+    echo "Cannot install Herdr automatically because curl is not available." >&2
+    return 1
+  fi
+
+  local installer_dir=""
+  local installer_path=""
+  installer_dir="$(mktemp -d "${TMPDIR:-/tmp}/herdr-world-install.XXXXXX")"
+  installer_path="$installer_dir/install.sh"
+
+  if ! curl --proto '=https' --tlsv1.2 -fsSL "$HERDR_INSTALLER_URL" -o "$installer_path"; then
+    rm -rf -- "$installer_dir"
+    echo "Could not download the official Herdr installer." >&2
+    return 1
+  fi
+
+  if ! sh "$installer_path"; then
+    rm -rf -- "$installer_dir"
+    echo "The Herdr installer did not complete successfully." >&2
+    return 1
+  fi
+
+  rm -rf -- "$installer_dir"
+}
+
+herdr_world_choose_workspace() {
+  local default_dir="$PWD"
+  local answer=""
+  local resolved=""
+
+  case "$PWD/" in
+    "$BUNDLE_ROOT/"*)
+      default_dir=""
+      echo "Choose a project directory; the unpacked Herdr World bundle should not become your Herdr workspace." >&2
+      ;;
+  esac
+
+  while true; do
+    if [[ -n "$default_dir" ]]; then
+      printf 'Directory containing the work Herdr should manage [%s]: ' "$default_dir" >&2
+    else
+      printf 'Directory containing the work Herdr should manage: ' >&2
+    fi
+    IFS= read -r answer || return 1
+    answer="${answer:-$default_dir}"
+
+    if [[ "$answer" == "~/"* && -n "${HOME:-}" ]]; then
+      answer="$HOME/${answer#\~/}"
+    fi
+    if [[ -z "$answer" || ! -d "$answer" ]]; then
+      echo "Enter an existing directory." >&2
+      continue
+    fi
+
+    resolved="$(cd "$answer" && pwd -P)"
+    printf '%s\n' "$resolved"
+    return 0
+  done
+}
+
+herdr_world_run_herdr() {
+  local herdr_bin="$1"
+  local workspace="$2"
+  (
+    cd "$workspace"
+    "$herdr_bin"
+  )
+}
+
+herdr_world_wait_for_socket() {
+  local socket_path="$1"
+  local attempt
+  for attempt in {1..50}; do
+    if herdr_world_socket_ready "$socket_path"; then
+      return 0
+    fi
+    sleep 0.1
+  done
+  return 1
+}
+
+herdr_world_exec_bridge() {
+  exec "$BRIDGE_BIN" --static-dir "$STATIC_DIR" "$@"
+}
+
+herdr_world_main() {
+  local -a bridge_args=()
+  local setup_enabled=true
+  local arg
+  local default_socket=""
+  local herdr_bin=""
+  local workspace=""
+
+  for arg in "$@"; do
+    if [[ "$arg" == "--no-herdr-setup" ]]; then
+      setup_enabled=false
+    else
+      bridge_args+=("$arg")
+    fi
+  done
+
+  for arg in "${bridge_args[@]}"; do
+    case "$arg" in
+      -h | --help)
+        herdr_world_exec_bridge "${bridge_args[@]}"
+        return
+        ;;
+    esac
+  done
+
+  # Explicit sessions and socket paths are operator-managed. The launcher must
+  # not create or start a different default session in response to their state.
+  for arg in "${bridge_args[@]}"; do
+    case "$arg" in
+      --session | --session=*)
+        herdr_world_exec_bridge "${bridge_args[@]}"
+        return
+        ;;
+    esac
+  done
+  if [[ -n "${HERDR_SOCKET_PATH:-}" || -n "${HERDR_CLIENT_SOCKET_PATH:-}" || -n "${HERDR_SESSION:-}" ]]; then
+    herdr_world_exec_bridge "${bridge_args[@]}"
+    return
+  fi
+
+  if ! default_socket="$(herdr_world_default_socket)"; then
+    echo "Herdr World could not determine the default Herdr socket because HOME and XDG_CONFIG_HOME are unset." >&2
+    herdr_world_manual_instructions
+    return 1
+  fi
+  if herdr_world_socket_ready "$default_socket"; then
+    herdr_world_exec_bridge "${bridge_args[@]}"
+    return
+  fi
+
+  case "${HERDR_WORLD_SETUP:-auto}" in
+    never | off | 0) setup_enabled=false ;;
+  esac
+  if [[ "$setup_enabled" != true ]] || ! herdr_world_is_interactive; then
+    echo "No running default Herdr session was found at $default_socket." >&2
+    herdr_world_manual_instructions
+    return 1
+  fi
+
+  if ! herdr_bin="$(herdr_world_find_binary)"; then
+    cat >&2 <<EOF
+Herdr is not installed or is not available on PATH.
+
+Herdr World can download ${HERDR_INSTALLER_URL} over HTTPS and run it locally.
+The official installer installs the latest stable Herdr (normally under ~/.local/bin)
+and verifies the downloaded Herdr binary checksum. It does not install Herdr World.
+EOF
+    if ! herdr_world_confirm "Download and run the official Herdr installer now?"; then
+      herdr_world_manual_instructions
+      return 1
+    fi
+    if ! herdr_world_install; then
+      herdr_world_manual_instructions
+      return 1
+    fi
+    if ! herdr_bin="$(herdr_world_find_binary)"; then
+      echo "Herdr was installed, but its executable could not be found." >&2
+      herdr_world_manual_instructions
+      return 1
+    fi
+  fi
+
+  cat >&2 <<EOF
+
+Herdr is available at: $herdr_bin
+Starting it opens the Herdr terminal UI. Detach with Ctrl+B, then Q; the Herdr
+server remains active and this launcher will then continue with Herdr World.
+EOF
+  if ! herdr_world_confirm "Start Herdr now?"; then
+    herdr_world_manual_instructions
+    return 1
+  fi
+  if ! workspace="$(herdr_world_choose_workspace)"; then
+    echo "Herdr was not started because no workspace directory was selected." >&2
+    return 1
+  fi
+  if ! herdr_world_run_herdr "$herdr_bin" "$workspace"; then
+    echo "Herdr exited with an error; Herdr World was not started." >&2
+    return 1
+  fi
+  if ! herdr_world_wait_for_socket "$default_socket"; then
+    echo "Herdr returned, but no running session appeared at $default_socket." >&2
+    herdr_world_manual_instructions
+    return 1
+  fi
+
+  echo "Herdr is running; starting Herdr World at http://127.0.0.1:8787." >&2
+  herdr_world_exec_bridge "${bridge_args[@]}"
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  herdr_world_main "$@"
+fi

--- a/scripts/herdr-world-launcher.test.mjs
+++ b/scripts/herdr-world-launcher.test.mjs
@@ -1,0 +1,176 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const launcher = resolve(root, "scripts/herdr-world-launcher.sh");
+
+function runLauncher(body, input = "") {
+  const result = spawnSync(
+    "bash",
+    [
+      "-c",
+      `source "$HERDR_WORLD_LAUNCHER_TEST_PATH"\n${body}`,
+    ],
+    {
+      cwd: root,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        HERDR_WORLD_LAUNCHER_TEST_PATH: launcher,
+        HERDR_CLIENT_SOCKET_PATH: "",
+        HERDR_SESSION: "",
+        HERDR_SOCKET_PATH: "",
+        HERDR_WORLD_SETUP: "auto",
+      },
+      input,
+    },
+  );
+  return {
+    status: result.status,
+    stdout: result.stdout,
+    stderr: result.stderr,
+  };
+}
+
+test("an available default session starts the packaged bridge directly", () => {
+  const result = runLauncher(`
+herdr_world_default_socket() { printf '/tmp/herdr.sock\\n'; }
+herdr_world_socket_ready() { return 0; }
+herdr_world_exec_bridge() { printf 'bridge'; printf ' <%s>' "$@"; printf '\\n'; }
+herdr_world_main --port 8791
+`);
+
+  assert.equal(result.status, 0);
+  assert.equal(result.stdout, "bridge <--port> <8791>\n");
+  assert.equal(result.stderr, "");
+});
+
+test("help and explicit connection targets never trigger guided setup", () => {
+  for (const args of ["--help", "--session work --port 8791"]) {
+    const result = runLauncher(`
+herdr_world_default_socket() { echo 'unexpected socket lookup' >&2; return 1; }
+herdr_world_exec_bridge() { printf 'bridge'; printf ' <%s>' "$@"; printf '\\n'; }
+herdr_world_main ${args}
+`);
+    assert.equal(result.status, 0);
+    assert.match(result.stdout, /^bridge /);
+    assert.doesNotMatch(result.stderr, /unexpected socket lookup/);
+  }
+
+  const customSocket = runLauncher(`
+export HERDR_SOCKET_PATH=/tmp/custom-herdr.sock
+herdr_world_default_socket() { echo 'unexpected socket lookup' >&2; return 1; }
+herdr_world_exec_bridge() { printf 'bridge'; printf ' <%s>' "$@"; printf '\\n'; }
+herdr_world_main --port 8792
+`);
+  assert.equal(customSocket.status, 0);
+  assert.equal(customSocket.stdout, "bridge <--port> <8792>\n");
+  assert.doesNotMatch(customSocket.stderr, /unexpected socket lookup/);
+
+  const namedSession = runLauncher(`
+export HERDR_SESSION=work
+herdr_world_default_socket() { echo 'unexpected socket lookup' >&2; return 1; }
+herdr_world_exec_bridge() { printf 'bridge'; printf ' <%s>' "$@"; printf '\\n'; }
+herdr_world_main --port 8794
+`);
+  assert.equal(namedSession.status, 0);
+  assert.equal(namedSession.stdout, "bridge <--port> <8794>\n");
+  assert.doesNotMatch(namedSession.stderr, /unexpected socket lookup/);
+});
+
+test("a non-interactive launch fails safely with actionable instructions", () => {
+  const result = runLauncher(`
+herdr_world_default_socket() { printf '/tmp/missing-herdr.sock\\n'; }
+herdr_world_socket_ready() { return 1; }
+herdr_world_is_interactive() { return 1; }
+herdr_world_exec_bridge() { echo 'unexpected bridge start'; }
+herdr_world_main
+`);
+
+  assert.equal(result.status, 1);
+  assert.equal(result.stdout, "");
+  assert.match(result.stderr, /No running default Herdr session/);
+  assert.match(result.stderr, /https:\/\/herdr\.dev\/docs\/install\//);
+  assert.match(result.stderr, /cd \/path\/to\/your\/project/);
+  assert.doesNotMatch(result.stderr, /unexpected bridge start/);
+});
+
+test("installation and startup each require affirmative consent", () => {
+  const declinedInstall = runLauncher(
+    `
+herdr_world_default_socket() { printf '/tmp/missing-herdr.sock\\n'; }
+herdr_world_socket_ready() { return 1; }
+herdr_world_is_interactive() { return 0; }
+herdr_world_find_binary() { return 1; }
+herdr_world_install() { echo 'unexpected install' >&2; }
+herdr_world_main
+`,
+    "n\n",
+  );
+  assert.equal(declinedInstall.status, 1);
+  assert.match(declinedInstall.stderr, /Download and run the official Herdr installer now\?/);
+  assert.doesNotMatch(declinedInstall.stderr, /unexpected install/);
+
+  const declinedStart = runLauncher(
+    `
+herdr_world_default_socket() { printf '/tmp/missing-herdr.sock\\n'; }
+herdr_world_socket_ready() { return 1; }
+herdr_world_is_interactive() { return 0; }
+herdr_world_find_binary() { printf '/fake/herdr\\n'; }
+herdr_world_run_herdr() { echo 'unexpected Herdr start' >&2; }
+herdr_world_main
+`,
+    "n\n",
+  );
+  assert.equal(declinedStart.status, 1);
+  assert.match(declinedStart.stderr, /Start Herdr now\?/);
+  assert.doesNotMatch(declinedStart.stderr, /unexpected Herdr start/);
+});
+
+test("consented installation and startup continue to the bridge", () => {
+  const result = runLauncher(
+    `
+installed=0
+socket_ready=0
+herdr_world_default_socket() { printf '/tmp/herdr.sock\\n'; }
+herdr_world_socket_ready() { [[ "$socket_ready" == 1 ]]; }
+herdr_world_is_interactive() { return 0; }
+herdr_world_find_binary() {
+  [[ "$installed" == 1 ]] || return 1
+  printf '/fake/herdr\\n'
+}
+herdr_world_install() { installed=1; echo 'installed' >&2; }
+herdr_world_choose_workspace() { printf '/tmp/project\\n'; }
+herdr_world_run_herdr() {
+  printf 'started <%s> in <%s>\\n' "$1" "$2" >&2
+  socket_ready=1
+}
+herdr_world_exec_bridge() { printf 'bridge'; printf ' <%s>' "$@"; printf '\\n'; }
+herdr_world_main --port 8793
+`,
+    "y\ny\n",
+  );
+
+  assert.equal(result.status, 0);
+  assert.equal(result.stdout, "bridge <--port> <8793>\n");
+  assert.match(result.stderr, /installed/);
+  assert.match(result.stderr, /started <\/fake\/herdr> in <\/tmp\/project>/);
+  assert.match(result.stderr, /Herdr is running; starting Herdr World/);
+});
+
+test("the launcher refuses to default Herdr's workspace to its own bundle", () => {
+  const result = runLauncher(
+    `
+BUNDLE_ROOT="$PWD"
+herdr_world_choose_workspace
+`,
+    "/tmp\n",
+  );
+
+  assert.equal(result.status, 0);
+  assert.equal(result.stdout, "/tmp\n");
+  assert.match(result.stderr, /bundle should not become your Herdr workspace/);
+});

--- a/scripts/package-tarball.sh
+++ b/scripts/package-tarball.sh
@@ -70,16 +70,7 @@ cp "$ROOT/UPSTREAM.md" "$STAGE/UPSTREAM.md"
 cp -R "$ROOT/third_party/." "$STAGE/third_party/"
 cp "$ROOT/docs/world-assets.md" "$STAGE/docs/world-assets.md"
 cp "$ROOT/vendor/herdr-compat/VENDOR-MANIFEST.toml" "$STAGE/vendor/herdr-compat/VENDOR-MANIFEST.toml"
-
-cat > "$STAGE/bin/herdr-world" <<'WRAPPER'
-#!/usr/bin/env bash
-set -euo pipefail
-
-BIN_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-ROOT="$(cd "$BIN_DIR/.." && pwd)"
-
-exec "$BIN_DIR/herdr-world-bridge" --static-dir "$ROOT/share/herdr-world/web" "$@"
-WRAPPER
+cp "$ROOT/scripts/herdr-world-launcher.sh" "$STAGE/bin/herdr-world"
 chmod +x "$STAGE/bin/herdr-world" "$STAGE/bin/herdr-world-bridge"
 
 (

--- a/scripts/pages.test.mjs
+++ b/scripts/pages.test.mjs
@@ -36,7 +36,7 @@ test("the Pages artifact is self-contained and release-accurate", () => {
   const html = readFileSync(join(output, "index.html"), "utf8");
   assert.match(html, /<main id="main">/);
   assert.match(html, /class="skip-link"/);
-  assert.match(html, /v0\.1\.0-rc\.1/);
+  assert.match(html, /v0\.1\.0-rc\.2/);
   assert.match(html, /control surface for your agents/i);
   assert.doesNotMatch(html, /control surface for Herdr agents/i);
   assert.match(html, /Protocol[\s\S]{0,80}<dd>20<\/dd>/i);

--- a/site/index.html
+++ b/site/index.html
@@ -44,7 +44,7 @@
           <h1 id="hero-title">Your agents.<br /><em>One office.</em></h1>
           <p class="hero-intro">Herdr World turns live Herdr sessions into one visual workspace: terminal-first Spaces, a multi-host Pixel Office, and the controls to move between them without losing context.</p>
           <div class="hero-actions">
-            <a class="button button-primary" href="https://github.com/IvoryHeart/herdr-world/releases/tag/v0.1.0-rc.1">Download the RC <span aria-hidden="true">↓</span></a>
+            <a class="button button-primary" href="https://github.com/IvoryHeart/herdr-world/releases/tag/v0.1.0-rc.2">Download the RC <span aria-hidden="true">↓</span></a>
             <a class="button button-secondary" href="#install">View install</a>
           </div>
           <dl class="hero-facts">
@@ -124,7 +124,7 @@
         <div class="install-heading">
           <p class="eyebrow">Linux x86-64 public preview</p>
           <h2 id="install-title">From archive<br />to office.</h2>
-          <p>Herdr stays independent. Start Herdr, download this seven-megabyte bundle, verify it, and run the included bridge and web app.</p>
+          <p>Herdr stays independent. Download this seven-megabyte bundle, verify it, and run the included bridge and web app. If Herdr is not ready, the launcher offers a consent-based setup.</p>
           <a href="https://github.com/IvoryHeart/herdr-world#requirements">Read requirements ↗</a>
         </div>
 
@@ -133,10 +133,7 @@
             <span class="terminal-title">HERDR WORLD / INSTALL</span>
             <button class="copy-button" type="button" data-copy-install><span data-copy-label>Copy</span><span aria-hidden="true">⧉</span></button>
           </div>
-          <pre tabindex="0" aria-label="Herdr World installation commands"><code data-install-command><span class="prompt">$</span> <span class="command">herdr</span>
-
-<span class="comment"># In another terminal</span>
-<span class="prompt">$</span> VERSION=v0.1.0-rc.1
+          <pre tabindex="0" aria-label="Herdr World installation commands"><code data-install-command><span class="prompt">$</span> VERSION=v0.1.0-rc.2
 <span class="prompt">$</span> curl -fLO "https://github.com/IvoryHeart/herdr-world/releases/download/${VERSION}/herdr-world-${VERSION}-linux-x86_64.tar.gz"
 <span class="prompt">$</span> curl -fLO "https://github.com/IvoryHeart/herdr-world/releases/download/${VERSION}/herdr-world-${VERSION}-linux-x86_64.tar.gz.sha256"
 <span class="prompt">$</span> sha256sum --check "herdr-world-${VERSION}-linux-x86_64.tar.gz.sha256"
@@ -163,7 +160,7 @@
         <p class="eyebrow">The office is open</p>
         <h2 id="cta-title">Bring your agents<br /><em>into the room.</em></h2>
         <div class="hero-actions">
-          <a class="button button-primary" href="https://github.com/IvoryHeart/herdr-world/releases/tag/v0.1.0-rc.1">Download v0.1.0-rc.1</a>
+          <a class="button button-primary" href="https://github.com/IvoryHeart/herdr-world/releases/tag/v0.1.0-rc.2">Download v0.1.0-rc.2</a>
           <a class="button button-secondary" href="https://github.com/IvoryHeart/herdr-world/discussions">Join the discussion</a>
         </div>
       </section>

--- a/site/site.js
+++ b/site/site.js
@@ -1,7 +1,4 @@
-const installCommand = `herdr
-
-# In another terminal
-VERSION=v0.1.0-rc.1
+const installCommand = `VERSION=v0.1.0-rc.2
 curl -fLO "https://github.com/IvoryHeart/herdr-world/releases/download/\${VERSION}/herdr-world-\${VERSION}-linux-x86_64.tar.gz"
 curl -fLO "https://github.com/IvoryHeart/herdr-world/releases/download/\${VERSION}/herdr-world-\${VERSION}-linux-x86_64.tar.gz.sha256"
 sha256sum --check "herdr-world-\${VERSION}-linux-x86_64.tar.gz.sha256"


### PR DESCRIPTION
## Outcome

The packaged `bin/herdr-world` launcher now detects a missing default Herdr session and offers an explicit, consent-based setup path. Installation downloads the official Herdr installer to a temporary file over HTTPS and runs it only after approval; startup requires separate approval and a user-selected workspace directory.

Custom sessions/socket targets and non-interactive launches remain operator-managed and fail safely with manual instructions. `--help` never triggers onboarding, and setup can be disabled with `--no-herdr-setup` or `HERDR_WORLD_SETUP=never`. The advanced bridge error is also actionable when invoked directly.

## Validation

- `npm run check`
- Launcher tests: 6/6
- Web tests: 439/439
- Herdr compatibility tests: 116/116
- Bridge tests: 162/162
- Real Linux tarball build and packaged wrapper smoke
- `git diff --check`

The existing service on port 8787 was not changed.