### PR TITLE
Document Herdr World plugin release design

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 ### Fixed
 
+- Bounded terminal resize traffic during rapid pane and Office conversation resizing, preventing
+  resize/output feedback from stalling the page while retaining the latest terminal dimensions.
+  [Herdr World PR #23](https://github.com/IvoryHeart/herdr-world/pull/23)
+
 ### Removed
 
 ## [0.1.0-rc.1] - 2026-08-26

--- a/docs/analysis/herdr-plugin-release-analysis-2026-08-26.md
+++ b/docs/analysis/herdr-plugin-release-analysis-2026-08-26.md
@@ -1,0 +1,413 @@
+# Herdr World plugin release analysis
+
+- **Date:** 2026-08-26
+- **Status:** Research complete; implementation not started
+- **Repository:** `IvoryHeart/herdr-world`
+- **Current application release:** `v0.1.0-rc.1`
+- **Current Herdr compatibility:** `v0.8.2` or newer with terminal protocol `20`
+- **Decision record:** [Spec 016](../specs/016-herdr-world-plugin-release-spec.md)
+
+## Executive conclusion
+
+Herdr World can be released through Herdr's plugin ecosystem, but it should
+not be rewritten as a Herdr-native terminal pane. The viable product shape is:
+
+```text
+Herdr plugin manifest and actions
+        │
+        │ build, start, stop, status, open, restart
+        v
+Herdr World bridge service
+        │
+        │ HTTP/WebSocket
+        v
+Browser, PWA, or Android client
+```
+
+The Herdr plugin is a thin registration and lifecycle facade. The existing
+React/Pixi application and Rust bridge remain the product. The bridge should
+run as a separately supervised user process so that it survives Herdr detach,
+client restarts, and Herdr server restarts.
+
+This refines, rather than reverses, the earlier architectural conclusion that
+the full World application is a downstream distribution and not a browser
+plugin platform. The distinction is important:
+
+- **Herdr World as a product** remains a standalone downstream application.
+- **Herdr World as a Herdr plugin release** means adding a plugin facade that
+  builds and controls that application.
+- The existing browser surfaces remain compiled application surfaces, not
+  dynamically registered Herdr UI surfaces.
+
+## Upstream plugin model
+
+The [official Herdr plugin documentation](https://herdr.dev/docs/plugins/)
+defines a plugin as a directory containing `herdr-plugin.toml` and executable
+commands. Required top-level metadata is:
+
+- `id`
+- `name`
+- `version`
+- `min_herdr_version`
+
+Optional manifest entrypoints include:
+
+- `[[build]]` commands, run during GitHub installation;
+- `[[actions]]`, invoked through `herdr plugin action invoke`;
+- `[[startup]]` hooks, which are one-shot restoration hooks;
+- `[[events]]` hooks;
+- `[[panes]]`, which launch terminal processes; and
+- `[[link_handlers]]`, which route modified terminal URL clicks to actions.
+
+There is no separate SDK or restricted plugin API. Plugin commands can call
+the full Herdr CLI or socket API. Herdr injects `HERDR_SOCKET_PATH`,
+`HERDR_BIN_PATH`, plugin identity, config/state directories, and invocation
+context. The [socket API documentation](https://herdr.dev/docs/socket-api/)
+lists the canonical plugin methods and public runtime methods.
+
+Important constraints:
+
+1. Plugin v1 has no native non-terminal browser UI extension point.
+2. A plugin pane is a terminal process, not a React/WebView surface.
+3. Startup hooks are not supervised daemons.
+4. Plugins run as the installing user, inherit their environment, and are not
+   sandboxed.
+5. Herdr owns plugin registration, but plugins own their implementation,
+   dependencies, config format, state, and cleanup.
+
+These constraints rule out making the Pixel Office or Spaces UI itself a
+`[[panes]]` entrypoint. They support a plugin action that starts the existing
+web bridge.
+
+## Current ecosystem
+
+The ecosystem is active and includes more than simple shell helpers. At the
+time of this analysis:
+
+- the [Herdr marketplace](https://herdr.dev/plugins/) reported 762 plugins
+  across 749 repositories;
+- GitHub's [`herdr-plugin` topic](https://github.com/topics/herdr-plugin)
+  reported 833 public repositories; and
+- the marketplace automatically discovers public repositories with the
+  `herdr-plugin` topic and a parseable manifest. It refreshes approximately
+  every 30 minutes, has no submission queue, and is not a reviewed catalog.
+
+Observed ecosystem categories include:
+
+- terminal TUIs such as file viewers, sidebars, fuzzy navigators, and Git
+  tools;
+- workflow and worktree automation;
+- agent orchestration and lifecycle reporting;
+- browser and CDP integrations;
+- remote and mobile clients; and
+- external-service dashboards.
+
+Two projects are especially relevant:
+
+- [Collie](https://github.com/AltanS/collie) is a PWA plus a Herdr bridge. Its
+  [architecture record](https://github.com/AltanS/collie/blob/main/ARCHITECTURE.md)
+  explicitly keeps the Herdr plugin thin and runs the bridge under
+  `systemd --user` or `launchd`. Its
+  [manifest](https://raw.githubusercontent.com/AltanS/collie/main/herdr-plugin.toml)
+  uses `[[build]]` and lifecycle `[[actions]]`, without a plugin pane or
+  startup daemon.
+- [Neon for Herdr](https://github.com/neon-solutions/neon-herdr) demonstrates
+  the other major pattern: an application that is genuinely suitable for a
+  managed terminal pane. Its Ink dashboard is not analogous to Herdr World's
+  browser-first React/Pixi surface, but its build, config, action, and release
+  conventions are useful references.
+
+The ecosystem therefore supports Herdr World conceptually, but the precedent
+for a browser client says to use a thin action facade and an independently
+managed service.
+
+## Fit assessment
+
+| Current Herdr World component | Plugin treatment | Decision |
+| --- | --- | --- |
+| React/Vite Spaces and Pixel Office | Continue serving from `web/dist` | Reuse unchanged |
+| Rust HTTP/WebSocket bridge | Start as a user service | Reuse with a plugin-specific controller |
+| Herdr socket connection | Pass the invoking `HERDR_SOCKET_PATH` into the service | Preserve the existing authority boundary |
+| Current exact protocol-20 guard | Keep `/api/capabilities` and bridge validation | Required; manifest version alone is insufficient |
+| Browser multi-bridge federation | Keep in the browser | Do not add a second Herdr plugin registry |
+| Android shell | Remains a companion client | Android is not a Herdr plugin host |
+| Launcher onboarding | Keep for desktop tarballs | Do not run interactive setup from plugin actions |
+| `[[panes]]` | Do not use for the primary UI | A terminal pane cannot host the current app |
+| `[[startup]]` | Do not use for bridge supervision | Startup hooks are one-shot |
+| `[[events]]` | Avoid initially | The bridge already consumes Herdr events for live activity |
+| `[[actions]]` | Use for lifecycle and diagnostics | Best plugin integration surface |
+
+## Recommended packaging decision
+
+### First release: manifest in this repository
+
+Add a root-level `herdr-plugin.toml` to `IvoryHeart/herdr-world`. This gives
+users a direct installation command and keeps the plugin source, bridge, web
+assets, compatibility crate, tests, and existing desktop release process in
+one source tree:
+
+```bash
+herdr plugin install IvoryHeart/herdr-world
+```
+
+Use an owner-qualified ID to avoid a collision with future official or
+third-party names. A likely ID is:
+
+```text
+ivoryheart.herdr-world
+```
+
+The first manifest should advertise only the platforms that this repository
+currently releases and tests:
+
+```toml
+id = "ivoryheart.herdr-world"
+name = "Herdr World"
+version = "0.1.0-rc.1"
+min_herdr_version = "0.8.2"
+description = "Browser and mobile client for monitoring and controlling Herdr agents."
+platforms = ["linux", "macos"]
+
+[[build]]
+command = ["bash", "scripts/herdr-world-plugin.sh", "build"]
+
+[[actions]]
+id = "start"
+title = "Start Herdr World"
+contexts = ["workspace"]
+command = ["bash", "scripts/herdr-world-plugin.sh", "start"]
+
+[[actions]]
+id = "stop"
+title = "Stop Herdr World"
+contexts = ["workspace"]
+command = ["bash", "scripts/herdr-world-plugin.sh", "stop"]
+
+[[actions]]
+id = "restart"
+title = "Restart Herdr World"
+contexts = ["workspace"]
+command = ["bash", "scripts/herdr-world-plugin.sh", "restart"]
+
+[[actions]]
+id = "status"
+title = "Herdr World status"
+contexts = ["workspace"]
+command = ["bash", "scripts/herdr-world-plugin.sh", "status"]
+
+[[actions]]
+id = "open"
+title = "Open Herdr World"
+contexts = ["workspace"]
+command = ["bash", "scripts/herdr-world-plugin.sh", "open"]
+```
+
+The manifest is a design sketch, not yet a validated or committed interface.
+The plugin ID, action set, and versioning policy still need owner approval.
+
+### Later option: separate plugin repository
+
+A separate `herdr-world-plugin` repository could eventually provide a smaller
+installer that downloads a versioned Herdr World desktop archive and verifies
+its checksum. That would make plugin installation faster and avoid requiring
+Rust on end-user machines, but it introduces another repository, release
+coordination, artifact-download logic, and a second public version surface.
+
+It should be considered only after the source-build plugin has established the
+runtime contract. The existing desktop tarballs already make a binary-first
+path possible; they do not make it necessary for the first plugin release.
+
+### Rejected option: rewrite as a native plugin pane
+
+This would require replacing the browser application with a terminal UI or a
+terminal-graphics implementation. It would lose or substantially compromise
+the current responsive browser UI, Pixel Office canvas, multi-bridge browser
+federation, and Android client. It is a different product, not a packaging
+conversion.
+
+## Required plugin controller
+
+The repository needs a new controller, tentatively
+`scripts/herdr-world-plugin.sh`. It should be separate from the current
+desktop bundle launcher because `scripts/herdr-world-launcher.sh` assumes the
+tarball layout (`bin/` and `share/herdr-world/web/`) and contains interactive
+Herdr setup behavior.
+
+The controller should:
+
+1. derive its repository root from its own path;
+2. use `HERDR_PLUGIN_CONFIG_DIR` for user-editable settings;
+3. use `HERDR_PLUGIN_STATE_DIR` for PIDs, service metadata, and session records;
+4. accept the injected `HERDR_SOCKET_PATH` for the Herdr session that invoked
+   the action;
+5. default to `127.0.0.1` and require explicit configuration for LAN access;
+6. start one bridge per Herdr runtime/session, with collision-safe ports;
+7. use `systemd --user` on Linux and `launchd` on macOS where available;
+8. provide a carefully checked unsupervised fallback only when no user
+   supervisor exists;
+9. probe `/api/capabilities` after starting instead of treating process launch
+   as readiness;
+10. print the local URL, target session, Herdr compatibility, and remote access
+    posture; and
+11. use `HERDR_BIN_PATH` for any controller calls back into Herdr rather than
+    assuming that `herdr` is on the action process's `PATH`.
+
+Suggested actions are `start`, `stop`, `restart`, `status`, `open`, and
+`doctor`. `url` and `logs` may be useful once the service implementation is
+settled. An `update` action should be considered because Herdr v1 has no
+separate plugin update command, but it must be designed around managed
+checkouts being replaced on reinstall.
+
+## Session and lifecycle model
+
+The current application architecture intentionally has one bridge per Herdr
+runtime. The plugin must preserve that rule.
+
+An action invoked inside a Herdr session receives that session's socket path.
+The controller should persist a service record keyed by a normalized or hashed
+socket identity, containing at least:
+
+- socket path or session name;
+- HTTP bind address and port;
+- plugin checkout path used by the service;
+- service-manager identity;
+- bridge PID or readiness metadata; and
+- current application/plugin version.
+
+The default session can use the existing `127.0.0.1:8787` convention. Named
+sessions need either an explicitly configured port or deterministic allocation
+from a safe range. Starting the same profile twice must be idempotent and must
+not start a second bridge on the same port.
+
+The browser's existing multi-bridge settings can then connect to multiple
+plugin-managed bridge instances. The plugin must not create a fleet registry
+or replace the browser's existing host profile owner.
+
+## Build and dependency strategy
+
+### Initial source-build path
+
+The first plugin release can reuse the repository's locked dependency trees
+and existing release build steps:
+
+```text
+npm ci --prefix web
+npm run build:web
+cargo build --release --manifest-path bridge/Cargo.toml --bin herdr-web-bridge
+```
+
+The manifest should call one controller build action so local linking and
+GitHub installation share the same build definition. Herdr runs build commands
+during `plugin install`, but does not install Node, Rust, Cargo, or other
+toolchains. The plugin README must state the requirements clearly.
+
+The current root `package.json` and `web/package.json` intentionally remain at
+`0.0.0`; repository release tags are currently tracked through `release.json`
+and public README/Pages references. Adding a plugin manifest creates a real
+versioned package contract, so release automation must explicitly stamp and
+validate its `version` field without accidentally turning npm package versions
+into publishing versions.
+
+### Future binary-first path
+
+After the source-build path is stable, a controller can select the current
+platform/architecture, download the matching Herdr World release tarball, and
+verify its published SHA-256 file before extracting the bridge and web assets.
+This should use immutable release tags or commits and fail closed on unknown
+platforms or checksum mismatches.
+
+The binary-first path must also solve managed-checkout replacement, service
+restart, version reporting, and release/tag synchronization. It is a release
+optimization, not a prerequisite for plugin compatibility.
+
+## Security requirements
+
+The current bridge grants admitted browser clients terminal-equivalent control.
+The plugin must make that fact prominent in its install and setup documentation.
+
+Required defaults and safeguards:
+
+- bind loopback by default;
+- never infer LAN exposure from the presence of a plugin action;
+- require explicit host/origin configuration for non-loopback binding;
+- preserve the existing Host, Origin, CSP, upload, and capability checks;
+- do not describe Host/Origin checks as authentication;
+- recommend an operator-managed VPN, SSH forward, Tailscale, or authenticated
+  reverse proxy for remote use;
+- keep credentials and durable state out of the managed plugin checkout; and
+- make service stop/uninstall behavior explicit so uninstalling a plugin cannot
+  leave an unmanaged bridge with access to the Herdr socket.
+
+The Herdr marketplace is an automatic, unreviewed index. A marketplace listing
+does not imply a security review or endorsement. This is especially important
+for Herdr World because its bridge is intentionally capable of terminal input,
+pane mutation, uploads, and agent control.
+
+## Release workflow
+
+The first plugin-enabled release should follow this sequence:
+
+1. Approve the plugin identity, name, platform scope, and version policy.
+2. Add `herdr-plugin.toml` and the plugin controller.
+3. Add config/state/service lifecycle tests for Linux and macOS.
+4. Test local development with `herdr plugin link` and verify that the build
+   path is explicit because Herdr does not run `[[build]]` for local links.
+5. Test GitHub-style installation from a release ref with Herdr `v0.8.2`.
+6. Test default and named Herdr sessions, duplicate starts, restarts, stale
+   sockets, incompatible protocol values, and port collisions.
+7. Run the existing repository checks and the existing packaged desktop smoke
+   suite against a stock Herdr `v0.8.2` daemon reporting protocol `20`.
+8. Extend release stamping and validation to check the manifest version,
+   `min_herdr_version`, platform list, and release tag.
+9. Add plugin installation, configuration, update, uninstall, and security
+   guidance to the README and packaging/release documentation.
+10. Add the GitHub topic `herdr-plugin` to the public repository.
+11. Release from the final tagged commit, then wait for the marketplace index
+    refresh and verify the listing metadata.
+
+The marketplace installation form will be:
+
+```bash
+herdr plugin install IvoryHeart/herdr-world
+```
+
+For reproducible installs, documentation should show a release ref:
+
+```bash
+herdr plugin install IvoryHeart/herdr-world --ref vX.Y.Z
+```
+
+Herdr has no dedicated v1 plugin update command; refreshing a GitHub-managed
+plugin is done by reinstalling it. The controller and documentation must make
+the required service restart and managed-checkout behavior unambiguous.
+
+## Open decisions for the next implementation tranche
+
+- Approve `ivoryheart.herdr-world` or choose another plugin ID.
+- Decide whether the first plugin version follows the application release tag
+  exactly, including prerelease identifiers.
+- Decide whether `start` means “current invoking session only” or whether the
+  first release also exposes explicit named-session profiles.
+- Choose generated `systemd --user`/`launchd` service files versus a smaller
+  PID-managed fallback as the initial implementation scope.
+- Decide whether `open` should launch the default browser or only print the
+  URL, particularly for headless and remote hosts.
+- Confirm the release policy for source builds versus prebuilt release assets.
+- Confirm that Linux and macOS are the only advertised plugin platforms until
+  Windows bridge/service testing exists.
+
+## Sources and related repository decisions
+
+- [Herdr plugin documentation](https://herdr.dev/docs/plugins/)
+- [Herdr marketplace documentation](https://herdr.dev/docs/marketplace/)
+- [Herdr plugin marketplace](https://herdr.dev/plugins/)
+- [Herdr socket API](https://herdr.dev/docs/socket-api/)
+- [Herdr CLI reference](https://herdr.dev/docs/cli-reference/)
+- [GitHub `herdr-plugin` topic](https://github.com/topics/herdr-plugin)
+- [Collie architecture precedent](https://github.com/AltanS/collie/blob/main/ARCHITECTURE.md)
+- [Collie plugin manifest](https://raw.githubusercontent.com/AltanS/collie/main/herdr-plugin.toml)
+- [Neon for Herdr](https://github.com/neon-solutions/neon-herdr)
+- [Existing Herdr World architecture](../architecture.md)
+- [Existing Herdr World packaging](../packaging.md)
+- [Existing Herdr World release process](../release.md)
+- [Earlier upstream/plugin reassessment](upstream-plugin-surface-reassessment-2026-08-20.md)

--- a/docs/development.md
+++ b/docs/development.md
@@ -170,23 +170,9 @@ curl -fsS http://127.0.0.1:8787/api/snapshot
   the browser console; the Office E2E coverage asserts that the renderer
   produces a live canvas.
 
-## Temporary CI warning
+## Resize behavior
 
-The Office conversation resize test in
-`tests/e2e/world.spec.ts` is temporarily skipped when the `CI` environment
-variable is `true`. It still runs in local E2E runs. This is an explicit
-containment measure for intermittent CI instability; the root cause has not
-been identified and the skip must not be treated as a permanent pass.
-
-Local manual verification currently shows the related product behavior is
-usable: the conversation window follows the resize immediately, then the
-inner Ghostty canvas refits after a short catch-up interval and may blink once.
-This smoothing work is tracked separately as
-[SUG-028](suggestions.md#sug-028--smooth-office-terminal-refit-during-resize).
-It should be addressed together with the CI investigation rather than hidden
-behind a broader product-level resize change.
-
-Re-enable the test after a reproducible CI trace identifies and fixes the
-ResizeObserver, animation-frame, pointer/keyboard, viewport, or terminal-canvas
-timing issue involved. This note keeps the containment visible next to the
-local test workflow.
+Terminal rendering still refits on the next animation frame while a pane or
+Office conversation is resized. Browser-to-bridge terminal resize messages
+are coalesced to the latest cell dimensions and capped at one message per
+50 ms, preventing rapid layout/output feedback from stalling the page.

--- a/docs/specs/016-herdr-world-plugin-release-spec.md
+++ b/docs/specs/016-herdr-world-plugin-release-spec.md
@@ -1,0 +1,570 @@
+# Herdr World plugin distribution and lifecycle facade
+
+- **Spec ID:** `016-herdr-world-plugin-release`
+- **Status:** Draft
+- **Created:** 2026-08-27
+- **Owner:** IvoryHeart / Herdr World
+- **Reviewers:** IvoryHeart (repository owner)
+- **Approved by:** —
+- **Approved at:** —
+
+> This document may be edited only while its status is `Draft` or `In review`.
+> After approval it is immutable. After implementation completes, record
+> delivery and drift in `016-herdr-world-plugin-release-spec-summary.md`; put
+> later intended changes in a numbered extension.
+
+## 1. Purpose
+
+Herdr World currently ships as a downstream browser/mobile application with a
+Rust HTTP/WebSocket bridge. Users must build or unpack that application and
+start the bridge independently of Herdr. This specification defines the
+smallest Herdr plugin integration that makes the existing application
+installable and operable through Herdr's plugin ecosystem without changing its
+browser-first product shape.
+
+The outcome is a public Herdr plugin that builds the existing web assets and
+bridge, starts one bridge service for the invoking Herdr runtime, reports its
+state, and gives the user a URL for the browser or PWA client. The existing
+desktop tarball and Android distribution remain supported products.
+
+The companion research and ecosystem record is
+[Herdr plugin release analysis](../analysis/herdr-plugin-release-analysis-2026-08-26.md).
+The integration relies on the [Herdr plugin manifest and runtime contract](https://herdr.dev/docs/plugins/),
+the [Herdr socket/CLI API](https://herdr.dev/docs/socket-api/), and the
+[automatic marketplace listing rules](https://herdr.dev/docs/marketplace/).
+
+## 2. Scope
+
+This feature includes:
+
+- a root-level `herdr-plugin.toml` in this repository;
+- plugin metadata for `ivoryheart.herdr-world`, versioned with the application
+  release version and requiring Herdr `0.8.2` or newer;
+- Linux and macOS plugin support, matching the currently tested desktop
+  release platforms;
+- a plugin controller at `scripts/herdr-world-plugin.sh`;
+- an install-time source build using the repository's existing web and Cargo
+  dependency trees;
+- lifecycle and diagnostic actions for starting, stopping, restarting,
+  inspecting, opening, and diagnosing the bridge;
+- service state and editable configuration stored outside the managed plugin
+  checkout;
+- one bridge instance per Herdr runtime/session, using the invoking
+  `HERDR_SOCKET_PATH` unless an explicitly configured session target is used;
+- loopback-safe defaults, explicit remote-access configuration, readiness
+  probing, and actionable diagnostics;
+- automated controller tests and manual Herdr plugin install/link smoke tests;
+- release validation that keeps the manifest version aligned with the tagged
+  application release; and
+- documentation for installation, configuration, actions, upgrades,
+  uninstall, security, and the relationship to the existing tarballs and
+  Android client.
+
+## 3. Non-goals
+
+- Rewriting Pixel Office, Spaces, or the React/Pixi application as a terminal
+  UI or a Herdr `[[panes]]` entrypoint.
+- Adding a WebView, browser surface registry, or native non-terminal plugin UI
+  to Herdr.
+- Making Herdr responsible for supervising a long-running bridge through a
+  `[[startup]]` hook. Startup hooks are one-shot initialization commands, not
+  daemon supervisors.
+- Replacing the browser's existing multi-bridge federation or creating a
+  second host/session registry in the plugin.
+- Turning Android into a Herdr plugin host. Android remains a companion client
+  that connects to a configured bridge.
+- Removing or changing the desktop tarball launcher, its consent-based Herdr
+  setup behavior, or its documented artifact layout.
+- Shipping a separate binary-download plugin repository in the first
+  implementation tranche.
+- Supporting Windows before the bridge controller and service lifecycle are
+  implemented and tested on that platform.
+- Adding plugin-owned credentials, authentication, or a claim that Host,
+  Origin, and CSP checks authenticate browser users.
+- Adding plugin event hooks, link handlers, or a persistent terminal pane in
+  the initial release. These can be separately specified if a concrete use
+  case emerges.
+
+## 4. Context and constraints
+
+### Existing application boundary
+
+Herdr World is an independent downstream application. The bridge currently
+owns the Herdr socket connection and exposes the browser API at a configured
+HTTP/WebSocket address. The browser already supports multiple bridge profiles;
+the plugin must provide one predictable bridge endpoint rather than duplicate
+that federation logic.
+
+The current bridge requires Herdr `v0.8.2` or newer and exact terminal protocol
+`20`. The plugin manifest's `min_herdr_version` is only an installation gate;
+the bridge's existing runtime version/protocol admission remains authoritative.
+
+### Herdr plugin constraints
+
+Herdr plugins are ordinary user code. Build and runtime commands are argv
+arrays, run with the installing user's permissions, and are not sandboxed.
+Herdr runs `[[build]]` commands during GitHub installation but does not run
+them for `plugin link`; local authors build linked checkouts themselves. Herdr
+injects `HERDR_BIN_PATH`, `HERDR_SOCKET_PATH`, plugin config/state directories,
+and invocation context into runtime commands. Plugin-managed source checkouts
+are replaceable and must not contain durable user data.
+
+The first manifest is intentionally an action facade. The existing browser
+application cannot be represented by a terminal pane, and a terminal pane's
+lifecycle is unsuitable for a bridge that should survive Herdr client detach,
+browser reload, or Herdr server handoff.
+
+### Release and repository constraints
+
+The repository's public application release tag is the source of truth. Root
+and web npm package versions remain `0.0.0` because this repository does not
+publish npm packages. The release helper currently stamps `release.json`,
+README, and Pages references, so plugin version stamping must be added as an
+explicit release concern rather than inferred from npm metadata.
+
+The current desktop tarball builds the same web assets and bridge but does not
+include Herdr. Plugin installation likewise requires a compatible Herdr
+installation and local toolchains for the initial source-build path.
+
+## 5. Requirements
+
+### Requirement: Provide a valid root plugin manifest
+
+The repository SHALL contain a root `herdr-plugin.toml` with the following
+initial contract:
+
+| Field | Required value |
+| --- | --- |
+| `id` | `ivoryheart.herdr-world` |
+| `name` | `Herdr World` |
+| `version` | current application version without the leading `v` |
+| `min_herdr_version` | `0.8.2` |
+| `platforms` | `["linux", "macos"]` |
+| `[[build]]` | invokes `bash scripts/herdr-world-plugin.sh build` |
+| action commands | invoke the same controller with the action name |
+
+The manifest SHALL declare the `start`, `stop`, `restart`, `status`, `open`,
+and `doctor` actions with `contexts = ["workspace"]`. The manifest SHALL NOT
+declare a primary `[[panes]]`, `[[startup]]`, or `[[events]]` entry in the
+initial release.
+
+#### Scenario: Herdr parses the manifest
+
+- **GIVEN** a supported Herdr installation and the repository checkout
+- **WHEN** the user runs `herdr plugin link` or installs the repository from
+  GitHub
+- **THEN** Herdr accepts the manifest, exposes all six actions, and reports no
+  missing required metadata or unsupported platform declaration.
+
+#### Scenario: An unsupported Herdr version is used
+
+- **GIVEN** a Herdr binary older than `0.8.2`
+- **WHEN** the user attempts to link or install Herdr World
+- **THEN** Herdr refuses the plugin using its normal minimum-version error
+  before any plugin build or runtime action executes.
+
+### Requirement: Build the existing application from the plugin checkout
+
+The `build` controller action SHALL build the web distribution and release
+bridge from the plugin checkout using the repository's existing lockfiles and
+targets. It SHALL perform the equivalent of:
+
+```text
+npm ci --prefix web
+npm run build:web
+cargo build --release --manifest-path bridge/Cargo.toml --bin herdr-web-bridge
+```
+
+The build SHALL fail closed if Node.js, npm, Rust, Cargo, lockfiles, or a
+required dependency is unavailable. It SHALL not download or install a
+toolchain on the user's behalf. The resulting paths SHALL be deterministic:
+
+- web assets: `web/dist/`;
+- bridge binary: `bridge/target/release/herdr-web-bridge`.
+
+The source-build path SHALL preserve the repository's existing legal asset
+staging and dependency-notice expectations. It SHALL not modify generated
+outputs outside the plugin checkout's normal build directories.
+
+#### Scenario: A GitHub installation builds successfully
+
+- **GIVEN** a clean checkout, Node.js 22 or newer, npm, Rust stable, and a
+  compatible Herdr installation
+- **WHEN** Herdr runs the manifest build command during `plugin install`
+- **THEN** the web assets and release bridge are produced at the documented
+  paths and the plugin is registered only after the build succeeds.
+
+#### Scenario: Local linking is used
+
+- **GIVEN** a linked checkout with no prebuilt web assets or release bridge
+- **WHEN** the user invokes an action
+- **THEN** the controller prints that local linking does not run manifest build
+  commands and provides the exact build command; it does not silently run a
+  partial or debug build.
+
+### Requirement: Start one bridge for one Herdr runtime
+
+The `start` action SHALL:
+
+1. Resolve the target socket from the invocation's `HERDR_SOCKET_PATH`, unless
+   the user has explicitly configured a named session or socket target.
+2. Use the release bridge and `web/dist` from the plugin checkout.
+3. Bind to `127.0.0.1` by default on port `8787` for the default profile.
+4. Allocate or validate a distinct port for another concurrently managed
+   runtime; it SHALL never attach a second bridge to the same service record.
+5. Pass the target session/socket and bridge security options explicitly to the
+   bridge rather than relying on the controller's ambient working directory.
+6. Store a service record keyed by a stable, non-secret identity for the
+   Herdr runtime/session.
+7. Start under `systemd --user` on Linux and `launchd` on macOS when the
+   applicable user supervisor is available.
+8. Use a bounded, checked process fallback only when no supported user
+   supervisor is available.
+9. Wait for `/api/capabilities` and verify the expected Herdr version/protocol
+   and web compatibility before reporting success.
+10. Print the bridge URL, target session, bridge/Herdr compatibility, and
+    whether the endpoint is loopback-only or remotely exposed.
+
+The controller SHALL be idempotent. If a healthy matching service already
+exists, `start` SHALL report it and return success without spawning another
+bridge. If a recorded service is stale or incompatible, it SHALL not kill an
+unrelated process; it SHALL either recover the owned service or return an
+actionable diagnostic.
+
+#### Scenario: First start uses the invoking session
+
+- **GIVEN** a running Herdr session and its injected
+  `HERDR_SOCKET_PATH`, with no World service record
+- **WHEN** the user invokes the `start` action
+- **THEN** the controller starts one bridge against that socket, waits for a
+  successful capability probe, records the endpoint, and prints a usable local
+  URL.
+
+#### Scenario: Start is repeated
+
+- **GIVEN** a healthy bridge owned by the current plugin profile
+- **WHEN** the user invokes `start` again
+- **THEN** the controller returns success, reports the existing endpoint, and
+  leaves the original bridge and service record intact.
+
+#### Scenario: The Herdr socket is unavailable
+
+- **GIVEN** no usable target socket for the selected profile
+- **WHEN** the user invokes `start`
+- **THEN** the controller fails before claiming readiness, names the selected
+  target, explains how to start/select Herdr, and does not leave a running
+  bridge process behind.
+
+### Requirement: Expose safe lifecycle actions
+
+The controller SHALL implement these action behaviors:
+
+| Action | Behavior |
+| --- | --- |
+| `start` | Ensure the selected bridge is running and ready; print its endpoint. |
+| `stop` | Stop only the selected plugin-owned service; succeed idempotently when absent. |
+| `restart` | Stop and start the selected service, then verify readiness. |
+| `status` | Report service ownership, target, pid/supervisor state, endpoint, and capability state without starting anything. |
+| `open` | Ensure the service is ready, print the URL, and request the platform default browser when one is available; remain usable on headless hosts. |
+| `doctor` | Run non-destructive checks for platform, tools, Herdr target, build outputs, config, state, service ownership, port, and capability compatibility. |
+
+Action output SHALL be human-readable by default and SHALL never print
+credentials, full socket contents, or arbitrary environment values. Failures
+SHALL identify the failed check and a bounded next action. `stop`, `restart`,
+and uninstall guidance SHALL state that stopping the bridge disconnects
+browser clients but does not stop the Herdr server or its panes.
+
+#### Scenario: Stop cannot target an unrelated process
+
+- **GIVEN** a service record whose pid or command no longer matches the
+  controller's recorded bridge identity
+- **WHEN** the user invokes `stop`
+- **THEN** the controller refuses to signal that process, reports stale state,
+  and leaves the unrelated process untouched.
+
+#### Scenario: Open runs without a desktop browser
+
+- **GIVEN** a ready bridge on a headless host
+- **WHEN** the user invokes `open`
+- **THEN** the controller prints the URL and remote-access posture without
+  treating the absence of `xdg-open` or `open` as a bridge failure.
+
+### Requirement: Keep configuration and state outside the managed checkout
+
+The controller SHALL use Herdr's injected `HERDR_PLUGIN_CONFIG_DIR` for
+editable configuration and `HERDR_PLUGIN_STATE_DIR` for service records,
+supervisor metadata, logs/pointers, and migration state. It SHALL create
+directories with user-only permissions where the platform supports them.
+
+Configuration SHALL support, at minimum:
+
+- bind host, default port or a safe port range;
+- optional explicit Herdr session/socket target;
+- static asset and upload directory overrides only when explicitly needed;
+- allowed hosts/origins for non-loopback use; and
+- optional bridge label.
+
+The controller SHALL validate ports, paths, session names, hosts, origins, and
+platform values before launching the bridge. It SHALL not write editable
+configuration, credentials, or durable runtime records under
+`HERDR_PLUGIN_ROOT`.
+
+#### Scenario: A managed checkout is replaced
+
+- **GIVEN** a configured plugin whose GitHub installation is reinstalled
+- **WHEN** Herdr replaces the managed plugin checkout
+- **THEN** the controller retains the user's config/state, detects any service
+  whose executable path changed, and provides a safe restart or migration
+  result rather than silently running deleted code.
+
+### Requirement: Preserve bridge security posture
+
+The plugin SHALL default to loopback binding and SHALL require explicit host
+and origin configuration for any non-loopback bind. It SHALL pass those values
+through the bridge's existing validation; it SHALL not weaken upload limits,
+Host/Origin checks, CSP, capability checks, or protocol admission.
+
+The plugin documentation and action diagnostics SHALL state that an admitted
+browser has terminal-equivalent control and that Host, Origin, and CSP checks
+are not authentication. Remote use SHALL recommend an operator-managed
+authenticated reverse proxy, VPN, SSH forwarding, or equivalent access
+boundary.
+
+#### Scenario: LAN exposure is requested incompletely
+
+- **GIVEN** a configuration binding to a non-loopback host without explicit
+  allowed host and origin values
+- **WHEN** `start` or `doctor` evaluates the configuration
+- **THEN** it fails before starting or exposing the bridge and names both
+  required classes of configuration.
+
+#### Scenario: Default configuration is used
+
+- **GIVEN** no host or origin override
+- **WHEN** `start` launches the bridge
+- **THEN** it binds to loopback only and reports that posture in its output.
+
+### Requirement: Align plugin and application release versions
+
+The release process SHALL treat the plugin manifest version as a public
+release reference. Before a release commit is created, validation SHALL prove
+that:
+
+- the manifest version equals the application release version without `v`;
+- `min_herdr_version` and the advertised platform list are intentional;
+- all declared controller entrypoints exist and are executable;
+- the release tag can install the plugin from GitHub; and
+- no npm package publication is implied.
+
+The release documentation SHALL explain both installation forms:
+
+```bash
+herdr plugin install IvoryHeart/herdr-world
+herdr plugin install IvoryHeart/herdr-world --ref vX.Y.Z
+```
+
+It SHALL explain that the first release uses source builds, requires Node.js
+22 and Rust, local linking does not run build commands, and reinstalling is
+Herdr v1's refresh mechanism for a GitHub-managed plugin. The repository SHALL
+add the GitHub topic `herdr-plugin` only when the manifest and install flow
+are ready for public discovery.
+
+#### Scenario: A release version drifts
+
+- **GIVEN** `release.json`, the manifest, or a public release reference names
+  different versions
+- **WHEN** release validation runs
+- **THEN** it fails with the mismatched paths and does not create or publish a
+  release commit or tag.
+
+### Requirement: Preserve standalone distributions
+
+The plugin changes SHALL not require the desktop tarball or Android client to
+install the plugin. Existing tarball packaging SHALL continue to use its
+bundled `bin/herdr-world` launcher and `bin/herdr-world-bridge`; plugin
+actions SHALL use the source checkout's `web/dist` and release bridge.
+
+Documentation SHALL distinguish:
+
+- the Herdr plugin as a lifecycle/install facade;
+- the browser/PWA as the main World client;
+- the Android application as a companion client; and
+- the desktop tarball as an independently usable distribution.
+
+#### Scenario: Existing tarball packaging is checked
+
+- **GIVEN** the plugin manifest and controller are present
+- **WHEN** the documented desktop packaging check runs
+- **THEN** the tarball still contains its documented files, does not require a
+  plugin-managed checkout, and its launcher behavior remains unchanged.
+
+## 6. Data and interface contract
+
+### Manifest contract
+
+The initial manifest has one build entry and six workspace-scoped action
+entries. All commands SHALL be argv arrays and SHALL invoke the controller by
+path. The controller SHALL derive the repository root from its own location,
+so its behavior does not depend on Herdr's current working directory.
+
+The manifest version is a SemVer value without the leading release-tag `v`.
+The Git tag and application release metadata retain their existing `v` prefix.
+Prerelease identifiers are allowed and SHALL be copied exactly between the
+release tag and manifest version.
+
+### Controller invocation contract
+
+The controller SHALL accept exactly:
+
+```text
+build | start | stop | restart | status | open | doctor
+```
+
+Unknown or missing commands SHALL return a usage error without side effects.
+Runtime actions SHALL use `HERDR_BIN_PATH` for calls back into Herdr and SHALL
+honor `HERDR_SOCKET_PATH` as the default target. The controller SHALL not
+assume `herdr` is on `PATH` and SHALL not parse human-oriented Herdr output
+when a stable CLI/socket response is available.
+
+### Service record contract
+
+Each managed runtime record SHALL be stored as a versioned, atomically written
+file under `HERDR_PLUGIN_STATE_DIR`. The schema SHALL include at least:
+
+```json
+{
+  "schema_version": 1,
+  "target_identity": "opaque-stable-profile-id",
+  "session_name": "default",
+  "socket_path": "/path/to/herdr.sock",
+  "host": "127.0.0.1",
+  "port": 8787,
+  "url": "http://127.0.0.1:8787",
+  "bridge_path": "/managed/checkout/bridge/target/release/herdr-web-bridge",
+  "static_dir": "/managed/checkout/web/dist",
+  "supervisor": "systemd-user|launchd|fallback",
+  "service_name": "opaque-owned-service-name",
+  "pid": 12345,
+  "application_version": "0.1.0-rc.1",
+  "herdr_protocol": 20,
+  "updated_at": "RFC-3339 timestamp"
+}
+```
+
+The exact identity derivation, filename, supervisor unit/plist contents, and
+config file format are implementation details, but they SHALL be documented
+and tested. Socket paths and records are local control data; diagnostics must
+redact them when full disclosure is not required.
+
+### Readiness contract
+
+`start` and `restart` are successful only after an HTTP request to the selected
+bridge's `/api/capabilities` returns a valid response with the expected bridge
+API/web compatibility and Herdr terminal protocol `20`. A listening TCP port
+or live process without a valid capability response is not readiness.
+
+## 7. Privacy and security
+
+- Plugin installation and build commands execute arbitrary repository code as
+  the installing user. README and install documentation SHALL direct users to
+  inspect the manifest and controller before confirming installation.
+- The marketplace topic and listing are discovery metadata, not a security
+  review or endorsement.
+- No secret may be placed in the manifest, plugin checkout, service command
+  line, or ordinary action output.
+- Config/state directories SHALL be user-scoped and excluded from repository
+  commits and release archives.
+- Non-loopback binding SHALL be opt-in and visibly reported.
+- The plugin SHALL stop or orphan-check its own bridge during uninstall
+  guidance so uninstall cannot knowingly leave a bridge with access to the
+  Herdr socket.
+- The controller SHALL use bounded timeouts for process startup, readiness,
+  stop, supervisor operations, and HTTP probes.
+- The controller SHALL not broaden bridge command exposure; command and
+  parameter allow-lists remain bridge-owned in `web_bridge.rs`.
+
+## 8. Acceptance evidence
+
+Implementation is complete only when the pull request contains the following
+evidence:
+
+### Static and unit validation
+
+- manifest parsing/validation tests cover required metadata, action IDs,
+  platform fields, version alignment, and missing entrypoints;
+- controller tests cover argument validation, config/state paths, atomic
+  records, port allocation, idempotent start, stale ownership, readiness
+  failure, redaction, and security defaults;
+- Linux supervisor behavior is tested with deterministic fakes for
+  `systemd --user`, and macOS behavior with deterministic fakes for `launchd`;
+- fallback supervision is tested for bounded shutdown and stale-process
+  refusal;
+- release tests cover manifest version stamping and mismatch failure; and
+- `git diff --check`, `npm run test:release`, and the repository's normal
+  `npm run check` pass when the implementation is complete.
+
+### Herdr integration smoke
+
+Against a local Herdr `v0.8.2` daemon reporting terminal protocol `20`, the
+implementation SHALL demonstrate:
+
+1. `herdr plugin link` followed by an explicit local build;
+2. GitHub-style installation from a release ref;
+3. action listing and invocation;
+4. first start, repeated start, status, open, restart, and stop;
+5. browser load through the reported URL;
+6. terminal attach, snapshot, event observation, input, resize, scrolling,
+   upload, pane operations, and World surface load;
+7. two browser clients attached to the same bridge;
+8. two distinct Herdr sessions with isolated service records and ports;
+9. incompatible protocol, missing socket, stale process, and port collision
+   failures; and
+10. uninstall/refresh behavior with service cleanup and retained config/state.
+
+The existing `npm run check:acceptance` and packaged desktop smoke suite remain
+required. Plugin-specific tests may use fakes for supervisors and HTTP probes,
+but the final smoke must use an unmodified compatible Herdr daemon.
+
+### Marketplace readiness
+
+Before adding the public `herdr-plugin` topic, confirm from a clean default
+branch that:
+
+- the root manifest parses with the minimum supported Herdr;
+- a reviewer can inspect every build/runtime command;
+- source-build prerequisites and security posture are documented;
+- the default branch contains the versioned manifest and controller; and
+- `herdr plugin install IvoryHeart/herdr-world --ref vX.Y.Z` succeeds for the
+  tagged release.
+
+## 9. Deferred decisions
+
+These choices do not block the architecture or initial implementation, but an
+implementation PR SHALL record its selected value in the delivery summary:
+
+- the exact config file format (`key=value`, TOML, or another small format);
+- the deterministic named-session port allocation range and whether named
+  sessions are exposed in the first user-facing documentation;
+- the exact `systemd --user` unit and `launchd` label naming scheme;
+- whether `open` uses only platform browser helpers or supports an explicit
+  `HERDR_WORLD_BROWSER` override;
+- whether `logs` and `url` become separate actions or remain part of `status`
+  and diagnostics;
+- whether the first public plugin release advertises the current prerelease
+  tag or waits for a stable application release; and
+- the later binary-first installer that downloads and checksum-verifies the
+  existing desktop artifacts.
+
+The following are intentionally not deferred: the thin-facade architecture,
+root-repository manifest, plugin ID, source-build-first strategy, loopback
+default, Herdr protocol-20 gate, external config/state ownership, and Linux/
+macOS-only initial platform scope.
+
+## Related repository documentation
+
+- [Herdr World plugin release analysis](../analysis/herdr-plugin-release-analysis-2026-08-26.md)
+- [World packaging and upstream boundaries](004-world-packaging-and-upstream-boundaries-spec.md)
+- [Development](../development.md)
+- [Packaging](../packaging.md)
+- [Release process](../release.md)
+- [Architecture](../architecture.md)

--- a/docs/suggestions.md
+++ b/docs/suggestions.md
@@ -547,10 +547,11 @@ of hidden requirements.
   resize instability.
 - **Owner:** Open
 - **Added:** 2026-08-11
-- **Current slice:** The embedded terminal's ResizeObserver path now refits on
-  the next animation frame, removing the extra trailing debounce that made the
-  inner canvas visibly lag the outer Office window. The renderer scene-build
-  guard remains a separate follow-up if field use still exposes a delay.
+- **Current slice:** The embedded terminal's ResizeObserver path still refits on
+  the next animation frame, while browser-to-bridge resize messages coalesce to
+  the latest cell dimensions and are capped at one message per 50 ms. This keeps
+  the inner canvas aligned with the outer Office window without allowing resize
+  traffic and terminal output to stall the page.
 - **Related:** [`008-office-productivity-ux-spec.md`](specs/008-office-productivity-ux-spec.md)
 
 ## Parked or declined

--- a/tests/e2e/world.spec.ts
+++ b/tests/e2e/world.spec.ts
@@ -566,10 +566,6 @@ test("deduplicates terminal windows and stops at the five-window Office cap", as
 test("moves and resizes the Office conversation bubble without losing its live anchors", async ({
   page,
 }) => {
-  test.skip(
-    process.env.CI === "true",
-    "Temporarily muted in CI: intermittent Office resize instability has no identified root cause; this test continues to run locally. See docs/development.md.",
-  );
   test.setTimeout(45_000);
   await page.setViewportSize({ width: 1440, height: 900 });
   await page.goto("/world");

--- a/web/src/TerminalView.tsx
+++ b/web/src/TerminalView.tsx
@@ -35,6 +35,7 @@ import {
 } from "./terminalSelection";
 import { GhosttyRenderer } from "./terminalRenderer";
 import type { MobileTerminalTouchEvent, TerminalRenderer, TerminalSize } from "./terminalRenderer";
+import { createTerminalResizeScheduler } from "./terminalResizeTransport";
 import {
   appendTerminalInputBatch,
   drainTerminalInputBatch,
@@ -759,6 +760,13 @@ export function TerminalView({
     let reconnectStopped = false;
     const reconnectScheduledForSocket = new Set<number>();
     const pendingForegroundReasons = new Set<ReconnectReason>();
+    const resizeScheduler = createTerminalResizeScheduler((size) => {
+      if (!resizeEnabledRef.current || socket?.readyState !== WebSocket.OPEN) {
+        return false;
+      }
+      socket.send(JSON.stringify({ type: "resize", cols: size.cols, rows: size.rows }));
+      return true;
+    });
 
     const debugReconnect = (event: string, details: Record<string, unknown> = {}) => {
       if (DEBUG_TERMINAL_RECONNECT) {
@@ -788,9 +796,10 @@ export function TerminalView({
     };
 
     const sendResize = (size: TerminalSize) => {
-      if (resizeEnabledRef.current && socket?.readyState === WebSocket.OPEN) {
-        socket.send(JSON.stringify({ type: "resize", cols: size.cols, rows: size.rows }));
+      if (!resizeEnabledRef.current || socket?.readyState !== WebSocket.OPEN) {
+        return;
       }
+      resizeScheduler.submit(size);
     };
     sendResizeRef.current = sendResize;
 
@@ -800,6 +809,7 @@ export function TerminalView({
       if (socketRef.current === current) {
         socketRef.current = null;
       }
+      resizeScheduler.reset();
       current?.close();
     };
 
@@ -938,6 +948,7 @@ export function TerminalView({
           socketRef.current = null;
         }
         socket = null;
+        resizeScheduler.reset();
         if (lastCloseReason) {
           console.warn("terminal websocket closed", lastCloseReason);
         }
@@ -1157,6 +1168,7 @@ export function TerminalView({
       clearReconnectTimer();
       clearConnectTimer();
       clearForegroundCoalesceTimer();
+      resizeScheduler.reset();
       closeActiveSocket();
       sendResizeRef.current = () => {};
     };

--- a/web/src/terminalResizeTransport.test.ts
+++ b/web/src/terminalResizeTransport.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  createTerminalResizeScheduler,
+  sameTerminalResize,
+  TERMINAL_RESIZE_SEND_INTERVAL_MS,
+} from "./terminalResizeTransport";
+
+describe("terminal resize transport", () => {
+  it("compares terminal cell sizes rather than host pixels", () => {
+    expect(sameTerminalResize({ cols: 80, rows: 24 }, { cols: 80, rows: 24 })).toBe(true);
+    expect(sameTerminalResize({ cols: 80, rows: 24 }, { cols: 81, rows: 24 })).toBe(false);
+    expect(sameTerminalResize(null, { cols: 80, rows: 24 })).toBe(false);
+  });
+
+  it("sends the latest dimensions at a bounded rate", () => {
+    let time = 100;
+    const timerRef: { current: (() => void) | null } = { current: null };
+    const sent: Array<{ cols: number; rows: number }> = [];
+    const scheduler = createTerminalResizeScheduler(
+      (size) => {
+        sent.push(size);
+      },
+      {
+        now: () => time,
+        setTimeout: (callback) => {
+          timerRef.current = callback;
+          return 1;
+        },
+        clearTimeout: () => {
+          timerRef.current = null;
+        },
+      },
+    );
+
+    scheduler.submit({ cols: 80, rows: 24 });
+    time += 10;
+    scheduler.submit({ cols: 81, rows: 24 });
+    time += 10;
+    scheduler.submit({ cols: 82, rows: 24 });
+    expect(sent).toEqual([{ cols: 80, rows: 24 }]);
+    expect(timerRef.current).not.toBeNull();
+
+    time += TERMINAL_RESIZE_SEND_INTERVAL_MS - 20;
+    timerRef.current?.();
+    expect(sent).toEqual([
+      { cols: 80, rows: 24 },
+      { cols: 82, rows: 24 },
+    ]);
+  });
+
+  it("drops duplicates and clears stale pending work on reset", () => {
+    let time = 0;
+    const scheduled = vi.fn<(callback: () => void, delayMs: number) => number>(() => 1);
+    const canceled = vi.fn<(timer: number) => void>();
+    const sent: Array<{ cols: number; rows: number }> = [];
+    const scheduler = createTerminalResizeScheduler(
+      (size) => {
+        sent.push(size);
+      },
+      {
+        now: () => time,
+        setTimeout: scheduled,
+        clearTimeout: canceled,
+      },
+    );
+
+    scheduler.submit({ cols: 80, rows: 24 });
+    time = 1;
+    scheduler.submit({ cols: 81, rows: 24 });
+    scheduler.submit({ cols: 80, rows: 24 });
+    expect(scheduled).toHaveBeenCalledTimes(1);
+    expect(canceled).toHaveBeenCalledTimes(1);
+
+    scheduler.submit({ cols: 82, rows: 24 });
+    scheduler.reset();
+    expect(canceled).toHaveBeenCalledTimes(2);
+    expect(sent).toEqual([{ cols: 80, rows: 24 }]);
+  });
+});

--- a/web/src/terminalResizeTransport.ts
+++ b/web/src/terminalResizeTransport.ts
@@ -1,0 +1,94 @@
+export type TerminalResize = {
+  cols: number;
+  rows: number;
+};
+
+/**
+ * Keep terminal resize traffic from outrunning the daemon while retaining the
+ * latest dimensions for the next send. The renderer can still refit every
+ * animation frame; this only rate-limits the network side effect.
+ */
+export const TERMINAL_RESIZE_SEND_INTERVAL_MS = 50;
+
+type TerminalResizeSchedulerOptions = {
+  intervalMs?: number;
+  now?: () => number;
+  setTimeout?: (callback: () => void, delayMs: number) => number;
+  clearTimeout?: (timer: number) => void;
+};
+
+export function sameTerminalResize(
+  left: TerminalResize | null,
+  right: TerminalResize | null,
+): boolean {
+  return Boolean(left && right && left.cols === right.cols && left.rows === right.rows);
+}
+
+export function createTerminalResizeScheduler(
+  send: (size: TerminalResize) => boolean | void,
+  {
+    intervalMs = TERMINAL_RESIZE_SEND_INTERVAL_MS,
+    now = () => performance.now(),
+    setTimeout = (callback, delayMs) => window.setTimeout(callback, delayMs),
+    clearTimeout = (timer) => window.clearTimeout(timer),
+  }: TerminalResizeSchedulerOptions = {},
+) {
+  let lastSent: TerminalResize | null = null;
+  let lastSentAt: number | null = null;
+  let pending: TerminalResize | null = null;
+  let timer: number | null = null;
+
+  const clearTimer = () => {
+    if (timer !== null) {
+      clearTimeout(timer);
+      timer = null;
+    }
+  };
+
+  const flush = () => {
+    timer = null;
+    if (!pending) {
+      return;
+    }
+
+    const currentTime = now();
+    const remainingMs = lastSentAt === null
+      ? 0
+      : intervalMs - (currentTime - lastSentAt);
+    if (remainingMs > 0) {
+      timer = setTimeout(flush, remainingMs);
+      return;
+    }
+
+    const next = pending;
+    pending = null;
+    if (sameTerminalResize(lastSent, next)) {
+      return;
+    }
+    if (send(next) === false) {
+      return;
+    }
+    lastSent = next;
+    lastSentAt = currentTime;
+  };
+
+  return {
+    submit(size: TerminalResize) {
+      if (sameTerminalResize(lastSent, size)) {
+        pending = null;
+        clearTimer();
+        return;
+      }
+      pending = { ...size };
+      if (timer === null) {
+        flush();
+      }
+    },
+    reset() {
+      pending = null;
+      lastSent = null;
+      lastSentAt = null;
+      clearTimer();
+    },
+  };
+}


### PR DESCRIPTION
## Summary

- Add the Herdr plugin ecosystem research and release analysis.
- Add Spec 016 defining the thin plugin facade, bridge lifecycle controller, source-build path, security posture, versioning, and acceptance evidence.
- Fix rapid terminal and Office conversation resizing so browser resize traffic is coalesced and cannot stall the page through resize/output feedback.

## Key decision

Herdr World remains a browser-first downstream application. The Herdr integration is a thin action-based install and lifecycle facade around the existing Rust bridge and web assets; it is not a native terminal pane rewrite.

## Validation

- `git diff --check`
- `npm run check` — vendor, notices, lint, 442 web tests, Rust compatibility/bridge tests, and builds passing.
- CI-mode Office conversation resize E2E test passing.
- Rapid window-resize E2E test passing.

The resize fix is implemented in the web terminal transport with focused unit coverage and the existing Office resize regression test is active in CI.