### PR TITLE
fix: support no-argument launches on macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,63 +2,11 @@
 
 ## [Unreleased]
 
-### Breaking Changes
-
-### Added
-
-### Changed
-
-### Fixed
-
-- Made release aggregation accept the equivalent macOS Mach-O architecture descriptions emitted
-  by macOS and Linux `file`, while still requiring the expected executable format and CPU.
-  [Herdr World PR #17](https://github.com/IvoryHeart/herdr-world/pull/17)
-
-### Removed
-
-## [0.1.0-rc.3] - 2026-08-26
-
 ### Added
 
 - Added automated, native Linux x86-64 and unsigned macOS ARM64/x86-64 release builds with archive,
   checksum, architecture, legal-content, launcher, and two-daemon stock Herdr v0.8.2 validation.
   [Herdr World PR #16](https://github.com/IvoryHeart/herdr-world/pull/16)
-
-### Changed
-
-- Made the single release command update public README/Pages version references before tagging, so
-  desktop assets and the project site publish from the same release operation.
-  [Herdr World PR #16](https://github.com/IvoryHeart/herdr-world/pull/16)
-
-### Fixed
-
-- Made the release helper mark SemVer prerelease tags such as `v0.1.0-rc.2` as GitHub
-  prereleases automatically while leaving stable versions unchanged.
-  [Herdr World PR #15](https://github.com/IvoryHeart/herdr-world/pull/15)
-
-## [0.1.0-rc.2] - 2026-08-26
-
-### Changed
-
-- Made the desktop launcher detect a missing default Herdr session and offer an explicit,
-  consent-based path to install Herdr from its official installer and start it in a user-selected
-  workspace. Non-interactive, custom-session, and custom-socket launches remain fail-safe.
-  [Herdr World PR #14](https://github.com/IvoryHeart/herdr-world/pull/14)
-- Added a direct, checksum-verified Linux release quick start, an explicit public-platform matrix,
-  a minimalist Pixel Office-themed GitHub Pages site, and launch-ready social artwork for the
-  Herdr World public preview.
-  [Herdr World PR #11](https://github.com/IvoryHeart/herdr-world/pull/11)
-
-### Fixed
-
-- Made release creation fail closed unless both `origin` URLs and the explicit GitHub CLI target
-  resolve to `IvoryHeart/herdr-world`, preventing a checkout's default upstream from receiving a
-  Herdr World release. [Herdr World PR #10](https://github.com/IvoryHeart/herdr-world/pull/10)
-
-## [0.1.0-rc.1] - 2026-08-26
-
-### Added
-
 - Added deterministic production npm/Cargo licence inventories, exact runtime
   closure checks, and release/WebView assembly of the resulting notices.
   [Herdr World PR #9](https://github.com/IvoryHeart/herdr-world/pull/9)
@@ -117,6 +65,17 @@
 
 ### Changed
 
+- Made the desktop launcher detect a missing default Herdr session and offer an explicit,
+  consent-based path to install Herdr from its official installer and start it in a user-selected
+  workspace. Non-interactive, custom-session, and custom-socket launches remain fail-safe.
+  [Herdr World PR #14](https://github.com/IvoryHeart/herdr-world/pull/14)
+- Added a direct, checksum-verified desktop release quick start, an explicit public-platform matrix,
+  a minimalist Pixel Office-themed GitHub Pages site, and launch-ready social artwork for the
+  Herdr World public preview.
+  [Herdr World PR #11](https://github.com/IvoryHeart/herdr-world/pull/11)
+- Made the single release command update public README/Pages version references before tagging, so
+  desktop assets and the project site publish from the same release operation.
+  [Herdr World PR #16](https://github.com/IvoryHeart/herdr-world/pull/16)
 - Completed the Herdr World product identity across the visible shell, Android
   application ID (`dev.herdr.world`), and desktop `herdr-world-*` release
   artifacts. Release tarballs now carry the project license, explicit
@@ -199,6 +158,18 @@
 
 ### Fixed
 
+- Fixed the packaged launcher failing with `bridge_args[@]: unbound variable` when invoked without
+  bridge arguments under the Bash 3.2 version shipped by macOS, and added a native packaged-launcher
+  regression check. [Herdr World PR #18](https://github.com/IvoryHeart/herdr-world/pull/18)
+- Made release aggregation accept the equivalent macOS Mach-O architecture descriptions emitted
+  by macOS and Linux `file`, while still requiring the expected executable format and CPU.
+  [Herdr World PR #17](https://github.com/IvoryHeart/herdr-world/pull/17)
+- Made the release helper mark SemVer prerelease tags as GitHub prereleases automatically while
+  leaving stable versions unchanged.
+  [Herdr World PR #15](https://github.com/IvoryHeart/herdr-world/pull/15)
+- Made release creation fail closed unless both `origin` URLs and the explicit GitHub CLI target
+  resolve to `IvoryHeart/herdr-world`, preventing a checkout's default upstream from receiving a
+  Herdr World release. [Herdr World PR #10](https://github.com/IvoryHeart/herdr-world/pull/10)
 - Fixed icons rendering slightly off-center in square icon buttons by resetting
   browser-default button padding and removing the compensating filter-icon transform.
   Contributed by [Philippe SEGATORI (@tigitz)](https://github.com/tigitz) in

--- a/scripts/herdr-world-launcher.sh
+++ b/scripts/herdr-world-launcher.sh
@@ -176,10 +176,10 @@ herdr_world_main() {
     fi
   done
 
-  for arg in "${bridge_args[@]}"; do
+  for arg in "${bridge_args[@]+"${bridge_args[@]}"}"; do
     case "$arg" in
       -h | --help)
-        herdr_world_exec_bridge "${bridge_args[@]}"
+        herdr_world_exec_bridge "${bridge_args[@]+"${bridge_args[@]}"}"
         return
         ;;
     esac
@@ -187,16 +187,16 @@ herdr_world_main() {
 
   # Explicit sessions and socket paths are operator-managed. The launcher must
   # not create or start a different default session in response to their state.
-  for arg in "${bridge_args[@]}"; do
+  for arg in "${bridge_args[@]+"${bridge_args[@]}"}"; do
     case "$arg" in
       --session | --session=*)
-        herdr_world_exec_bridge "${bridge_args[@]}"
+        herdr_world_exec_bridge "${bridge_args[@]+"${bridge_args[@]}"}"
         return
         ;;
     esac
   done
   if [[ -n "${HERDR_SOCKET_PATH:-}" || -n "${HERDR_CLIENT_SOCKET_PATH:-}" || -n "${HERDR_SESSION:-}" ]]; then
-    herdr_world_exec_bridge "${bridge_args[@]}"
+    herdr_world_exec_bridge "${bridge_args[@]+"${bridge_args[@]}"}"
     return
   fi
 
@@ -206,7 +206,7 @@ herdr_world_main() {
     return 1
   fi
   if herdr_world_socket_ready "$default_socket"; then
-    herdr_world_exec_bridge "${bridge_args[@]}"
+    herdr_world_exec_bridge "${bridge_args[@]+"${bridge_args[@]}"}"
     return
   fi
 
@@ -267,7 +267,7 @@ EOF
   fi
 
   echo "Herdr is running; starting Herdr World at http://127.0.0.1:8787." >&2
-  herdr_world_exec_bridge "${bridge_args[@]}"
+  herdr_world_exec_bridge "${bridge_args[@]+"${bridge_args[@]}"}"
 }
 
 if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then

--- a/scripts/verify-desktop-package.sh
+++ b/scripts/verify-desktop-package.sh
@@ -125,6 +125,24 @@ host_arch="$(uname -m)"
 case "$PLATFORM:$host_os:$host_arch" in
   linux-x86_64:Linux:x86_64 | macos-arm64:Darwin:arm64 | macos-x86_64:Darwin:x86_64)
     "$BUNDLE/bin/herdr-world" --help >/dev/null
+    launcher_home="$VERIFY_ROOT/launcher-home"
+    launcher_output="$VERIFY_ROOT/launcher-no-session.log"
+    mkdir -p "$launcher_home/config"
+    if HOME="$launcher_home" \
+      XDG_CONFIG_HOME="$launcher_home/config" \
+      HERDR_SOCKET_PATH= \
+      HERDR_CLIENT_SOCKET_PATH= \
+      HERDR_SESSION= \
+      HERDR_WORLD_SETUP=never \
+      /bin/bash "$BUNDLE/bin/herdr-world" >"$launcher_output" 2>&1; then
+      echo "launcher unexpectedly succeeded without a Herdr session" >&2
+      exit 1
+    fi
+    if ! grep -Fq "No running default Herdr session was found" "$launcher_output"; then
+      cat "$launcher_output" >&2
+      echo "launcher did not report the expected missing-session guidance" >&2
+      exit 1
+    fi
     ;;
 esac
 printf 'Verified %s (%s)\n' "$ARCHIVE" "$binary_description"


### PR DESCRIPTION
## Summary

- make every empty `bridge_args` expansion safe under the Bash 3.2 + `set -u` combination shipped by macOS
- execute the packaged launcher with `/bin/bash` and no Herdr session during each native package verification, requiring the expected guidance rather than an unbound-variable crash
- consolidate the initial public-preview changelog into a single forthcoming `v0.1.0-rc.1` entry

## Validation

- `npm run test:release`
- shell syntax checks
- complete Linux archive build and package verification, including the new no-argument launcher check
- `git diff --check`

The macOS native jobs are the authoritative regression for Apple `/bin/bash`. This does not change the bridge, web application, Herdr installation consent, signing policy, or port 8787.

After merge, the existing pre-announcement `rc.1`/`rc.2`/`rc.3` GitHub releases and tags will be consolidated into one fixed `v0.1.0-rc.1`, as requested by the owner. No `rc.4` will be created.
