### PR TITLE
fix: preserve installed Herdr path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - Kept the official Herdr installer's stdout diagnostics out of the launcher's resolved executable
   path, allowing guided macOS installation to stop an incompatible daemon and continue startup.
+  [Herdr World PR #21](https://github.com/IvoryHeart/herdr-world/pull/21)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
 
 ### Fixed
 
+- Kept the official Herdr installer's stdout diagnostics out of the launcher's resolved executable
+  path, allowing guided macOS installation to stop an incompatible daemon and continue startup.
+
 ### Removed
 
 ## [0.1.0-rc.1] - 2026-08-26

--- a/scripts/herdr-world-launcher.sh
+++ b/scripts/herdr-world-launcher.sh
@@ -195,7 +195,10 @@ EOF
     herdr_world_manual_instructions
     return 1
   fi
-  if ! herdr_world_install; then
+  # This function's stdout is its resolved-binary return value. The official
+  # installer is intentionally chatty on stdout, so display that output on the
+  # launcher diagnostic stream instead of capturing it as part of the path.
+  if ! herdr_world_install >&2; then
     herdr_world_manual_instructions
     return 1
   fi

--- a/scripts/herdr-world-launcher.test.mjs
+++ b/scripts/herdr-world-launcher.test.mjs
@@ -178,7 +178,7 @@ herdr_world_find_binary() { return 1; }
 herdr_world_find_installer_binary() { printf '/fake/herdr\\n'; }
 herdr_world_binary_is_supported() { return 0; }
 herdr_world_server_is_supported() { return 1; }
-herdr_world_install() { echo 'installed current Herdr' >&2; }
+herdr_world_install() { echo 'chatty official installer output'; }
 herdr_world_stop_herdr() {
   printf 'stopped <%s>\\n' "$1" >&2
   socket_ready=0
@@ -197,9 +197,11 @@ herdr_world_main --port 8795
   assert.equal(result.status, 0);
   assert.equal(result.stdout, "bridge <--port> <8795>\n");
   assert.match(result.stderr, /Download and run the official Herdr installer now\?/);
+  assert.match(result.stderr, /chatty official installer output/);
   assert.match(result.stderr, /Stop the incompatible Herdr server now\?/);
   assert.match(result.stderr, /Stopping it exits the/);
   assert.match(result.stderr, /stopped <\/fake\/herdr>/);
+  assert.doesNotMatch(result.stderr, /stopped <chatty official installer output/);
   assert.match(result.stderr, /Start Herdr now\?/);
   assert.match(result.stderr, /started <\/fake\/herdr> in <\/tmp\/project>/);
 });


### PR DESCRIPTION
Fixes guided installation when the official Herdr installer writes its banner and progress messages to stdout. Installer diagnostics are displayed on the launcher diagnostic stream, leaving stdout reserved for the resolved executable path. The regression uses a chatty installer stub and proves the exact binary path reaches server stop/start.

Validation:
- npm run check
- npm run test:release
- git diff --check