### PR TITLE
fix: guide incompatible Herdr setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,18 +2,6 @@
 
 ## [Unreleased]
 
-### Breaking Changes
-
-### Added
-
-### Changed
-
-### Fixed
-
-### Removed
-
-## [0.1.0-rc.1] - 2026-08-26
-
 ### Added
 
 - Added automated, native Linux x86-64 and unsigned macOS ARM64/x86-64 release builds with archive,
@@ -170,6 +158,9 @@
 
 ### Fixed
 
+- Fixed guided desktop setup bypassing an incompatible detached Herdr server merely because its
+  socket still existed. Interactive launches now offer to install/update Herdr, explicitly warn and
+  ask before stopping the old server, then start the compatible server in the selected workspace.
 - Fixed the packaged launcher failing with `bridge_args[@]: unbound variable` when invoked without
   bridge arguments under the Bash 3.2 version shipped by macOS, and added a native packaged-launcher
   regression check. [Herdr World PR #18](https://github.com/IvoryHeart/herdr-world/pull/18)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -161,6 +161,7 @@
 - Fixed guided desktop setup bypassing an incompatible detached Herdr server merely because its
   socket still existed. Interactive launches now offer to install/update Herdr, explicitly warn and
   ask before stopping the old server, then start the compatible server in the selected workspace.
+  [Herdr World PR #19](https://github.com/IvoryHeart/herdr-world/pull/19)
 - Fixed the packaged launcher failing with `bridge_args[@]: unbound variable` when invoked without
   bridge arguments under the Bash 3.2 version shipped by macOS, and added a native packaged-launcher
   regression check. [Herdr World PR #18](https://github.com/IvoryHeart/herdr-world/pull/18)

--- a/README.md
+++ b/README.md
@@ -145,11 +145,12 @@ The macOS binaries are not yet Developer ID signed or notarized. macOS may there
 confirm the first launch in System Settings → Privacy & Security after you have verified the
 downloaded checksum and source. Signing and notarization will be added when project credentials are
 available.
-If the default Herdr session is not running, an interactive `bin/herdr-world` launch explains the
-requirement and asks separately before downloading the [official Herdr
-installer](https://herdr.dev/docs/install/) or starting Herdr. Before starting Herdr, it asks for
-the directory containing the work you want Herdr to manage. Declining either action leaves the
-system unchanged and prints manual instructions.
+If the default Herdr session is missing or incompatible, an interactive `bin/herdr-world` launch
+explains the requirement and asks separately before downloading the [official Herdr
+installer](https://herdr.dev/docs/install/), stopping an incompatible detached server, or starting
+Herdr. Stopping a server exits the terminal panes and processes it owns. Before starting Herdr, the
+launcher asks for the directory containing the work you want Herdr to manage. Declining any action
+leaves that action undone and prints manual instructions.
 
 The launcher never performs guided setup in a non-interactive environment or when `--session`,
 `HERDR_SESSION`, or a socket override selects an operator-managed target. Pass

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -49,10 +49,12 @@ herdr-world-vX.Y.Z-PLATFORM/
 ```
 
 `bin/herdr-world` points `herdr-world-bridge` at the bundled web assets. When the default Herdr
-socket is absent, it can run Herdr's official installer and start Herdr only after separate explicit
-consent. It asks for a Herdr workspace directory rather than using the unpacked bundle by accident.
-It fails with manual instructions instead of prompting in automation, and it leaves explicit
-session and socket targets under operator control.
+session is missing or incompatible, it can run Herdr's official installer, stop an incompatible
+detached server, and start the current Herdr only after separate explicit consent for each action.
+The stop prompt warns that the server's panes and processes will exit. The launcher asks for a Herdr
+workspace directory rather than using the unpacked bundle by accident. It fails with manual
+instructions instead of prompting in automation, and it leaves explicit session and socket targets
+under operator control.
 
 ## Build A Desktop Tarball
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -93,9 +93,11 @@ attempt to weaken Gatekeeper or modify a user's security policy.
 
 For the desktop launcher, verify `bin/herdr-world --help` never starts onboarding, a
 non-interactive launch with no default Herdr socket fails with manual instructions, and an
-interactive missing-session launch asks independently before installation and startup. Do not
-exercise the live installer during release verification; the launcher tests replace its network and
-process boundaries with deterministic fakes.
+interactive missing-session launch asks independently before installation and startup. Also verify
+that an interactive incompatible default server asks independently before installation/update,
+server stop, and restart, while declining the stop leaves it running. Do not exercise the live
+installer during release verification; the launcher tests replace its network and process
+boundaries with deterministic fakes.
 
 To stage the current debug APK under the release asset name for private testing:
 

--- a/docs/tarball-readme.md
+++ b/docs/tarball-readme.md
@@ -20,11 +20,12 @@ From the unpacked bundle directory:
 bin/herdr-world
 ```
 
-If the default Herdr session is not running, an interactive launch offers to download and run the
-[official Herdr installer](https://herdr.dev/docs/install/), then separately offers to start Herdr
-in a directory you select. Nothing is installed or started without an affirmative answer. Starting
-Herdr opens its terminal UI; detach with <kbd>Ctrl</kbd>+<kbd>B</kbd> then <kbd>Q</kbd> so this
-launcher can continue.
+If the default Herdr session is missing or incompatible, an interactive launch offers to download
+and run the [official Herdr installer](https://herdr.dev/docs/install/), separately asks before
+stopping an incompatible detached server, then offers to start Herdr in a directory you select.
+Stopping a server exits its panes and processes. Nothing is installed, stopped, or started without
+an affirmative answer. Starting Herdr opens its terminal UI; detach with
+<kbd>Ctrl</kbd>+<kbd>B</kbd> then <kbd>Q</kbd> so this launcher can continue.
 
 Guided setup is disabled for non-interactive launches, explicit `--session`/`HERDR_SESSION` targets,
 and socket overrides. Use `--no-herdr-setup` or `HERDR_WORLD_SETUP=never` to disable it for a

--- a/scripts/herdr-world-launcher.sh
+++ b/scripts/herdr-world-launcher.sh
@@ -44,6 +44,71 @@ herdr_world_find_binary() {
   return 1
 }
 
+herdr_world_find_installer_binary() {
+  if [[ -n "${HERDR_INSTALL_DIR:-}" && -x "$HERDR_INSTALL_DIR/herdr" ]]; then
+    printf '%s/herdr\n' "$HERDR_INSTALL_DIR"
+    return 0
+  fi
+
+  if [[ -n "${HOME:-}" && -x "$HOME/.local/bin/herdr" ]]; then
+    printf '%s/.local/bin/herdr\n' "$HOME"
+    return 0
+  fi
+
+  herdr_world_find_binary
+}
+
+herdr_world_version_is_supported() {
+  local version="$1"
+  local major
+  local minor
+  local patch
+
+  version="${version#v}"
+  if [[ ! "$version" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)([-+].*)?$ ]]; then
+    return 1
+  fi
+  major="${BASH_REMATCH[1]}"
+  minor="${BASH_REMATCH[2]}"
+  patch="${BASH_REMATCH[3]}"
+
+  (( major > 0 || minor > 8 || (minor == 8 && patch >= 2) ))
+}
+
+herdr_world_binary_is_supported() {
+  local herdr_bin="$1"
+  local version_output=""
+  local version=""
+
+  version_output="$("$herdr_bin" -V 2>/dev/null)" || return 1
+  version="${version_output##* }"
+  herdr_world_version_is_supported "$version"
+}
+
+herdr_world_server_is_supported() {
+  local herdr_bin="$1"
+  local status_output=""
+  local server_fields=""
+  local server_version=""
+  local server_protocol=""
+  local server_compatible=""
+
+  status_output="$("$herdr_bin" status 2>/dev/null)" || return 1
+  server_fields="$(printf '%s\n' "$status_output" | awk '
+    $0 == "server:" { in_server = 1; next }
+    in_server && $0 !~ /^  / { in_server = 0 }
+    in_server && $1 == "version:" { version = $2 }
+    in_server && $1 == "protocol:" { protocol = $2 }
+    in_server && $1 == "compatible:" { compatible = $2 }
+    END { printf "%s\t%s\t%s\n", version, protocol, compatible }
+  ')"
+  IFS=$'\t' read -r server_version server_protocol server_compatible <<<"$server_fields"
+
+  herdr_world_version_is_supported "$server_version" \
+    && [[ "$server_protocol" == "$HERDR_TERMINAL_PROTOCOL" ]] \
+    && [[ "$server_compatible" == "yes" ]]
+}
+
 herdr_world_is_interactive() {
   [[ -t 0 && -t 2 ]]
 }
@@ -98,6 +163,54 @@ herdr_world_install() {
   fi
 
   rm -rf -- "$installer_dir"
+}
+
+herdr_world_ensure_supported_binary() {
+  local herdr_bin=""
+
+  if herdr_bin="$(herdr_world_find_binary)" && herdr_world_binary_is_supported "$herdr_bin"; then
+    printf '%s\n' "$herdr_bin"
+    return 0
+  fi
+
+  if [[ -n "$herdr_bin" ]]; then
+    cat >&2 <<EOF
+The installed Herdr executable is older than ${HERDR_MINIMUM_VERSION}:
+  $herdr_bin
+
+Herdr World can download ${HERDR_INSTALLER_URL} over HTTPS and run it locally
+to install the latest stable Herdr.
+EOF
+  else
+    cat >&2 <<EOF
+Herdr is not installed or is not available on PATH.
+
+Herdr World can download ${HERDR_INSTALLER_URL} over HTTPS and run it locally.
+The official installer installs the latest stable Herdr (normally under ~/.local/bin)
+and verifies the downloaded Herdr binary checksum. It does not install Herdr World.
+EOF
+  fi
+
+  if ! herdr_world_confirm "Download and run the official Herdr installer now?"; then
+    herdr_world_manual_instructions
+    return 1
+  fi
+  if ! herdr_world_install; then
+    herdr_world_manual_instructions
+    return 1
+  fi
+  if ! herdr_bin="$(herdr_world_find_installer_binary)"; then
+    echo "Herdr was installed, but its executable could not be found." >&2
+    herdr_world_manual_instructions
+    return 1
+  fi
+  if ! herdr_world_binary_is_supported "$herdr_bin"; then
+    echo "The installed Herdr executable is still older than ${HERDR_MINIMUM_VERSION}." >&2
+    herdr_world_manual_instructions
+    return 1
+  fi
+
+  printf '%s\n' "$herdr_bin"
 }
 
 herdr_world_choose_workspace() {
@@ -156,6 +269,23 @@ herdr_world_wait_for_socket() {
   return 1
 }
 
+herdr_world_wait_for_socket_to_stop() {
+  local socket_path="$1"
+  local attempt
+  for attempt in {1..50}; do
+    if ! herdr_world_socket_ready "$socket_path"; then
+      return 0
+    fi
+    sleep 0.1
+  done
+  return 1
+}
+
+herdr_world_stop_herdr() {
+  local herdr_bin="$1"
+  "$herdr_bin" server stop
+}
+
 herdr_world_exec_bridge() {
   exec "$BRIDGE_BIN" --static-dir "$STATIC_DIR" "$@"
 }
@@ -167,6 +297,7 @@ herdr_world_main() {
   local default_socket=""
   local herdr_bin=""
   local workspace=""
+  local socket_is_ready=false
 
   for arg in "$@"; do
     if [[ "$arg" == "--no-herdr-setup" ]]; then
@@ -205,38 +336,61 @@ herdr_world_main() {
     herdr_world_manual_instructions
     return 1
   fi
-  if herdr_world_socket_ready "$default_socket"; then
-    herdr_world_exec_bridge "${bridge_args[@]+"${bridge_args[@]}"}"
-    return
-  fi
 
   case "${HERDR_WORLD_SETUP:-auto}" in
     never | off | 0) setup_enabled=false ;;
   esac
+
+  if herdr_world_socket_ready "$default_socket"; then
+    socket_is_ready=true
+    if herdr_bin="$(herdr_world_find_binary)" \
+      && herdr_world_binary_is_supported "$herdr_bin" \
+      && herdr_world_server_is_supported "$herdr_bin"; then
+      herdr_world_exec_bridge "${bridge_args[@]+"${bridge_args[@]}"}"
+      return
+    fi
+
+    # Preserve non-interactive and explicitly disabled behavior. The bridge
+    # remains the authority for the detailed compatibility error in this path.
+    if [[ "$setup_enabled" != true ]] || ! herdr_world_is_interactive; then
+      herdr_world_exec_bridge "${bridge_args[@]+"${bridge_args[@]}"}"
+      return
+    fi
+  fi
+
   if [[ "$setup_enabled" != true ]] || ! herdr_world_is_interactive; then
     echo "No running default Herdr session was found at $default_socket." >&2
     herdr_world_manual_instructions
     return 1
   fi
 
-  if ! herdr_bin="$(herdr_world_find_binary)"; then
-    cat >&2 <<EOF
-Herdr is not installed or is not available on PATH.
+  if ! herdr_bin="$(herdr_world_ensure_supported_binary)"; then
+    return 1
+  fi
 
-Herdr World can download ${HERDR_INSTALLER_URL} over HTTPS and run it locally.
-The official installer installs the latest stable Herdr (normally under ~/.local/bin)
-and verifies the downloaded Herdr binary checksum. It does not install Herdr World.
+  if [[ "$socket_is_ready" == true ]]; then
+    if herdr_world_server_is_supported "$herdr_bin"; then
+      herdr_world_exec_bridge "${bridge_args[@]+"${bridge_args[@]}"}"
+      return
+    fi
+
+    cat >&2 <<EOF
+The running default Herdr server is incompatible with Herdr World.
+
+It must be stopped before the current Herdr can start. Stopping it exits the
+terminal panes and processes owned by that server.
 EOF
-    if ! herdr_world_confirm "Download and run the official Herdr installer now?"; then
+    if ! herdr_world_confirm "Stop the incompatible Herdr server now?"; then
       herdr_world_manual_instructions
       return 1
     fi
-    if ! herdr_world_install; then
+    if ! herdr_world_stop_herdr "$herdr_bin"; then
+      echo "The incompatible Herdr server could not be stopped." >&2
       herdr_world_manual_instructions
       return 1
     fi
-    if ! herdr_bin="$(herdr_world_find_binary)"; then
-      echo "Herdr was installed, but its executable could not be found." >&2
+    if ! herdr_world_wait_for_socket_to_stop "$default_socket"; then
+      echo "The incompatible Herdr server did not release $default_socket." >&2
       herdr_world_manual_instructions
       return 1
     fi

--- a/scripts/herdr-world-launcher.test.mjs
+++ b/scripts/herdr-world-launcher.test.mjs
@@ -39,6 +39,9 @@ test("an available default session starts the packaged bridge directly", () => {
   const result = runLauncher(`
 herdr_world_default_socket() { printf '/tmp/herdr.sock\\n'; }
 herdr_world_socket_ready() { return 0; }
+herdr_world_find_binary() { printf '/fake/herdr\\n'; }
+herdr_world_binary_is_supported() { return 0; }
+herdr_world_server_is_supported() { return 0; }
 herdr_world_exec_bridge() { printf 'bridge'; printf ' <%s>' "$@"; printf '\\n'; }
 herdr_world_main --port 8791
 `);
@@ -120,6 +123,7 @@ herdr_world_default_socket() { printf '/tmp/missing-herdr.sock\\n'; }
 herdr_world_socket_ready() { return 1; }
 herdr_world_is_interactive() { return 0; }
 herdr_world_find_binary() { printf '/fake/herdr\\n'; }
+herdr_world_binary_is_supported() { return 0; }
 herdr_world_run_herdr() { echo 'unexpected Herdr start' >&2; }
 herdr_world_main
 `,
@@ -142,6 +146,8 @@ herdr_world_find_binary() {
   [[ "$installed" == 1 ]] || return 1
   printf '/fake/herdr\\n'
 }
+herdr_world_find_installer_binary() { printf '/fake/herdr\\n'; }
+herdr_world_binary_is_supported() { return 0; }
 herdr_world_install() { installed=1; echo 'installed' >&2; }
 herdr_world_choose_workspace() { printf '/tmp/project\\n'; }
 herdr_world_run_herdr() {
@@ -159,6 +165,78 @@ herdr_world_main --port 8793
   assert.match(result.stderr, /installed/);
   assert.match(result.stderr, /started <\/fake\/herdr> in <\/tmp\/project>/);
   assert.match(result.stderr, /Herdr is running; starting Herdr World/);
+});
+
+test("an incompatible detached server is updated and restarted only with consent", () => {
+  const result = runLauncher(
+    `
+socket_ready=1
+herdr_world_default_socket() { printf '/tmp/herdr.sock\\n'; }
+herdr_world_socket_ready() { [[ "$socket_ready" == 1 ]]; }
+herdr_world_is_interactive() { return 0; }
+herdr_world_find_binary() { return 1; }
+herdr_world_find_installer_binary() { printf '/fake/herdr\\n'; }
+herdr_world_binary_is_supported() { return 0; }
+herdr_world_server_is_supported() { return 1; }
+herdr_world_install() { echo 'installed current Herdr' >&2; }
+herdr_world_stop_herdr() {
+  printf 'stopped <%s>\\n' "$1" >&2
+  socket_ready=0
+}
+herdr_world_choose_workspace() { printf '/tmp/project\\n'; }
+herdr_world_run_herdr() {
+  printf 'started <%s> in <%s>\\n' "$1" "$2" >&2
+  socket_ready=1
+}
+herdr_world_exec_bridge() { printf 'bridge'; printf ' <%s>' "$@"; printf '\\n'; }
+herdr_world_main --port 8795
+`,
+    "y\ny\ny\n",
+  );
+
+  assert.equal(result.status, 0);
+  assert.equal(result.stdout, "bridge <--port> <8795>\n");
+  assert.match(result.stderr, /Download and run the official Herdr installer now\?/);
+  assert.match(result.stderr, /Stop the incompatible Herdr server now\?/);
+  assert.match(result.stderr, /Stopping it exits the/);
+  assert.match(result.stderr, /stopped <\/fake\/herdr>/);
+  assert.match(result.stderr, /Start Herdr now\?/);
+  assert.match(result.stderr, /started <\/fake\/herdr> in <\/tmp\/project>/);
+});
+
+test("declining an incompatible server stop leaves it untouched", () => {
+  const result = runLauncher(
+    `
+herdr_world_default_socket() { printf '/tmp/herdr.sock\\n'; }
+herdr_world_socket_ready() { return 0; }
+herdr_world_is_interactive() { return 0; }
+herdr_world_find_binary() { printf '/fake/herdr\\n'; }
+herdr_world_binary_is_supported() { return 0; }
+herdr_world_server_is_supported() { return 1; }
+herdr_world_stop_herdr() { echo 'unexpected stop' >&2; }
+herdr_world_exec_bridge() { echo 'unexpected bridge start' >&2; }
+herdr_world_main
+`,
+    "n\n",
+  );
+
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /Stop the incompatible Herdr server now\?/);
+  assert.doesNotMatch(result.stderr, /unexpected stop/);
+  assert.doesNotMatch(result.stderr, /unexpected bridge start/);
+});
+
+test("supported Herdr version parsing is bounded to v0.8.2 or newer", () => {
+  const result = runLauncher(`
+for version in 0.8.2 v0.8.2 0.8.3 0.9.0 1.0.0 0.8.2+build.1; do
+  herdr_world_version_is_supported "$version" || exit 11
+done
+for version in 0.8.1 0.7.9 invalid 0.8; do
+  if herdr_world_version_is_supported "$version"; then exit 12; fi
+done
+`);
+
+  assert.equal(result.status, 0);
 });
 
 test("the launcher refuses to default Herdr's workspace to its own bundle", () => {


### PR DESCRIPTION
Fixes the clean-mac onboarding failure where an older detached Herdr daemon leaves the default socket behind after the executable is removed. The launcher previously treated socket existence as compatibility and bypassed guided setup.\n\nScope:\n- verify the discovered Herdr binary is v0.8.2 or newer\n- verify the running default server reports v0.8.2+, protocol 20, and client compatibility\n- offer the official installer when the binary is missing or outdated\n- require a separate explicit warning and consent before stopping an incompatible server\n- start current Herdr in the user-selected workspace, then launch World\n- preserve non-interactive, setup-disabled, explicit-session, and socket-override behavior\n- document that stopping an old server exits its owned panes and processes\n\nValidation:\n- npm run check\n- release tests: 18 passed\n- npm run test:pages\n- packaged Linux archive verification\n- git diff --check\n\nRelease handling:\n- this is a pre-announcement correction to the existing public preview\n- after native macOS validation and merge, replace v0.1.0-rc.1 in place\n- do not create rc.2 or another release-candidate number