### PR TITLE
fix: mark release candidates as prereleases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - Made the release helper mark SemVer prerelease tags such as `v0.1.0-rc.2` as GitHub
   prereleases automatically while leaving stable versions unchanged.
+  [Herdr World PR #15](https://github.com/IvoryHeart/herdr-world/pull/15)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
 
 ### Fixed
 
+- Made the release helper mark SemVer prerelease tags such as `v0.1.0-rc.2` as GitHub
+  prereleases automatically while leaving stable versions unchanged.
+
 ### Removed
 
 ## [0.1.0-rc.2] - 2026-08-26

--- a/scripts/release-target.mjs
+++ b/scripts/release-target.mjs
@@ -40,3 +40,11 @@ export function assertReleaseRemoteUrls(remoteUrls, direction) {
 export function withReleaseRepository(args) {
   return [...args, "--repo", RELEASE_REPOSITORY];
 }
+
+export function releaseCreateArgs(tag, notesFile) {
+  const args = ["release", "create", tag, "--verify-tag", "--notes-file", notesFile];
+  if (tag.includes("-")) {
+    args.push("--prerelease");
+  }
+  return withReleaseRepository(args);
+}

--- a/scripts/release-target.test.mjs
+++ b/scripts/release-target.test.mjs
@@ -5,6 +5,7 @@ import {
   RELEASE_REPOSITORY,
   assertReleaseRemoteUrls,
   githubRepositoryFromRemoteUrl,
+  releaseCreateArgs,
   withReleaseRepository,
 } from "./release-target.mjs";
 
@@ -62,6 +63,33 @@ test("adds an explicit repository to GitHub CLI release commands", () => {
     "release",
     "view",
     "v1.2.3",
+    "--repo",
+    "IvoryHeart/herdr-world",
+  ]);
+});
+
+test("marks release-candidate GitHub releases as prereleases", () => {
+  assert.deepEqual(releaseCreateArgs("v0.1.0-rc.3", "notes.md"), [
+    "release",
+    "create",
+    "v0.1.0-rc.3",
+    "--verify-tag",
+    "--notes-file",
+    "notes.md",
+    "--prerelease",
+    "--repo",
+    "IvoryHeart/herdr-world",
+  ]);
+});
+
+test("leaves stable GitHub releases stable", () => {
+  assert.deepEqual(releaseCreateArgs("v0.1.0", "notes.md"), [
+    "release",
+    "create",
+    "v0.1.0",
+    "--verify-tag",
+    "--notes-file",
+    "notes.md",
     "--repo",
     "IvoryHeart/herdr-world",
   ]);

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -7,6 +7,7 @@ import {
   RELEASE_REMOTE,
   RELEASE_REPOSITORY,
   assertReleaseRemoteUrls,
+  releaseCreateArgs,
   withReleaseRepository,
 } from "./release-target.mjs";
 
@@ -196,14 +197,7 @@ try {
 
   run(
     "gh",
-    withReleaseRepository([
-      "release",
-      "create",
-      tag,
-      "--verify-tag",
-      "--notes-file",
-      notesFile,
-    ]),
+    releaseCreateArgs(tag, notesFile),
   );
 
   openNextUnreleased(released);


### PR DESCRIPTION
## Outcome

Release tags with a SemVer prerelease suffix now pass `--prerelease` to `gh release create`; stable tags do not. This prevents future RCs from briefly appearing as stable GitHub releases.

## Validation

- `npm run test:release` — 12/12
- `npm run check`
- `git diff --check`

No release, tag, service, or artifact was created or changed.