### PR TITLE
fix: verify Mach-O release assets across hosts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 ### Fixed
 
+- Made release aggregation accept the equivalent macOS Mach-O architecture descriptions emitted
+  by macOS and Linux `file`, while still requiring the expected executable format and CPU.
+  [Herdr World PR #17](https://github.com/IvoryHeart/herdr-world/pull/17)
+
 ### Removed
 
 ## [0.1.0-rc.3] - 2026-08-26

--- a/scripts/verify-desktop-package.sh
+++ b/scripts/verify-desktop-package.sh
@@ -84,13 +84,17 @@ case "$PLATFORM" in
     }
     ;;
   macos-arm64)
-    [[ "$binary_description" == *"Mach-O 64-bit executable arm64"* ]] || {
+    [[ "$binary_description" == *"Mach-O 64-bit"* \
+      && "$binary_description" == *"arm64"* \
+      && "$binary_description" == *"executable"* ]] || {
       echo "unexpected macOS ARM64 bridge architecture: $binary_description" >&2
       exit 1
     }
     ;;
   macos-x86_64)
-    [[ "$binary_description" == *"Mach-O 64-bit executable x86_64"* ]] || {
+    [[ "$binary_description" == *"Mach-O 64-bit"* \
+      && "$binary_description" == *"x86_64"* \
+      && "$binary_description" == *"executable"* ]] || {
       echo "unexpected macOS x86-64 bridge architecture: $binary_description" >&2
       exit 1
     }


### PR DESCRIPTION
## Summary

- make the desktop package verifier accept the equivalent Mach-O descriptions emitted by macOS and Linux `file`
- continue to require Mach-O 64-bit, the exact expected CPU, and executable format
- document the release aggregation fix

## Evidence

- reproduced from the exact three native artifacts built by the `v0.1.0-rc.3` tag workflow
- all three downloaded archives and checksum files pass the corrected verifier on the Linux aggregation host
- `npm run test:release`, `bash -n`, and `git diff --check` pass

This does not change the native packages, product, launcher, signing policy, or port 8787. It fixes only the final cross-host aggregation check. After merge, the next prerelease will exercise the complete automated upload path.
