### PR TITLE
feat: install Herdr World as a user command

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,8 @@ on:
       - "scripts/live-stock-v082.sh"
       - "scripts/live-bridge-smoke.mjs"
       - "scripts/herdr-world-launcher.sh"
+      - "scripts/herdr-world-installer.sh"
+      - "scripts/herdr-world-installer.test.mjs"
       - "scripts/dependency-notices.mjs"
       - "scripts/stage-web-legal-assets.mjs"
       - "bridge/**"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 ### Added
 
+- Added a desktop `install` / `herdr-world-installer` entrypoint that installs the complete
+  versioned World bundle for the current user, exposes the `herdr-world` command, and then hands off
+  to the consent-based Herdr dependency setup.
+
 ### Changed
 
 ### Fixed
@@ -13,6 +17,9 @@
 - Bounded terminal resize traffic during rapid pane and Office conversation resizing, preventing
   resize/output feedback from stalling the page while retaining the latest terminal dimensions.
   [Herdr World PR #23](https://github.com/IvoryHeart/herdr-world/pull/23)
+- Treat stale default Herdr sockets as stopped instead of asking to stop a nonexistent daemon, wait
+  for an actually compatible server after startup, and print the World URL before the foreground
+  bridge begins serving.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Added a desktop `install` / `herdr-world-installer` entrypoint that installs the complete
   versioned World bundle for the current user, exposes the `herdr-world` command, and then hands off
   to the consent-based Herdr dependency setup.
+  [Herdr World PR #22](https://github.com/IvoryHeart/herdr-world/pull/22)
 
 ### Changed
 
@@ -20,6 +21,7 @@
 - Treat stale default Herdr sockets as stopped instead of asking to stop a nonexistent daemon, wait
   for an actually compatible server after startup, and print the World URL before the foreground
   bridge begins serving.
+  [Herdr World PR #22](https://github.com/IvoryHeart/herdr-world/pull/22)
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ else
 fi
 tar -xzf "herdr-world-${VERSION}-${PLATFORM}.tar.gz"
 cd "herdr-world-${VERSION}-${PLATFORM}"
-bin/herdr-world
+./install
 ```
 
 Open:
@@ -140,17 +140,23 @@ Open:
 http://127.0.0.1:8787
 ```
 
-The desktop tarball includes the web assets and `herdr-world-bridge`; it does not include Herdr.
+`./install` installs the complete versioned World bundle under `~/.local/share/herdr-world`, exposes
+`herdr-world` and `herdr-world-installer` under `~/.local/bin`, and continues into the consent-based
+Herdr dependency setup. The desktop tarball includes the web assets and `herdr-world-bridge`; it
+does not embed Herdr.
 The macOS binaries are not yet Developer ID signed or notarized. macOS may therefore require you to
 confirm the first launch in System Settings → Privacy & Security after you have verified the
 downloaded checksum and source. Signing and notarization will be added when project credentials are
 available.
-If the default Herdr session is missing or incompatible, an interactive `bin/herdr-world` launch
+If the default Herdr session is missing or incompatible, the installed `herdr-world` command
 explains the requirement and asks separately before downloading the [official Herdr
 installer](https://herdr.dev/docs/install/), stopping an incompatible detached server, or starting
 Herdr. Stopping a server exits the terminal panes and processes it owns. Before starting Herdr, the
 launcher asks for the directory containing the work you want Herdr to manage. Declining any action
 leaves that action undone and prints manual instructions.
+
+Use `./install --install-only` when installation and startup should be separate. The bundle remains
+portable: `bin/herdr-world` still runs directly without copying anything into the user directories.
 
 The launcher never performs guided setup in a non-interactive environment or when `--session`,
 `HERDR_SESSION`, or a socket override selects an operator-managed target. Pass
@@ -161,13 +167,13 @@ start Herdr yourself from a project directory, detach with <kbd>Ctrl</kbd>+<kbd>
 Use another unused port when needed:
 
 ```bash
-bin/herdr-world --port 8791
+herdr-world --port 8791
 ```
 
 If Herdr uses a non-default socket, provide it explicitly:
 
 ```bash
-HERDR_SOCKET_PATH=/path/to/herdr.sock bin/herdr-world --port 8791
+HERDR_SOCKET_PATH=/path/to/herdr.sock herdr-world --port 8791
 ```
 
 Android currently uses a locally built debug APK; no signed APK is included in the public RC.

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -35,7 +35,10 @@ and the corresponding CI steps are in place.
 
 ```text
 herdr-world-vX.Y.Z-PLATFORM/
+  install
+  VERSION
   bin/herdr-world
+  bin/herdr-world-installer
   bin/herdr-world-bridge
   share/herdr-world/web/
   third_party/licenses/
@@ -48,7 +51,13 @@ herdr-world-vX.Y.Z-PLATFORM/
   README.md
 ```
 
-`bin/herdr-world` points `herdr-world-bridge` at the bundled web assets. When the default Herdr
+`install` (also available as `bin/herdr-world-installer`) installs the versioned bundle under the
+user's local data directory and exposes `herdr-world` and `herdr-world-installer` under
+`~/.local/bin`. It then hands off to the installed application, whose Herdr dependency actions
+remain separately consented. `--install-only` performs only the local World installation.
+
+`bin/herdr-world` is the portable application launcher and points `herdr-world-bridge` at the
+bundled web assets. When the default Herdr
 session is missing or incompatible, it can run Herdr's official installer, stop an incompatible
 detached server, and start the current Herdr only after separate explicit consent for each action.
 The stop prompt warns that the server's panes and processes will exit. The launcher asks for a Herdr
@@ -109,8 +118,9 @@ matrix, then passes the internal `--notices-verified` assembly flag to avoid reb
 notice tool on every operating system. Local packaging omits that flag and therefore performs its
 own notice check.
 
-Confirm the archive contains the expected root directory, `bin/herdr-world`,
-`bin/herdr-world-bridge`, bundled `share/herdr-world/web/` assets, `LICENSE`,
+Confirm the archive contains the expected root directory, `install`, `VERSION`,
+`bin/herdr-world`, `bin/herdr-world-installer`, `bin/herdr-world-bridge`, bundled
+`share/herdr-world/web/` assets, `LICENSE`,
 `THIRD_PARTY_NOTICES.md`, `UPSTREAM.md`, the Apache/PixiJS license texts, the World asset
 record, complete production npm/Cargo licence inventories, the Herdr vendor
 manifest, and `README.md`. The bundled web tree must also contain its
@@ -161,19 +171,22 @@ dist-packages/herdr-world-vX.Y.Z-android.apk
 
 ## User Quick Start From Tarball
 
-Unpack and run. If necessary, the interactive launcher offers consent-based Herdr installation and
-startup:
+Unpack and install. The installer exposes the application command for the current user and then
+continues through consent-based Herdr installation and startup when necessary:
 
 ```bash
 tar -xzf herdr-world-vX.Y.Z-linux-x86_64.tar.gz
 cd herdr-world-vX.Y.Z-linux-x86_64
-bin/herdr-world
+./install
 ```
+
+For a portable run without installing World, use `bin/herdr-world`. To install the World commands
+without starting anything, use `./install --install-only`.
 
 To manage Herdr yourself or run from automation, start Herdr first and disable launcher prompts:
 
 ```bash
-HERDR_WORLD_SETUP=never bin/herdr-world
+HERDR_WORLD_SETUP=never herdr-world
 ```
 
 Open:

--- a/docs/release.md
+++ b/docs/release.md
@@ -87,7 +87,8 @@ Local desktop tarballs are written to `dist-packages/`. The debug APK is written
 
 Before uploading or distributing any tarball or APK, inspect the artifact and confirm it matches the
 documented release layout, platform, version, and source commit/tag. For desktop tarballs, list the
-archive contents and verify the wrapper, bridge binary, bundled `web/dist`, README, root license,
+archive contents and verify the root installer, named installer, version marker, wrapper, bridge
+binary, bundled `web/dist`, README, root license,
 third-party notices, upstream record, Apache/PixiJS license texts, generated production npm/Cargo
 licence inventories, World asset record, and Herdr vendor manifest are present.
 For APKs, inspect the package listing or metadata and verify the bundled
@@ -97,11 +98,15 @@ The macOS archives are intentionally unsigned and unnotarized until Developer ID
 available. Release notes and user documentation must retain that limitation. The workflow does not
 attempt to weaken Gatekeeper or modify a user's security policy.
 
-For the desktop launcher, verify `bin/herdr-world --help` never starts onboarding, a
+For the desktop installer, verify `./install --install-only` creates versioned user-local files and
+working `herdr-world`/`herdr-world-installer` command links without starting Herdr. Verify the
+normal `./install` path hands off to the installed launcher. For the desktop launcher, verify
+`bin/herdr-world --help` never starts onboarding, a
 non-interactive launch with no default Herdr socket fails with manual instructions, and an
 interactive missing-session launch asks independently before installation and startup. Also verify
 that an interactive incompatible default server asks independently before installation/update,
-server stop, and restart, while declining the stop leaves it running. Do not exercise the live
+server stop, and restart, while declining the stop leaves it running. A stale socket with no
+reachable daemon must proceed to startup without a stop prompt. Do not exercise the live
 installer during release verification; the launcher tests replace its network and process
 boundaries with deterministic fakes.
 

--- a/docs/tarball-readme.md
+++ b/docs/tarball-readme.md
@@ -12,20 +12,29 @@ The macOS archives are not yet Developer ID signed or notarized. After verifying
 checksum and source, macOS may require the first launch to be confirmed in System Settings →
 Privacy & Security. Signing and notarization will be added when project credentials are available.
 
-## Run
+## Install And Run
 
 From the unpacked bundle directory:
 
 ```bash
-bin/herdr-world
+./install
 ```
+
+This installs the complete versioned bundle under `~/.local/share/herdr-world`, exposes
+`herdr-world` and `herdr-world-installer` under `~/.local/bin`, and then continues into the
+consent-based Herdr setup and World startup. Use `./install --install-only` to stop after installing
+World. To keep the archive fully portable and install nothing, run `bin/herdr-world` directly.
 
 If the default Herdr session is missing or incompatible, an interactive launch offers to download
 and run the [official Herdr installer](https://herdr.dev/docs/install/), separately asks before
 stopping an incompatible detached server, then offers to start Herdr in a directory you select.
-Stopping a server exits its panes and processes. Nothing is installed, stopped, or started without
-an affirmative answer. Starting Herdr opens its terminal UI; detach with
+Stopping a server exits its panes and processes. Herdr is not installed, stopped, or started
+without an affirmative answer. Starting Herdr opens its terminal UI; detach with
 <kbd>Ctrl</kbd>+<kbd>B</kbd> then <kbd>Q</kbd> so this launcher can continue.
+
+A stale socket with no reachable server is treated as stopped and does not trigger the destructive
+stop prompt. Once the bridge starts, it remains in the foreground and prints the local World URL;
+press Ctrl+C to stop it.
 
 Guided setup is disabled for non-interactive launches, explicit `--session`/`HERDR_SESSION` targets,
 and socket overrides. Use `--no-herdr-setup` or `HERDR_WORLD_SETUP=never` to disable it for a

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "notices:generate": "node scripts/dependency-notices.mjs --generate",
     "notices:check": "node scripts/dependency-notices.mjs --check",
     "test:dev": "node --test scripts/dev.test.mjs",
-    "test:release": "node --test scripts/release-target.test.mjs scripts/release-version.test.mjs scripts/herdr-world-launcher.test.mjs",
+    "test:release": "node --test scripts/release-target.test.mjs scripts/release-version.test.mjs scripts/herdr-world-installer.test.mjs scripts/herdr-world-launcher.test.mjs",
     "test:pages": "node --test scripts/pages.test.mjs",
     "test:web": "npm run test --prefix web",
     "test:observability": "npm run test --prefix web -- observability.test.ts && cargo test --manifest-path bridge/Cargo.toml --bin herdr-web-bridge observability",

--- a/scripts/herdr-world-installer.sh
+++ b/scripts/herdr-world-installer.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+herdr_world_installer_resolve_script() {
+  local source="$1"
+  local link_dir=""
+  local link_target=""
+
+  while [[ -L "$source" ]]; do
+    link_dir="$(cd -P "$(dirname "$source")" && pwd)"
+    link_target="$(readlink "$source")"
+    case "$link_target" in
+      /*) source="$link_target" ;;
+      *) source="$link_dir/$link_target" ;;
+    esac
+  done
+
+  printf '%s\n' "$source"
+}
+
+herdr_world_installer_usage() {
+  cat <<'EOF'
+Usage: install [--install-only] [-- LAUNCHER_ARGS...]
+       herdr-world-installer [--install-only] [-- LAUNCHER_ARGS...]
+
+Installs this Herdr World bundle for the current user and exposes these commands:
+  ~/.local/bin/herdr-world
+  ~/.local/bin/herdr-world-installer
+
+Unless --install-only is supplied, the installed launcher then offers the
+consent-based Herdr installation/startup flow and starts Herdr World.
+
+Environment overrides:
+  HERDR_WORLD_INSTALL_ROOT  Versioned bundle base (default: ~/.local/share/herdr-world)
+  HERDR_WORLD_BIN_DIR       User command directory (default: ~/.local/bin)
+EOF
+}
+
+installer_path="$(herdr_world_installer_resolve_script "${BASH_SOURCE[0]}")"
+installer_dir="$(cd "$(dirname "$installer_path")" && pwd -P)"
+
+if [[ -f "$installer_dir/VERSION" && -x "$installer_dir/bin/herdr-world" ]]; then
+  bundle_root="$installer_dir"
+elif [[ -f "$installer_dir/../VERSION" && -x "$installer_dir/herdr-world" ]]; then
+  bundle_root="$(cd "$installer_dir/.." && pwd -P)"
+else
+  echo "This installer must be run from an unpacked Herdr World desktop bundle." >&2
+  exit 1
+fi
+
+version="$(tr -d '\r\n' < "$bundle_root/VERSION")"
+if [[ ! "$version" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+  echo "The desktop bundle contains an invalid VERSION value: $version" >&2
+  exit 1
+fi
+
+install_only=false
+launcher_args=()
+while (($# > 0)); do
+  case "$1" in
+    -h | --help)
+      herdr_world_installer_usage
+      exit 0
+      ;;
+    --install-only)
+      install_only=true
+      shift
+      ;;
+    --)
+      shift
+      launcher_args=("$@")
+      break
+      ;;
+    *)
+      echo "Unknown installer option: $1" >&2
+      herdr_world_installer_usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ "$install_only" == true && ${#launcher_args[@]} -gt 0 ]]; then
+  echo "Launcher arguments cannot be used with --install-only." >&2
+  exit 2
+fi
+
+if [[ -z "${HOME:-}" ]]; then
+  echo "Herdr World cannot determine the current user's home directory." >&2
+  exit 1
+fi
+
+data_home="${XDG_DATA_HOME:-$HOME/.local/share}"
+install_base="${HERDR_WORLD_INSTALL_ROOT:-$data_home/herdr-world}"
+command_dir="${HERDR_WORLD_BIN_DIR:-$HOME/.local/bin}"
+case "$install_base:$command_dir" in
+  /*:/*) ;;
+  *) echo "Herdr World installation directories must be absolute paths." >&2; exit 1 ;;
+esac
+
+mkdir -p "$install_base" "$command_dir"
+install_base="$(cd "$install_base" && pwd -P)"
+command_dir="$(cd "$command_dir" && pwd -P)"
+install_target="$install_base/$version"
+
+for command_name in herdr-world herdr-world-installer; do
+  command_path="$command_dir/$command_name"
+  if [[ -e "$command_path" && ! -L "$command_path" ]]; then
+    echo "Refusing to replace the existing non-symlink command: $command_path" >&2
+    echo "Move it aside or set HERDR_WORLD_BIN_DIR to another directory." >&2
+    exit 1
+  fi
+done
+
+bundle_real="$(cd "$bundle_root" && pwd -P)"
+target_real=""
+if [[ -d "$install_target" ]]; then
+  target_real="$(cd "$install_target" && pwd -P)"
+fi
+
+if [[ "$bundle_real" != "$target_real" ]]; then
+  if [[ -e "$install_target" || -L "$install_target" ]]; then
+    if [[ ! -d "$install_target" \
+      || ! -f "$install_target/VERSION" \
+      || "$(tr -d '\r\n' < "$install_target/VERSION")" != "$version" \
+      || ! -x "$install_target/bin/herdr-world" \
+      || ! -x "$install_target/bin/herdr-world-bridge" ]]; then
+      echo "Refusing to replace an unrecognized installation at $install_target." >&2
+      exit 1
+    fi
+  fi
+
+  stage="$(mktemp -d "$install_base/.install-$version.XXXXXX")"
+  backup=""
+  installed_new=false
+  committed=false
+  cleanup_install() {
+    local status=$?
+    if [[ "$committed" != true ]]; then
+      [[ -z "$stage" || ! -e "$stage" ]] || rm -rf -- "$stage"
+      if [[ "$installed_new" == true && -e "$install_target" ]]; then
+        rm -rf -- "$install_target"
+      fi
+      if [[ -n "$backup" && -e "$backup" ]]; then
+        mv "$backup" "$install_target"
+      fi
+    fi
+    return "$status"
+  }
+  trap cleanup_install EXIT
+
+  cp -R "$bundle_root/." "$stage/"
+  if [[ -e "$install_target" ]]; then
+    backup="$install_base/.previous-$version.$$"
+    [[ ! -e "$backup" ]] || { echo "Temporary backup path already exists: $backup" >&2; exit 1; }
+    mv "$install_target" "$backup"
+  fi
+  mv "$stage" "$install_target"
+  stage=""
+  installed_new=true
+
+  ln -sfn "$install_target/bin/herdr-world" "$command_dir/herdr-world"
+  ln -sfn "$install_target/bin/herdr-world-installer" "$command_dir/herdr-world-installer"
+
+  [[ -z "$backup" || ! -e "$backup" ]] || rm -rf -- "$backup"
+  backup=""
+  committed=true
+  trap - EXIT
+  echo "Installed Herdr World $version to $install_target"
+else
+  ln -sfn "$install_target/bin/herdr-world" "$command_dir/herdr-world"
+  ln -sfn "$install_target/bin/herdr-world-installer" "$command_dir/herdr-world-installer"
+  echo "Herdr World $version is already installed at $install_target"
+fi
+
+echo "Installed command: $command_dir/herdr-world"
+if [[ ":${PATH:-}:" != *":$command_dir:"* ]]; then
+  echo "Add $command_dir to PATH to run herdr-world by name in a new shell." >&2
+fi
+
+if [[ "$install_only" == true ]]; then
+  exit 0
+fi
+
+echo "Continuing with Herdr dependency setup and Herdr World startup." >&2
+exec "$install_target/bin/herdr-world" "${launcher_args[@]+"${launcher_args[@]}"}"

--- a/scripts/herdr-world-installer.test.mjs
+++ b/scripts/herdr-world-installer.test.mjs
@@ -1,0 +1,169 @@
+import assert from "node:assert/strict";
+import {
+  chmodSync,
+  cpSync,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readlinkSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const installerSource = resolve(root, "scripts/herdr-world-installer.sh");
+const launcherSource = resolve(root, "scripts/herdr-world-launcher.sh");
+
+function makeBundle(testRoot) {
+  const bundle = join(testRoot, "herdr-world-v0.0.0-test-linux-x86_64");
+  mkdirSync(join(bundle, "bin"), { recursive: true });
+  mkdirSync(join(bundle, "share/herdr-world/web"), { recursive: true });
+  writeFileSync(join(bundle, "VERSION"), "v0.0.0-test\n");
+  writeFileSync(join(bundle, "share/herdr-world/web/index.html"), "<!doctype html>\n");
+  cpSync(installerSource, join(bundle, "install"));
+  cpSync(installerSource, join(bundle, "bin/herdr-world-installer"));
+  cpSync(launcherSource, join(bundle, "bin/herdr-world"));
+  writeFileSync(
+    join(bundle, "bin/herdr-world-bridge"),
+    "#!/usr/bin/env bash\nprintf '<%s>\\n' \"$@\"\n",
+  );
+  for (const executable of [
+    "install",
+    "bin/herdr-world-installer",
+    "bin/herdr-world",
+    "bin/herdr-world-bridge",
+  ]) {
+    chmodSync(join(bundle, executable), 0o755);
+  }
+  return bundle;
+}
+
+function installerEnvironment(testRoot) {
+  const home = join(testRoot, "home");
+  const dataHome = join(home, ".local/share");
+  const commandDir = join(home, ".local/bin");
+  mkdirSync(home, { recursive: true });
+  return {
+    env: {
+      ...process.env,
+      HOME: home,
+      XDG_DATA_HOME: dataHome,
+      HERDR_WORLD_BIN_DIR: commandDir,
+      HERDR_CLIENT_SOCKET_PATH: "",
+      HERDR_SESSION: "",
+      HERDR_SOCKET_PATH: "",
+      HERDR_WORLD_SETUP: "auto",
+    },
+    commandDir,
+    installTarget: join(dataHome, "herdr-world/v0.0.0-test"),
+  };
+}
+
+test("the bundle installer creates versioned commands and the installed launcher resolves its assets", () => {
+  const testRoot = mkdtempSync(join(tmpdir(), "herdr-world-installer-test-"));
+  try {
+    const bundle = makeBundle(testRoot);
+    const { env, commandDir, installTarget } = installerEnvironment(testRoot);
+    const result = spawnSync("/bin/bash", [join(bundle, "install"), "--install-only"], {
+      cwd: testRoot,
+      encoding: "utf8",
+      env,
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /Installed Herdr World v0\.0\.0-test/);
+    assert.equal(existsSync(join(installTarget, "share/herdr-world/web/index.html")), true);
+    assert.equal(lstatSync(join(commandDir, "herdr-world")).isSymbolicLink(), true);
+    assert.equal(lstatSync(join(commandDir, "herdr-world-installer")).isSymbolicLink(), true);
+    assert.equal(
+      readlinkSync(join(commandDir, "herdr-world")),
+      join(installTarget, "bin/herdr-world"),
+    );
+
+    const launch = spawnSync(join(commandDir, "herdr-world"), ["--help"], {
+      cwd: testRoot,
+      encoding: "utf8",
+      env,
+    });
+    assert.equal(launch.status, 0, launch.stderr);
+    assert.equal(
+      launch.stdout,
+      `<--static-dir>\n<${join(installTarget, "share/herdr-world/web")}>\n<--help>\n`,
+    );
+
+    writeFileSync(join(bundle, "share/herdr-world/web/index.html"), "updated\n");
+    const reinstall = spawnSync("/bin/bash", [join(bundle, "install"), "--install-only"], {
+      cwd: testRoot,
+      encoding: "utf8",
+      env,
+    });
+    assert.equal(reinstall.status, 0, reinstall.stderr);
+    assert.equal(
+      readFileSync(join(installTarget, "share/herdr-world/web/index.html"), "utf8"),
+      "updated\n",
+    );
+
+    const installedRerun = spawnSync(
+      join(commandDir, "herdr-world-installer"),
+      ["--install-only"],
+      { cwd: testRoot, encoding: "utf8", env },
+    );
+    assert.equal(installedRerun.status, 0, installedRerun.stderr);
+    assert.match(installedRerun.stdout, /is already installed/);
+  } finally {
+    rmSync(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("the installer can hand off directly to the installed application command", () => {
+  const testRoot = mkdtempSync(join(tmpdir(), "herdr-world-installer-launch-test-"));
+  try {
+    const bundle = makeBundle(testRoot);
+    const { env, installTarget } = installerEnvironment(testRoot);
+    const result = spawnSync("/bin/bash", [join(bundle, "install"), "--", "--help"], {
+      cwd: testRoot,
+      encoding: "utf8",
+      env,
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stderr, /Continuing with Herdr dependency setup/);
+    assert.equal(
+      result.stdout.endsWith(
+        `<--static-dir>\n<${join(installTarget, "share/herdr-world/web")}>\n<--help>\n`,
+      ),
+      true,
+    );
+  } finally {
+    rmSync(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("the installer refuses to replace an unrelated command", () => {
+  const testRoot = mkdtempSync(join(tmpdir(), "herdr-world-installer-conflict-test-"));
+  try {
+    const bundle = makeBundle(testRoot);
+    const { env, commandDir, installTarget } = installerEnvironment(testRoot);
+    mkdirSync(commandDir, { recursive: true });
+    writeFileSync(join(commandDir, "herdr-world"), "unrelated\n");
+
+    const result = spawnSync("/bin/bash", [join(bundle, "install"), "--install-only"], {
+      cwd: testRoot,
+      encoding: "utf8",
+      env,
+    });
+
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /Refusing to replace the existing non-symlink command/);
+    assert.equal(existsSync(installTarget), false);
+  } finally {
+    rmSync(testRoot, { recursive: true, force: true });
+  }
+});

--- a/scripts/herdr-world-launcher.sh
+++ b/scripts/herdr-world-launcher.sh
@@ -1,7 +1,25 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-BIN_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+herdr_world_resolve_script() {
+  local source="$1"
+  local link_dir=""
+  local link_target=""
+
+  while [[ -L "$source" ]]; do
+    link_dir="$(cd -P "$(dirname "$source")" && pwd)"
+    link_target="$(readlink "$source")"
+    case "$link_target" in
+      /*) source="$link_target" ;;
+      *) source="$link_dir/$link_target" ;;
+    esac
+  done
+
+  printf '%s\n' "$source"
+}
+
+LAUNCHER_PATH="$(herdr_world_resolve_script "${BASH_SOURCE[0]}")"
+BIN_DIR="$(cd "$(dirname "$LAUNCHER_PATH")" && pwd)"
 BUNDLE_ROOT="$(cd "$BIN_DIR/.." && pwd)"
 BRIDGE_BIN="$BIN_DIR/herdr-world-bridge"
 STATIC_DIR="$BUNDLE_ROOT/share/herdr-world/web"
@@ -109,6 +127,20 @@ herdr_world_server_is_supported() {
     && [[ "$server_compatible" == "yes" ]]
 }
 
+herdr_world_server_is_reachable() {
+  local herdr_bin="$1"
+  local status_output=""
+  local server_state=""
+
+  status_output="$("$herdr_bin" status 2>/dev/null)" || return 1
+  server_state="$(printf '%s\n' "$status_output" | awk '
+    $0 == "server:" { in_server = 1; next }
+    in_server && $0 !~ /^  / { in_server = 0 }
+    in_server && $1 == "status:" { print $2; exit }
+  ')"
+  [[ "$server_state" == "running" ]]
+}
+
 herdr_world_is_interactive() {
   [[ -t 0 && -t 2 ]]
 }
@@ -135,7 +167,8 @@ Then start it from the directory containing the work you want Herdr to manage:
   cd /path/to/your/project
   herdr
 
-Detach from Herdr with Ctrl+B, then Q, and run bin/herdr-world again.
+Detach from Herdr with Ctrl+B, then Q, and run herdr-world again
+(or bin/herdr-world from a portable bundle).
 EOF
 }
 
@@ -187,7 +220,8 @@ Herdr is not installed or is not available on PATH.
 
 Herdr World can download ${HERDR_INSTALLER_URL} over HTTPS and run it locally.
 The official installer installs the latest stable Herdr (normally under ~/.local/bin)
-and verifies the downloaded Herdr binary checksum. It does not install Herdr World.
+and verifies the downloaded Herdr binary checksum. Herdr and Herdr World remain
+separate commands and installations.
 EOF
   fi
 
@@ -260,11 +294,11 @@ herdr_world_run_herdr() {
   )
 }
 
-herdr_world_wait_for_socket() {
-  local socket_path="$1"
+herdr_world_wait_for_server() {
+  local herdr_bin="$1"
   local attempt
   for attempt in {1..50}; do
-    if herdr_world_socket_ready "$socket_path"; then
+    if herdr_world_server_is_supported "$herdr_bin"; then
       return 0
     fi
     sleep 0.1
@@ -272,11 +306,11 @@ herdr_world_wait_for_socket() {
   return 1
 }
 
-herdr_world_wait_for_socket_to_stop() {
-  local socket_path="$1"
+herdr_world_wait_for_server_to_stop() {
+  local herdr_bin="$1"
   local attempt
   for attempt in {1..50}; do
-    if ! herdr_world_socket_ready "$socket_path"; then
+    if ! herdr_world_server_is_reachable "$herdr_bin"; then
       return 0
     fi
     sleep 0.1
@@ -291,6 +325,26 @@ herdr_world_stop_herdr() {
 
 herdr_world_exec_bridge() {
   exec "$BRIDGE_BIN" --static-dir "$STATIC_DIR" "$@"
+}
+
+herdr_world_start_bridge() {
+  local -a args=("$@")
+  local port="8787"
+  local index
+
+  for ((index = 0; index < ${#args[@]}; index += 1)); do
+    case "${args[$index]}" in
+      --port)
+        if ((index + 1 < ${#args[@]})); then
+          port="${args[$((index + 1))]}"
+        fi
+        ;;
+      --port=*) port="${args[$index]#--port=}" ;;
+    esac
+  done
+
+  echo "Herdr is running; starting Herdr World at http://127.0.0.1:$port (press Ctrl+C to stop)." >&2
+  herdr_world_exec_bridge "${args[@]+"${args[@]}"}"
 }
 
 herdr_world_main() {
@@ -349,8 +403,14 @@ herdr_world_main() {
     if herdr_bin="$(herdr_world_find_binary)" \
       && herdr_world_binary_is_supported "$herdr_bin" \
       && herdr_world_server_is_supported "$herdr_bin"; then
-      herdr_world_exec_bridge "${bridge_args[@]+"${bridge_args[@]}"}"
+      herdr_world_start_bridge "${bridge_args[@]+"${bridge_args[@]}"}"
       return
+    fi
+
+    if [[ -n "$herdr_bin" ]] \
+      && herdr_world_binary_is_supported "$herdr_bin" \
+      && ! herdr_world_server_is_reachable "$herdr_bin"; then
+      socket_is_ready=false
     fi
 
     # Preserve non-interactive and explicitly disabled behavior. The bridge
@@ -373,10 +433,20 @@ herdr_world_main() {
 
   if [[ "$socket_is_ready" == true ]]; then
     if herdr_world_server_is_supported "$herdr_bin"; then
-      herdr_world_exec_bridge "${bridge_args[@]+"${bridge_args[@]}"}"
+      herdr_world_start_bridge "${bridge_args[@]+"${bridge_args[@]}"}"
       return
     fi
 
+    if ! herdr_world_server_is_reachable "$herdr_bin"; then
+      socket_is_ready=false
+      cat >&2 <<EOF
+A stale Herdr socket was found at $default_socket, but no server is running.
+Continuing with normal Herdr startup.
+EOF
+    fi
+  fi
+
+  if [[ "$socket_is_ready" == true ]]; then
     cat >&2 <<EOF
 The running default Herdr server is incompatible with Herdr World.
 
@@ -392,8 +462,8 @@ EOF
       herdr_world_manual_instructions
       return 1
     fi
-    if ! herdr_world_wait_for_socket_to_stop "$default_socket"; then
-      echo "The incompatible Herdr server did not release $default_socket." >&2
+    if ! herdr_world_wait_for_server_to_stop "$herdr_bin"; then
+      echo "The incompatible Herdr server did not stop." >&2
       herdr_world_manual_instructions
       return 1
     fi
@@ -417,14 +487,13 @@ EOF
     echo "Herdr exited with an error; Herdr World was not started." >&2
     return 1
   fi
-  if ! herdr_world_wait_for_socket "$default_socket"; then
-    echo "Herdr returned, but no running session appeared at $default_socket." >&2
+  if ! herdr_world_wait_for_server "$herdr_bin"; then
+    echo "Herdr returned, but no compatible running session appeared at $default_socket." >&2
     herdr_world_manual_instructions
     return 1
   fi
 
-  echo "Herdr is running; starting Herdr World at http://127.0.0.1:8787." >&2
-  herdr_world_exec_bridge "${bridge_args[@]+"${bridge_args[@]}"}"
+  herdr_world_start_bridge "${bridge_args[@]+"${bridge_args[@]}"}"
 }
 
 if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then

--- a/scripts/herdr-world-launcher.test.mjs
+++ b/scripts/herdr-world-launcher.test.mjs
@@ -48,7 +48,7 @@ herdr_world_main --port 8791
 
   assert.equal(result.status, 0);
   assert.equal(result.stdout, "bridge <--port> <8791>\n");
-  assert.equal(result.stderr, "");
+  assert.match(result.stderr, /starting Herdr World at http:\/\/127\.0\.0\.1:8791/);
 });
 
 test("help and explicit connection targets never trigger guided setup", () => {
@@ -148,6 +148,7 @@ herdr_world_find_binary() {
 }
 herdr_world_find_installer_binary() { printf '/fake/herdr\\n'; }
 herdr_world_binary_is_supported() { return 0; }
+herdr_world_server_is_supported() { [[ "$socket_ready" == 1 ]]; }
 herdr_world_install() { installed=1; echo 'installed' >&2; }
 herdr_world_choose_workspace() { printf '/tmp/project\\n'; }
 herdr_world_run_herdr() {
@@ -171,22 +172,28 @@ test("an incompatible detached server is updated and restarted only with consent
   const result = runLauncher(
     `
 socket_ready=1
+server_reachable=1
+server_supported=0
 herdr_world_default_socket() { printf '/tmp/herdr.sock\\n'; }
 herdr_world_socket_ready() { [[ "$socket_ready" == 1 ]]; }
 herdr_world_is_interactive() { return 0; }
 herdr_world_find_binary() { return 1; }
 herdr_world_find_installer_binary() { printf '/fake/herdr\\n'; }
 herdr_world_binary_is_supported() { return 0; }
-herdr_world_server_is_supported() { return 1; }
+herdr_world_server_is_supported() { [[ "$server_supported" == 1 ]]; }
+herdr_world_server_is_reachable() { [[ "$server_reachable" == 1 ]]; }
 herdr_world_install() { echo 'chatty official installer output'; }
 herdr_world_stop_herdr() {
   printf 'stopped <%s>\\n' "$1" >&2
   socket_ready=0
+  server_reachable=0
 }
 herdr_world_choose_workspace() { printf '/tmp/project\\n'; }
 herdr_world_run_herdr() {
   printf 'started <%s> in <%s>\\n' "$1" "$2" >&2
   socket_ready=1
+  server_reachable=1
+  server_supported=1
 }
 herdr_world_exec_bridge() { printf 'bridge'; printf ' <%s>' "$@"; printf '\\n'; }
 herdr_world_main --port 8795
@@ -215,6 +222,7 @@ herdr_world_is_interactive() { return 0; }
 herdr_world_find_binary() { printf '/fake/herdr\\n'; }
 herdr_world_binary_is_supported() { return 0; }
 herdr_world_server_is_supported() { return 1; }
+herdr_world_server_is_reachable() { return 0; }
 herdr_world_stop_herdr() { echo 'unexpected stop' >&2; }
 herdr_world_exec_bridge() { echo 'unexpected bridge start' >&2; }
 herdr_world_main
@@ -226,6 +234,71 @@ herdr_world_main
   assert.match(result.stderr, /Stop the incompatible Herdr server now\?/);
   assert.doesNotMatch(result.stderr, /unexpected stop/);
   assert.doesNotMatch(result.stderr, /unexpected bridge start/);
+});
+
+test("a stale default socket starts Herdr without attempting to stop a server", () => {
+  const result = runLauncher(
+    `
+socket_ready=1
+server_supported=0
+herdr_world_default_socket() { printf '/tmp/stale-herdr.sock\\n'; }
+herdr_world_socket_ready() { [[ "$socket_ready" == 1 ]]; }
+herdr_world_is_interactive() { return 0; }
+herdr_world_find_binary() { return 1; }
+herdr_world_find_installer_binary() { printf '/fake/herdr\\n'; }
+herdr_world_binary_is_supported() { return 0; }
+herdr_world_server_is_supported() { [[ "$server_supported" == 1 ]]; }
+herdr_world_server_is_reachable() { return 1; }
+herdr_world_install() { echo 'installed Herdr' >&2; }
+herdr_world_stop_herdr() { echo 'unexpected stop' >&2; return 1; }
+herdr_world_choose_workspace() { printf '/tmp/project\\n'; }
+herdr_world_run_herdr() {
+  printf 'started <%s> in <%s>\\n' "$1" "$2" >&2
+  server_supported=1
+}
+herdr_world_exec_bridge() { printf 'bridge'; printf ' <%s>' "$@"; printf '\\n'; }
+herdr_world_main --port 8796
+`,
+    "y\ny\n",
+  );
+
+  assert.equal(result.status, 0);
+  assert.equal(result.stdout, "bridge <--port> <8796>\n");
+  assert.doesNotMatch(result.stderr, /Stop the incompatible Herdr server/);
+  assert.doesNotMatch(result.stderr, /unexpected stop/);
+  assert.match(result.stderr, /installed Herdr/);
+  assert.match(result.stderr, /stale Herdr socket/);
+  assert.match(result.stderr, /Start Herdr now\?/);
+  assert.match(result.stderr, /started <\/fake\/herdr> in <\/tmp\/project>/);
+});
+
+test("server reachability parses Herdr status instead of trusting its exit code", () => {
+  const result = runLauncher(`
+fake_herdr() {
+  cat <<'EOF'
+client:
+  version: 0.8.2
+server:
+  status: not running
+  socket: /tmp/stale.sock
+EOF
+}
+if herdr_world_server_is_reachable fake_herdr; then exit 21; fi
+fake_herdr() {
+  cat <<'EOF'
+client:
+  version: 0.8.2
+server:
+  status: running
+  version: 0.8.2
+  protocol: 20
+  compatible: yes
+EOF
+}
+herdr_world_server_is_reachable fake_herdr
+`);
+
+  assert.equal(result.status, 0);
 });
 
 test("supported Herdr version parsing is bounded to v0.8.2 or newer", () => {

--- a/scripts/package-tarball.sh
+++ b/scripts/package-tarball.sh
@@ -79,7 +79,14 @@ cp -R "$ROOT/third_party/." "$STAGE/third_party/"
 cp "$ROOT/docs/world-assets.md" "$STAGE/docs/world-assets.md"
 cp "$ROOT/vendor/herdr-compat/VENDOR-MANIFEST.toml" "$STAGE/vendor/herdr-compat/VENDOR-MANIFEST.toml"
 cp "$ROOT/scripts/herdr-world-launcher.sh" "$STAGE/bin/herdr-world"
-chmod +x "$STAGE/bin/herdr-world" "$STAGE/bin/herdr-world-bridge"
+cp "$ROOT/scripts/herdr-world-installer.sh" "$STAGE/bin/herdr-world-installer"
+cp "$ROOT/scripts/herdr-world-installer.sh" "$STAGE/install"
+printf '%s\n' "$VERSION" > "$STAGE/VERSION"
+chmod +x \
+  "$STAGE/install" \
+  "$STAGE/bin/herdr-world" \
+  "$STAGE/bin/herdr-world-installer" \
+  "$STAGE/bin/herdr-world-bridge"
 
 (
   cd "$PKG_ROOT"

--- a/scripts/verify-desktop-package.sh
+++ b/scripts/verify-desktop-package.sh
@@ -51,7 +51,10 @@ tar -xzf "$ARCHIVE" -C "$VERIFY_ROOT"
 BUNDLE="$VERIFY_ROOT/$NAME"
 
 required=(
+  "install"
+  "VERSION"
   "bin/herdr-world"
+  "bin/herdr-world-installer"
   "bin/herdr-world-bridge"
   "share/herdr-world/web/index.html"
   "share/herdr-world/web/legal/manifest.json"
@@ -72,7 +75,13 @@ for relative_path in "${required[@]}"; do
     exit 1
   }
 done
+[[ "$(tr -d '\r\n' < "$BUNDLE/VERSION")" == "$VERSION" ]] || {
+  echo "desktop archive VERSION does not match $VERSION" >&2
+  exit 1
+}
+[[ -x "$BUNDLE/install" ]] || { echo "root installer is not executable" >&2; exit 1; }
 [[ -x "$BUNDLE/bin/herdr-world" ]] || { echo "launcher is not executable" >&2; exit 1; }
+[[ -x "$BUNDLE/bin/herdr-world-installer" ]] || { echo "named installer is not executable" >&2; exit 1; }
 [[ -x "$BUNDLE/bin/herdr-world-bridge" ]] || { echo "bridge is not executable" >&2; exit 1; }
 
 binary_description="$(file "$BUNDLE/bin/herdr-world-bridge")"
@@ -125,6 +134,23 @@ host_arch="$(uname -m)"
 case "$PLATFORM:$host_os:$host_arch" in
   linux-x86_64:Linux:x86_64 | macos-arm64:Darwin:arm64 | macos-x86_64:Darwin:x86_64)
     "$BUNDLE/bin/herdr-world" --help >/dev/null
+    installer_home="$VERIFY_ROOT/installer-home"
+    installer_bin="$installer_home/.local/bin"
+    installer_data="$installer_home/.local/share"
+    HOME="$installer_home" \
+      XDG_DATA_HOME="$installer_data" \
+      HERDR_WORLD_BIN_DIR="$installer_bin" \
+      PATH="$installer_bin:$PATH" \
+      /bin/bash "$BUNDLE/install" --install-only >/dev/null
+    [[ -L "$installer_bin/herdr-world" ]] || {
+      echo "bundle installer did not expose herdr-world" >&2
+      exit 1
+    }
+    [[ -L "$installer_bin/herdr-world-installer" ]] || {
+      echo "bundle installer did not expose herdr-world-installer" >&2
+      exit 1
+    }
+    "$installer_bin/herdr-world" --help >/dev/null
     launcher_home="$VERIFY_ROOT/launcher-home"
     launcher_output="$VERIFY_ROOT/launcher-no-session.log"
     mkdir -p "$launcher_home/config"


### PR DESCRIPTION
## Summary

- add `install` / `herdr-world-installer` as the desktop distribution entrypoint
- install versioned World assets under the user local data directory and expose `herdr-world` in `~/.local/bin`
- preserve `bin/herdr-world` as a portable application launcher
- treat stale Herdr sockets as stopped by parsing `herdr status`
- wait for a compatible daemon after startup and print the foreground bridge URL

## Validation

- `npm run check`
- `npm run test:release` (24 tests)
- real Linux archive build and `scripts/verify-desktop-package.sh`
- embedded installer, reinstall, installed symlink, portable launcher, stale socket, and command-conflict coverage
- Linux, macOS ARM64, and macOS x86_64 package/live-smoke CI
