### PR TITLE
fix: permit guarded prerelease reissue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -161,6 +161,7 @@
 - Added a guarded same-tag prerelease reissue mode for correcting an unannounced candidate without
   inventing another release-candidate number. It retains all normal remote, tag, release, and test
   safety checks and cannot replace a stable release.
+  [Herdr World PR #20](https://github.com/IvoryHeart/herdr-world/pull/20)
 - Fixed guided desktop setup bypassing an incompatible detached Herdr server merely because its
   socket still existed. Interactive launches now offer to install/update Herdr, explicitly warn and
   ask before stopping the old server, then start the compatible server in the selected workspace.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -158,6 +158,9 @@
 
 ### Fixed
 
+- Added a guarded same-tag prerelease reissue mode for correcting an unannounced candidate without
+  inventing another release-candidate number. It retains all normal remote, tag, release, and test
+  safety checks and cannot replace a stable release.
 - Fixed guided desktop setup bypassing an incompatible detached Herdr server merely because its
   socket still existed. Interactive launches now offer to install/update Herdr, explicitly warn and
   ask before stopping the old server, then start the compatible server in the selected workspace.

--- a/docs/release.md
+++ b/docs/release.md
@@ -35,6 +35,12 @@ npm run check
 
 Do not cut a release without bridge test/build coverage.
 
+If an unannounced prerelease must be replaced under the same tag, first delete its GitHub release
+and local/remote tag, then run `node scripts/release.mjs vX.Y.Z-rc.N --reissue-prerelease`. This
+explicit recovery mode is limited to prereleases whose public version references already match;
+the normal clean-tree, canonical-remote, absent-tag, absent-release, test, commit, and publication
+checks still apply. Never use it to replace a stable release or immutable release assets.
+
 ## Package Artifacts
 
 Desktop artifacts are built from the final tag by `.github/workflows/release.yml`; do not upload a

--- a/scripts/release-version.mjs
+++ b/scripts/release-version.mjs
@@ -36,14 +36,21 @@ export function assertCurrentReleaseReferences(root = process.cwd()) {
   return current;
 }
 
-export function stampCurrentRelease(newTag, root = process.cwd()) {
+export function stampCurrentRelease(
+  newTag,
+  root = process.cwd(),
+  { allowSameTag = false } = {},
+) {
   if (!VERSION_PATTERN.test(newTag)) {
     throw new Error(`invalid release tag: ${newTag}`);
   }
 
   const current = assertCurrentReleaseReferences(root);
   if (current === newTag) {
-    throw new Error(`release references already point to ${newTag}`);
+    if (!allowSameTag) {
+      throw new Error(`release references already point to ${newTag}`);
+    }
+    return [];
   }
 
   const updates = RELEASE_REFERENCE_PATHS.slice(0, -1).map((relativePath) => {

--- a/scripts/release-version.test.mjs
+++ b/scripts/release-version.test.mjs
@@ -5,6 +5,7 @@ import { join, resolve } from "node:path";
 import test from "node:test";
 
 import {
+  RELEASE_REFERENCE_PATHS,
   assertCurrentReleaseReferences,
   readCurrentReleaseTag,
   stampCurrentRelease,
@@ -51,6 +52,38 @@ test("fails closed when a required public surface has drifted", () => {
       /site\/site\.js does not reference the current release v1\.2\.3/,
     );
     assert.equal(readFileSync(join(root, "README.md"), "utf8"), "v1.2.3\n");
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("allows an explicit same-tag prerelease reissue without rewriting public files", () => {
+  const root = mkdtempSync(join(tmpdir(), "herdr-world-release-version-"));
+  try {
+    mkdirSync(join(root, "site"));
+    writeFileSync(join(root, "release.json"), '{"current":"v1.2.3-rc.1"}\n');
+    writeFileSync(join(root, "README.md"), "v1.2.3-rc.1\n");
+    writeFileSync(join(root, "site", "index.html"), "v1.2.3-rc.1\n");
+    writeFileSync(join(root, "site", "site.js"), "v1.2.3-rc.1\n");
+
+    assert.throws(
+      () => stampCurrentRelease("v1.2.3-rc.1", root),
+      /release references already point to v1\.2\.3-rc\.1/,
+    );
+
+    const before = RELEASE_REFERENCE_PATHS.map((relativePath) =>
+      readFileSync(join(root, relativePath), "utf8"),
+    );
+    assert.deepEqual(
+      stampCurrentRelease("v1.2.3-rc.1", root, { allowSameTag: true }),
+      [],
+    );
+    assert.deepEqual(
+      RELEASE_REFERENCE_PATHS.map((relativePath) =>
+        readFileSync(join(root, relativePath), "utf8"),
+      ),
+      before,
+    );
   } finally {
     rmSync(root, { recursive: true, force: true });
   }

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -10,15 +10,22 @@ import {
   releaseCreateArgs,
   withReleaseRepository,
 } from "./release-target.mjs";
-import { RELEASE_REFERENCE_PATHS, stampCurrentRelease } from "./release-version.mjs";
+import {
+  RELEASE_REFERENCE_PATHS,
+  readCurrentReleaseTag,
+  stampCurrentRelease,
+} from "./release-version.mjs";
 
 const RELEASE_BRANCH = "main";
 const RELEASE_ARG = process.argv[2];
+const REISSUE_PRERELEASE = process.argv[3] === "--reissue-prerelease";
 const VERSION_ARG = /^v?(\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?)$/;
 
 const match = RELEASE_ARG?.match(VERSION_ARG);
-if (!match) {
-  console.error("Usage: node scripts/release.mjs <vX.Y.Z|X.Y.Z>");
+if (!match || process.argv.length > (REISSUE_PRERELEASE ? 4 : 3)) {
+  console.error(
+    "Usage: node scripts/release.mjs <vX.Y.Z|X.Y.Z> [--reissue-prerelease]",
+  );
   process.exit(1);
 }
 
@@ -184,11 +191,19 @@ function escapeRegex(value) {
 
 try {
   validatePreflight();
+  if (REISSUE_PRERELEASE) {
+    if (!tag.includes("-")) {
+      fail("--reissue-prerelease is only valid for a SemVer prerelease tag");
+    }
+    if (readCurrentReleaseTag() !== tag) {
+      fail("--reissue-prerelease requires public release references to match the requested tag");
+    }
+  }
   const changelog = readChangelogForRelease();
 
   run("npm", ["run", "check"]);
 
-  stampCurrentRelease(tag);
+  stampCurrentRelease(tag, process.cwd(), { allowSameTag: REISSUE_PRERELEASE });
   const released = stampChangelog(changelog);
   writeFileSync(notesFile, extractReleaseNotes(released));
 


### PR DESCRIPTION
Adds one explicit fail-closed path for reissuing an unannounced prerelease under the same tag. Normal releases remain unchanged. The mode is restricted to prerelease tags whose public references already match, while the existing canonical remote, absent local/remote tag, absent GitHub release, clean tree, validation, and publication checks still apply. Stable releases cannot use it.

Validation:
- npm run check
- npm run test:release
- git diff --check