### PR TITLE
build: sign and notarize macOS releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,9 @@ on:
       - ".github/workflows/release.yml"
       - "scripts/package-tarball.sh"
       - "scripts/verify-desktop-package.sh"
+      - "scripts/import-macos-signing-certificate.sh"
+      - "scripts/sign-macos-package.sh"
+      - "scripts/notarize-macos-package.sh"
       - "scripts/live-stock-v082.sh"
       - "scripts/live-bridge-smoke.mjs"
       - "scripts/herdr-world-launcher.sh"
@@ -111,12 +114,33 @@ jobs:
         run: |
           npm ci
           npm ci --prefix web
-      - name: Build and inspect native archive
+      - name: Build native archive
         env:
           CARGO_TARGET_DIR: ${{ runner.temp }}/herdr-world-cargo
         run: |
           scripts/package-tarball.sh "${{ steps.version.outputs.version }}" "${{ matrix.platform }}" --notices-verified
-          scripts/verify-desktop-package.sh "${{ steps.version.outputs.version }}" "${{ matrix.platform }}"
+      - name: Import Developer ID certificate
+        id: signing
+        if: startsWith(matrix.platform, 'macos-') && github.event_name == 'push' && github.ref_type == 'tag'
+        env:
+          APPLE_DEVELOPER_ID_CERTIFICATE_BASE64: ${{ secrets.APPLE_DEVELOPER_ID_CERTIFICATE_BASE64 }}
+          APPLE_DEVELOPER_ID_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_DEVELOPER_ID_CERTIFICATE_PASSWORD }}
+        run: scripts/import-macos-signing-certificate.sh
+      - name: Apply test-only ad hoc signature
+        if: startsWith(matrix.platform, 'macos-') && (github.event_name != 'push' || github.ref_type != 'tag')
+        env:
+          MACOS_SIGNING_IDENTITY: "-"
+        run: scripts/sign-macos-package.sh "${{ steps.version.outputs.version }}" "${{ matrix.platform }}"
+      - name: Apply release Developer ID signature
+        if: startsWith(matrix.platform, 'macos-') && github.event_name == 'push' && github.ref_type == 'tag'
+        env:
+          HERDR_WORLD_REQUIRE_DEVELOPER_ID: "1"
+          MACOS_SIGNING_IDENTITY: ${{ steps.signing.outputs.identity }}
+        run: scripts/sign-macos-package.sh "${{ steps.version.outputs.version }}" "${{ matrix.platform }}"
+      - name: Inspect native archive
+        env:
+          HERDR_WORLD_REQUIRE_DEVELOPER_ID: ${{ github.event_name == 'push' && github.ref_type == 'tag' && '1' || '0' }}
+        run: scripts/verify-desktop-package.sh "${{ steps.version.outputs.version }}" "${{ matrix.platform }}"
       - name: Download verified stock Herdr v0.8.2
         env:
           HERDR_ASSET: ${{ matrix.herdr_asset }}
@@ -139,6 +163,18 @@ jobs:
           HERDR_WEB_BRIDGE_BIN: ${{ github.workspace }}/dist-packages/herdr-world-${{ steps.version.outputs.version }}-${{ matrix.platform }}/bin/herdr-world-bridge
           HERDR_WEB_STATIC_DIR: ${{ github.workspace }}/dist-packages/herdr-world-${{ steps.version.outputs.version }}-${{ matrix.platform }}/share/herdr-world/web
         run: scripts/live-stock-v082.sh
+      - name: Notarize macOS release payload
+        if: startsWith(matrix.platform, 'macos-') && github.event_name == 'push' && github.ref_type == 'tag'
+        env:
+          APPLE_NOTARY_KEY_ID: ${{ secrets.APPLE_NOTARY_KEY_ID }}
+          APPLE_NOTARY_ISSUER_ID: ${{ secrets.APPLE_NOTARY_ISSUER_ID }}
+          APPLE_NOTARY_PRIVATE_KEY_BASE64: ${{ secrets.APPLE_NOTARY_PRIVATE_KEY_BASE64 }}
+        run: scripts/notarize-macos-package.sh "${{ steps.version.outputs.version }}" "${{ matrix.platform }}"
+      - name: Remove ephemeral signing keychain
+        if: always() && startsWith(matrix.platform, 'macos-') && steps.signing.outputs.keychain_path != ''
+        env:
+          SIGNING_KEYCHAIN_PATH: ${{ steps.signing.outputs.keychain_path }}
+        run: /usr/bin/security delete-keychain "$SIGNING_KEYCHAIN_PATH"
       - name: Upload verified desktop archive
         uses: actions/upload-artifact@v7
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - Added fail-closed Developer ID signing and Apple notarization for release-tag macOS packages;
   pull-request packages exercise the same hardened-runtime assembly with test-only ad-hoc
   signatures and never access the release credentials.
-  [Herdr World PR #22](https://github.com/IvoryHeart/herdr-world/pull/22)
+  [Herdr World PR #24](https://github.com/IvoryHeart/herdr-world/pull/24)
 - Added a desktop `install` / `herdr-world-installer` entrypoint that installs the complete
   versioned World bundle for the current user, exposes the `herdr-world` command, and then hands off
   to the consent-based Herdr dependency setup.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 ### Added
 
+- Added fail-closed Developer ID signing and Apple notarization for release-tag macOS packages;
+  pull-request packages exercise the same hardened-runtime assembly with test-only ad-hoc
+  signatures and never access the release credentials.
+  [Herdr World PR #22](https://github.com/IvoryHeart/herdr-world/pull/22)
 - Added a desktop `install` / `herdr-world-installer` entrypoint that installs the complete
   versioned World bundle for the current user, exposes the `herdr-world` command, and then hands off
   to the consent-based Herdr dependency setup.

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Android development also needs a JDK and Android SDK. See [docs/android.md](docs
 | Platform | Status |
 | --- | --- |
 | Linux x86-64 | Available in [`v0.1.0-rc.1`](https://github.com/IvoryHeart/herdr-world/releases/tag/v0.1.0-rc.1) |
-| macOS ARM64 / x86-64 | Available unsigned in [`v0.1.0-rc.1`](https://github.com/IvoryHeart/herdr-world/releases/tag/v0.1.0-rc.1) |
+| macOS ARM64 / x86-64 | Available in [`v0.1.0-rc.1`](https://github.com/IvoryHeart/herdr-world/releases/tag/v0.1.0-rc.1) |
 | Android | Source and debug build workflow are available; no signed public APK yet |
 
 ## Quick Start From Release
@@ -144,10 +144,11 @@ http://127.0.0.1:8787
 `herdr-world` and `herdr-world-installer` under `~/.local/bin`, and continues into the consent-based
 Herdr dependency setup. The desktop tarball includes the web assets and `herdr-world-bridge`; it
 does not embed Herdr.
-The macOS binaries are not yet Developer ID signed or notarized. macOS may therefore require you to
-confirm the first launch in System Settings → Privacy & Security after you have verified the
-downloaded checksum and source. Signing and notarization will be added when project credentials are
-available.
+The release workflow now refuses to publish new macOS archives unless the bridge has a timestamped
+Developer ID Application signature and Apple accepts its notarization submission. Pull-request and
+manual CI artifacts use test-only ad-hoc signatures and are not release artifacts. Archives
+published before this gate are not silently replaced; check the corresponding release notes and
+checksum when testing an older download.
 If the default Herdr session is missing or incompatible, the installed `herdr-world` command
 explains the requirement and asks separately before downloading the [official Herdr
 installer](https://herdr.dev/docs/install/), stopping an incompatible detached server, or starting

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -26,10 +26,12 @@ stock Herdr v0.8.2 daemons before upload. Build the APK separately on a machine 
 Android SDK setup; Android is not part of the automated public release until a signed release APK
 exists.
 
-The macOS archives are currently unsigned and not notarized. They are public preview artifacts, and
-macOS may require users to confirm the first launch in System Settings → Privacy & Security after
-verifying the checksum. Do not describe them as signed or notarized until Developer ID credentials
-and the corresponding CI steps are in place.
+Release-tag macOS archives are fail-closed: CI imports an ephemeral Developer ID Application
+certificate, signs `herdr-world-bridge` with hardened runtime and a secure timestamp, exercises the
+signed package, and requires Apple notarization acceptance before uploading it. Pull-request and
+manual CI packages use test-only ad-hoc signatures, never access the release credentials, and are
+not published. The distributed tarball cannot carry a stapled ticket; Gatekeeper can retrieve the
+notarization ticket for the signed bridge online.
 
 ## Desktop Tarball Shape
 
@@ -112,6 +114,18 @@ The automated workflow performs the same inspection used locally:
 tar -tzf dist-packages/herdr-world-vX.Y.Z-PLATFORM.tar.gz
 cat dist-packages/herdr-world-vX.Y.Z-PLATFORM.tar.gz.sha256
 ```
+
+On macOS, a local package must be signed and repacked before signature-aware verification. Use an
+ad-hoc identity for local testing only:
+
+```bash
+MACOS_SIGNING_IDENTITY=- \
+  scripts/sign-macos-package.sh vX.Y.Z macos-arm64
+scripts/verify-desktop-package.sh vX.Y.Z macos-arm64
+```
+
+Official release signing and notarization occur only in the tag workflow; do not use an ad-hoc
+package as a release asset.
 
 CI verifies the complete cross-platform dependency notice closure once before starting the native
 matrix, then passes the internal `--notices-verified` assembly flag to avoid rebuilding the same
@@ -233,9 +247,11 @@ WebSocket.
 
 `node scripts/release.mjs vX.Y.Z` updates the public version references, pushes the release tag,
 creates the GitHub release, and triggers `.github/workflows/release.yml`. The workflow builds,
-inspects, live-tests, and uploads all six Linux/macOS archive and checksum assets. Existing assets
-are never replaced. The release command also updates the website source, so the same release push
-deploys current links through the Pages workflow.
+signs and notarizes both macOS payloads, inspects and live-tests all three native packages, and
+uploads all six Linux/macOS archive and checksum assets. Missing or invalid Apple credentials stop
+the macOS jobs before artifact upload. Existing assets are never replaced. The release command also
+updates the website source, so the same release push deploys current links through the Pages
+workflow.
 
 Android remains a deliberate separate step until a signed public APK exists. Do not attach a debug
 APK to a public release as though it were a production artifact.

--- a/docs/release.md
+++ b/docs/release.md
@@ -11,6 +11,12 @@ They do not publish npm packages, and the package versions are not release versi
 - `cargo-about` 0.9.2 (`cargo install cargo-about --version 0.9.2 --locked --features cli`).
 - JDK 21 and Android SDK when validating the Android shell.
 - GitHub CLI authenticated as a user that can create releases.
+- The following `IvoryHeart/herdr-world` GitHub Actions repository secrets for macOS releases:
+  `APPLE_DEVELOPER_ID_CERTIFICATE_BASE64`, `APPLE_DEVELOPER_ID_CERTIFICATE_PASSWORD`,
+  `APPLE_NOTARY_KEY_ID`, `APPLE_NOTARY_ISSUER_ID`, and
+  `APPLE_NOTARY_PRIVATE_KEY_BASE64`. The certificate must be a password-protected `.p12` export of
+  one Developer ID Application certificate and its private key. The notarization key must be an App
+  Store Connect team API key; an individual API key cannot authenticate `notarytool`.
 - `origin` fetch and push URLs both resolve to `IvoryHeart/herdr-world`. The release helper rejects
   upstream, fork, local-path, and unsupported remote URLs before making any release mutation.
 - A local Herdr `v0.8.2` or newer session reporting terminal protocol `20` for browser and packaged
@@ -94,9 +100,13 @@ licence inventories, World asset record, and Herdr vendor manifest are present.
 For APKs, inspect the package listing or metadata and verify the bundled
 `public/legal/manifest.json` and every file it names.
 
-The macOS archives are intentionally unsigned and unnotarized until Developer ID credentials are
-available. Release notes and user documentation must retain that limitation. The workflow does not
-attempt to weaken Gatekeeper or modify a user's security policy.
+Release-tag macOS jobs import the certificate into an ephemeral keychain, sign only the packaged
+Mach-O bridge using hardened runtime and a secure timestamp, run package/live verification, and
+submit a ZIP representation of the same signed payload to Apple's notary service. The published
+tarball contains those exact accepted bridge bytes; because a tarball cannot carry a stapled ticket,
+Gatekeeper retrieves the ticket online. Missing, malformed, or placeholder credentials fail the tag
+job before artifact upload. Pull requests and manual workflow runs exercise package signing with an
+ad-hoc identity and never read the release secrets.
 
 For the desktop installer, verify `./install --install-only` creates versioned user-local files and
 working `herdr-world`/`herdr-world-installer` command links without starting Herdr. Verify the
@@ -196,9 +206,9 @@ The script:
 - opens the next `## [Unreleased]` changelog section and pushes it
 
 The tag starts the desktop release workflow. It builds and verifies Linux x86-64, macOS ARM64, and
-macOS x86-64 archives, uploads their checksum files, and fails rather than replacing an asset that
-already exists. The release commit's site changes also trigger the Pages deployment. No separate
-desktop upload or documentation-edit step is required.
+macOS x86-64 archives; signs and notarizes both macOS payloads; uploads their checksum files; and
+fails rather than replacing an asset that already exists. The release commit's site changes also
+trigger the Pages deployment. No separate desktop upload or documentation-edit step is required.
 
 ## Android Validation
 
@@ -211,12 +221,14 @@ adding any pairing token or other secret storage.
 
 After the tag is pushed, monitor both `Desktop release` and `Deploy GitHub Pages`. The desktop
 workflow attaches exactly three native archives and three checksum files. It does not publish npm,
-an Android debug APK, or any unsigned artifact represented as production-signed software.
+an Android debug APK, or an ad-hoc-signed macOS CI package.
 
 ## After
 
 - Confirm the GitHub release exists and points at the expected tag.
 - Confirm release assets and checksum files are attached.
-- Confirm both macOS archives are still described as unsigned until signing is implemented.
+- Download both macOS archives and run `codesign --verify --strict --verbose=2` plus
+  `codesign --display --verbose=4` against each unpacked `bin/herdr-world-bridge`; confirm the
+  Developer ID Application authority, hardened-runtime flag, and secure timestamp.
 - Confirm the project site links to the new release after the Pages deployment.
 - Confirm `CHANGELOG.md` on `main` has a fresh empty `## [Unreleased]` section.

--- a/docs/tarball-readme.md
+++ b/docs/tarball-readme.md
@@ -8,9 +8,11 @@ upstream, asset, npm, and Cargo terms.
 It does not include Herdr itself. Herdr World requires Herdr `v0.8.2` or newer with terminal
 protocol `20`.
 
-The macOS archives are not yet Developer ID signed or notarized. After verifying the archive
-checksum and source, macOS may require the first launch to be confirmed in System Settings →
-Privacy & Security. Signing and notarization will be added when project credentials are available.
+Official macOS release archives are published only after `herdr-world-bridge` has a timestamped
+Developer ID Application signature and Apple accepts its notarization submission. The distributed
+tarball cannot carry a stapled ticket, so Gatekeeper resolves the notarization ticket online when
+the bridge first runs. Pull-request and manual CI packages use test-only ad-hoc signatures and are
+not production release artifacts.
 
 ## Install And Run
 

--- a/scripts/import-macos-signing-certificate.sh
+++ b/scripts/import-macos-signing-certificate.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "$(uname -s)" != "Darwin" ]]; then
+  echo "Developer ID certificates can only be imported on macOS" >&2
+  exit 2
+fi
+
+: "${RUNNER_TEMP:?RUNNER_TEMP is required}"
+: "${GITHUB_OUTPUT:?GITHUB_OUTPUT is required}"
+: "${APPLE_DEVELOPER_ID_CERTIFICATE_BASE64:?APPLE_DEVELOPER_ID_CERTIFICATE_BASE64 is required}"
+: "${APPLE_DEVELOPER_ID_CERTIFICATE_PASSWORD:?APPLE_DEVELOPER_ID_CERTIFICATE_PASSWORD is required}"
+
+CERTIFICATE_PATH="$RUNNER_TEMP/herdr-world-developer-id.p12"
+KEYCHAIN_PATH="$RUNNER_TEMP/herdr-world-signing.keychain-db"
+KEYCHAIN_PASSWORD="$(/usr/bin/openssl rand -hex 32)"
+imported=0
+
+cleanup() {
+  rm -f -- "$CERTIFICATE_PATH"
+  if [[ "$imported" -ne 1 ]]; then
+    /usr/bin/security delete-keychain "$KEYCHAIN_PATH" >/dev/null 2>&1 || true
+  fi
+}
+trap cleanup EXIT
+
+printf '%s' "$APPLE_DEVELOPER_ID_CERTIFICATE_BASE64" |
+  /usr/bin/openssl base64 -d -A -out "$CERTIFICATE_PATH"
+
+/usr/bin/security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+/usr/bin/security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+/usr/bin/security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+/usr/bin/security import "$CERTIFICATE_PATH" \
+  -P "$APPLE_DEVELOPER_ID_CERTIFICATE_PASSWORD" \
+  -A \
+  -t cert \
+  -f pkcs12 \
+  -k "$KEYCHAIN_PATH"
+/usr/bin/security set-key-partition-list \
+  -S apple-tool:,apple: \
+  -k "$KEYCHAIN_PASSWORD" \
+  "$KEYCHAIN_PATH" >/dev/null
+/usr/bin/security list-keychains -d user -s "$KEYCHAIN_PATH"
+
+mapfile_output="$(
+  /usr/bin/security find-identity -v -p codesigning "$KEYCHAIN_PATH" |
+    /usr/bin/sed -n 's/^.*"\(Developer ID Application:.*\)".*$/\1/p'
+)"
+identity_count="$(printf '%s\n' "$mapfile_output" | /usr/bin/awk 'NF { count += 1 } END { print count + 0 }')"
+if [[ "$identity_count" -ne 1 ]]; then
+  echo "expected exactly one Developer ID Application identity in the certificate; found $identity_count" >&2
+  /usr/bin/security find-identity -v -p codesigning "$KEYCHAIN_PATH" >&2 || true
+  exit 1
+fi
+
+identity="$(printf '%s\n' "$mapfile_output" | /usr/bin/awk 'NF { print; exit }')"
+printf 'identity=%s\n' "$identity" >> "$GITHUB_OUTPUT"
+printf 'keychain_path=%s\n' "$KEYCHAIN_PATH" >> "$GITHUB_OUTPUT"
+imported=1
+
+echo "Imported $identity into an ephemeral CI keychain"

--- a/scripts/notarize-macos-package.sh
+++ b/scripts/notarize-macos-package.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+if [[ $# -ne 2 ]]; then
+  echo "usage: scripts/notarize-macos-package.sh VERSION PLATFORM" >&2
+  exit 2
+fi
+
+VERSION="$1"
+PLATFORM="$2"
+: "${APPLE_NOTARY_KEY_ID:?APPLE_NOTARY_KEY_ID is required}"
+: "${APPLE_NOTARY_ISSUER_ID:?APPLE_NOTARY_ISSUER_ID is required}"
+: "${APPLE_NOTARY_PRIVATE_KEY_BASE64:?APPLE_NOTARY_PRIVATE_KEY_BASE64 is required}"
+
+if [[ ! "$VERSION" =~ ^v?[0-9A-Za-z][0-9A-Za-z._+-]*$ ]]; then
+  echo "invalid VERSION" >&2
+  exit 2
+fi
+
+if [[ "$(uname -s)" != "Darwin" ]]; then
+  echo "macOS packages can only be notarized on macOS" >&2
+  exit 2
+fi
+case "$PLATFORM" in
+  macos-arm64 | macos-x86_64) ;;
+  *)
+    echo "unsupported notarization platform: $PLATFORM" >&2
+    exit 2
+    ;;
+esac
+if [[ ! "$APPLE_NOTARY_KEY_ID" =~ ^[A-Za-z0-9]+$ ]]; then
+  echo "APPLE_NOTARY_KEY_ID has an invalid format" >&2
+  exit 1
+fi
+if [[ ! "$APPLE_NOTARY_ISSUER_ID" =~ ^[A-Fa-f0-9-]+$ ]]; then
+  echo "APPLE_NOTARY_ISSUER_ID has an invalid format" >&2
+  exit 1
+fi
+
+NAME="herdr-world-${VERSION}-${PLATFORM}"
+STAGE="$ROOT/dist-packages/$NAME"
+BRIDGE="$STAGE/bin/herdr-world-bridge"
+[[ -f "$BRIDGE" ]] || {
+  echo "missing packaged bridge to notarize: $BRIDGE" >&2
+  exit 1
+}
+/usr/bin/codesign --verify --strict --verbose=2 "$BRIDGE"
+
+NOTARY_ROOT="$(mktemp -d "${RUNNER_TEMP:-${TMPDIR:-/tmp}}/herdr-world-notary.XXXXXX")"
+KEY_PATH="$NOTARY_ROOT/AuthKey_${APPLE_NOTARY_KEY_ID}.p8"
+ZIP_PATH="$NOTARY_ROOT/$NAME.zip"
+RESULT_PATH="$NOTARY_ROOT/result.json"
+cleanup() {
+  rm -rf -- "$NOTARY_ROOT"
+}
+trap cleanup EXIT
+
+printf '%s' "$APPLE_NOTARY_PRIVATE_KEY_BASE64" |
+  /usr/bin/openssl base64 -d -A -out "$KEY_PATH"
+chmod 600 "$KEY_PATH"
+/usr/bin/ditto -c -k --keepParent "$STAGE" "$ZIP_PATH"
+
+if ! /usr/bin/xcrun notarytool submit "$ZIP_PATH" \
+  --key "$KEY_PATH" \
+  --key-id "$APPLE_NOTARY_KEY_ID" \
+  --issuer "$APPLE_NOTARY_ISSUER_ID" \
+  --wait \
+  --output-format json > "$RESULT_PATH"; then
+  cat "$RESULT_PATH" >&2 || true
+  exit 1
+fi
+
+status="$(node -e 'const fs = require("node:fs"); const r = JSON.parse(fs.readFileSync(process.argv[1], "utf8")); process.stdout.write(String(r.status || ""));' "$RESULT_PATH")"
+submission_id="$(node -e 'const fs = require("node:fs"); const r = JSON.parse(fs.readFileSync(process.argv[1], "utf8")); process.stdout.write(String(r.id || ""));' "$RESULT_PATH")"
+if [[ "$status" != "Accepted" || -z "$submission_id" ]]; then
+  cat "$RESULT_PATH" >&2
+  if [[ -n "$submission_id" ]]; then
+    /usr/bin/xcrun notarytool log "$submission_id" \
+      --key "$KEY_PATH" \
+      --key-id "$APPLE_NOTARY_KEY_ID" \
+      --issuer "$APPLE_NOTARY_ISSUER_ID" >&2 || true
+  fi
+  echo "Apple notarization was not accepted" >&2
+  exit 1
+fi
+
+echo "Apple notarization accepted for $NAME (submission $submission_id)"

--- a/scripts/pages.test.mjs
+++ b/scripts/pages.test.mjs
@@ -41,7 +41,7 @@ test("the Pages artifact is self-contained and release-accurate", () => {
   assert.match(html, /class="skip-link"/);
   assert.ok(html.includes(currentRelease));
   assert.match(html, /Public preview \/ Linux \+ macOS/);
-  assert.match(html, /macOS previews are currently unsigned/i);
+  assert.match(html, /macOS release assets require Developer ID signing and Apple notarization/i);
   assert.match(html, /control surface for your agents/i);
   assert.doesNotMatch(html, /control surface for Herdr agents/i);
   assert.match(html, /Protocol[\s\S]{0,80}<dd>20<\/dd>/i);

--- a/scripts/sign-macos-package.sh
+++ b/scripts/sign-macos-package.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+if [[ $# -ne 2 ]]; then
+  echo "usage: scripts/sign-macos-package.sh VERSION PLATFORM" >&2
+  exit 2
+fi
+
+VERSION="$1"
+PLATFORM="$2"
+: "${MACOS_SIGNING_IDENTITY:?MACOS_SIGNING_IDENTITY is required}"
+
+if [[ ! "$VERSION" =~ ^v?[0-9A-Za-z][0-9A-Za-z._+-]*$ ]]; then
+  echo "invalid VERSION" >&2
+  exit 2
+fi
+
+if [[ "$(uname -s)" != "Darwin" ]]; then
+  echo "macOS packages can only be signed on macOS" >&2
+  exit 2
+fi
+case "$PLATFORM" in
+  macos-arm64 | macos-x86_64) ;;
+  *)
+    echo "unsupported signing platform: $PLATFORM" >&2
+    exit 2
+    ;;
+esac
+
+NAME="herdr-world-${VERSION}-${PLATFORM}"
+PKG_ROOT="$ROOT/dist-packages"
+STAGE="$PKG_ROOT/$NAME"
+BRIDGE="$STAGE/bin/herdr-world-bridge"
+ARCHIVE="$PKG_ROOT/$NAME.tar.gz"
+
+[[ -f "$BRIDGE" && -x "$BRIDGE" ]] || {
+  echo "missing packaged bridge to sign: $BRIDGE" >&2
+  exit 1
+}
+
+codesign_args=(
+  --force
+  --identifier dev.herdr.world.bridge
+  --options runtime
+  --sign "$MACOS_SIGNING_IDENTITY"
+)
+if [[ "$MACOS_SIGNING_IDENTITY" != "-" ]]; then
+  codesign_args+=(--timestamp)
+fi
+
+/usr/bin/codesign "${codesign_args[@]}" "$BRIDGE"
+/usr/bin/codesign --verify --strict --verbose=2 "$BRIDGE"
+
+signature_details="$(/usr/bin/codesign --display --verbose=4 "$BRIDGE" 2>&1)"
+if [[ "$signature_details" != *"flags="*"runtime"* ]]; then
+  echo "signed bridge is missing hardened runtime" >&2
+  printf '%s\n' "$signature_details" >&2
+  exit 1
+fi
+
+if [[ "${HERDR_WORLD_REQUIRE_DEVELOPER_ID:-0}" == "1" ]]; then
+  if [[ "$MACOS_SIGNING_IDENTITY" == "-" \
+    || "$signature_details" == *"Signature=adhoc"* \
+    || "$signature_details" != *"Authority=Developer ID Application:"* \
+    || "$signature_details" != *"Timestamp="* ]]; then
+    echo "release package does not have a timestamped Developer ID Application signature" >&2
+    printf '%s\n' "$signature_details" >&2
+    exit 1
+  fi
+fi
+
+rm -f -- "$ARCHIVE" "$ARCHIVE.sha256"
+(
+  cd "$PKG_ROOT"
+  COPYFILE_DISABLE=1 tar -czf "$ARCHIVE" "$NAME"
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$(basename "$ARCHIVE")" > "$ARCHIVE.sha256"
+  else
+    shasum -a 256 "$(basename "$ARCHIVE")" > "$ARCHIVE.sha256"
+  fi
+)
+
+echo "Signed and repacked $ARCHIVE"

--- a/scripts/verify-desktop-package.sh
+++ b/scripts/verify-desktop-package.sh
@@ -85,6 +85,8 @@ done
 [[ -x "$BUNDLE/bin/herdr-world-bridge" ]] || { echo "bridge is not executable" >&2; exit 1; }
 
 binary_description="$(file "$BUNDLE/bin/herdr-world-bridge")"
+host_os="$(uname -s)"
+host_arch="$(uname -m)"
 case "$PLATFORM" in
   linux-x86_64)
     [[ "$binary_description" == *"ELF 64-bit"* && "$binary_description" == *"x86-64"* ]] || {
@@ -114,6 +116,25 @@ case "$PLATFORM" in
     ;;
 esac
 
+if [[ "$PLATFORM" == macos-* && "$host_os" == "Darwin" ]]; then
+  signature_details="$(/usr/bin/codesign --display --verbose=4 "$BUNDLE/bin/herdr-world-bridge" 2>&1)"
+  /usr/bin/codesign --verify --strict --verbose=2 "$BUNDLE/bin/herdr-world-bridge"
+  if [[ "$signature_details" != *"flags="*"runtime"* ]]; then
+    echo "macOS bridge signature is missing hardened runtime" >&2
+    printf '%s\n' "$signature_details" >&2
+    exit 1
+  fi
+  if [[ "${HERDR_WORLD_REQUIRE_DEVELOPER_ID:-0}" == "1" ]]; then
+    if [[ "$signature_details" == *"Signature=adhoc"* \
+      || "$signature_details" != *"Authority=Developer ID Application:"* \
+      || "$signature_details" != *"Timestamp="* ]]; then
+      echo "macOS release bridge is not timestamped with a Developer ID Application certificate" >&2
+      printf '%s\n' "$signature_details" >&2
+      exit 1
+    fi
+  fi
+fi
+
 node - "$BUNDLE/share/herdr-world/web/legal" <<'NODE'
 const fs = require("node:fs");
 const path = require("node:path");
@@ -129,8 +150,6 @@ for (const entry of manifest.files) {
 }
 NODE
 
-host_os="$(uname -s)"
-host_arch="$(uname -m)"
 case "$PLATFORM:$host_os:$host_arch" in
   linux-x86_64:Linux:x86_64 | macos-arm64:Darwin:arm64 | macos-x86_64:Darwin:x86_64)
     "$BUNDLE/bin/herdr-world" --help >/dev/null

--- a/site/index.html
+++ b/site/index.html
@@ -124,7 +124,7 @@
         <div class="install-heading">
           <p class="eyebrow">Desktop public preview</p>
           <h2 id="install-title">From archive<br />to office.</h2>
-          <p>Herdr stays independent. Choose Linux x86-64, macOS Apple Silicon, or macOS Intel from the release, verify it, and run the included bridge and web app. The macOS previews are currently unsigned. If Herdr is not ready, the launcher offers a consent-based setup.</p>
+          <p>Herdr stays independent. Choose Linux x86-64, macOS Apple Silicon, or macOS Intel from the release, verify it, and run the included bridge and web app. New macOS release assets require Developer ID signing and Apple notarization before publication. If Herdr is not ready, the launcher offers a consent-based setup.</p>
           <a href="https://github.com/IvoryHeart/herdr-world#requirements">Read requirements ↗</a>
         </div>
 


### PR DESCRIPTION
## Status

Draft until valid Apple Developer ID and App Store Connect team API credentials are available. This PR does not contain credentials.

Installer PR #22 is merged, and this signing follow-up is now based directly on main.

## Summary

- fail closed on release-tag macOS builds unless herdr-world-bridge has a timestamped Developer ID Application signature with hardened runtime
- submit the exact signed payload to Apple with notarytool and require an Accepted result before artifact upload
- import the certificate into an ephemeral CI keychain and remove credential files/keychain on completion or failure
- exercise signing, repacking, signature verification, installation, and live smoke in PR/manual CI using a test-only ad-hoc identity without reading release secrets
- document the five required repository-secret names and the release verification procedure

## Required repository secrets

- APPLE_DEVELOPER_ID_CERTIFICATE_BASE64
- APPLE_DEVELOPER_ID_CERTIFICATE_PASSWORD
- APPLE_NOTARY_KEY_ID
- APPLE_NOTARY_ISSUER_ID
- APPLE_NOTARY_PRIVATE_KEY_BASE64

Missing, malformed, placeholder, or invalid values stop release-tag macOS jobs before public artifact upload.

## Validation already completed

- npm run check
- 439 web tests, 116 vendored compatibility tests, 162 bridge tests on the original combined head
- workflow YAML parse, Bash syntax, Pages tests, release tests, and git diff --check
- native macOS ARM64 and x86_64 ad-hoc signing, unpacked signature verification, installer, and two-daemon live smoke

## Remaining merge gate

1. Replace placeholder Apple repository secrets with valid credentials.
2. Validate a real Developer ID signature and an accepted Apple notarization submission.
3. Mark this PR ready and merge only after that validation passes.
