### PR TITLE
docs: specify npm and Homebrew distribution

### DIFF
--- a/docs/analysis/npm-homebrew-distribution-analysis-2026-08-28.md
+++ b/docs/analysis/npm-homebrew-distribution-analysis-2026-08-28.md
@@ -449,16 +449,15 @@ upload workflow completes. Publication sequencing should therefore be explicit:
 6. Install-test and hash-record the npm tarballs.
 7. Bootstrap-publish, or stage and approve, the npm package set under the
    selected dist-tag.
-8. Update or dispatch the Homebrew tap change after its stable/signing gates,
+8. Prepare the reviewed Homebrew tap change after its stable/signing gates,
    then fetch/install-test the Cask.
 
-The Homebrew tap update needs its own authorization and failure behavior. A
-source repository release should not silently rewrite an external tap unless
-the owner explicitly chooses a narrowly scoped bot or GitHub App flow. A safer
-first approach is a generated pull request or a controlled release workflow in
-the tap that updates the version, three checksums, and release URL only after
-the complete source release is available. The PR must pass Cask audit/style
-and install checks and require review.
+The Homebrew tap update needs its own authorization and failure behavior. The
+initial release should use a maintainer-prepared pull request from the verified
+release data, with Cask audit/style and install checks and human review. A
+source repository release should not silently rewrite an external tap. Bot or
+GitHub App automation is deferred; if introduced later, it should use narrowly
+scoped credentials limited to the required tap pull-request operation.
 
 All public package versions should derive from the same release tag after
 removing only the leading `v`. The root development package versions should
@@ -597,8 +596,8 @@ The follow-up specification resolves the research questions as follows:
    would need a separate name and documented channel.
 7. Preserve Spec 016's source-build-only plugin and defer package-manager
    discovery or external binary reuse.
-8. Use a generated, reviewed tap pull request with narrowly scoped bot or
-   GitHub App credentials.
+8. Use a reviewed tap pull request prepared from verified release data; defer
+   bot or GitHub App automation until it is justified by repeated releases.
 
 ## Recommended implementation order
 

--- a/docs/analysis/npm-homebrew-distribution-analysis-2026-08-28.md
+++ b/docs/analysis/npm-homebrew-distribution-analysis-2026-08-28.md
@@ -431,11 +431,11 @@ verification. The existing release matrix should remain the source of native
 truth. The npm packager can extract the verified archive into its staging
 layout; the Cask should reference the immutable archive directly.
 
-Before npm generation, release validation must compare the relative path set
-and bytes of the shared launcher, web assets, documentation, and legal payload
-across all three archives. Platform-specific bridge files and their runtime
-metadata are excluded from this common-payload identity check. Only after that
-check succeeds may the designated verified Linux x86-64 archive supply the
+Before npm generation, release validation must compare a canonical sorted
+relative-path/SHA-256 manifest for the shared launcher, web assets,
+documentation, and legal payload across all three archives. Platform-specific
+bridge files are excluded from this common-payload identity check. Only after
+that check succeeds may the designated verified Linux x86-64 archive supply the
 common npm payload.
 
 The current release process creates the GitHub release before the archive

--- a/docs/analysis/npm-homebrew-distribution-analysis-2026-08-28.md
+++ b/docs/analysis/npm-homebrew-distribution-analysis-2026-08-28.md
@@ -5,54 +5,40 @@
 - **Repository:** `IvoryHeart/herdr-world`
 - **Current application release:** `v0.1.0-rc.1`
 - **Current desktop artifacts:** Linux x86-64, macOS ARM64, and macOS x86-64
-- **Related decision record:** [Herdr World plugin release analysis](herdr-plugin-release-analysis-2026-08-26.md)
-- **Related specification:** [Spec 016](../specs/016-herdr-world-plugin-release-spec.md)
+- **Related specification:** [Spec 017](../specs/017-herdr-world-npm-homebrew-distribution-spec.md)
+- **Related research:** [Herdr plugin release analysis](herdr-plugin-release-analysis-2026-08-26.md)
 
 ## Executive conclusion
 
-Herdr World should add two binary-first user distributions backed by the
-existing verified desktop release artifacts:
+The smallest useful distribution is one public universal npm package and one
+binary-first Homebrew Cask:
 
-1. A public npm launcher package with platform-specific optional packages for
-   the native bridge.
-2. A Homebrew Cask in a separate `IvoryHeart/homebrew-tap` repository, with
-   platform- and architecture-specific URLs pointing at the GitHub release
-   archives.
+1. `@ivoryheart/herdr-world` contains the Node entrypoint, the shared
+   launcher/web/documentation/legal payload, and all three native bridges.
+2. `IvoryHeart/homebrew-tap` contains one manually prepared, reviewed Cask
+   that selects an existing immutable GitHub release archive.
 
-The npm package and Homebrew Cask should be assembled from the same release
-tarballs that are already built, inspected, checksum-published, and exercised
-against stock Herdr daemons. They should not introduce a second native build
-pipeline or an install-time downloader for release assets.
+The existing verified desktop archives remain the only native source. Package
+generation should re-layout those outputs, not compile a second bridge or
+download release assets during installation. A universal npm package avoids a
+four-package publication graph and is adequate while the current release
+artifacts remain small. A later platform split should require measured evidence.
 
-The recommended Homebrew shape is a Cask rather than a Homebrew/core formula:
-the current distribution is an upstream-provided, platform-specific binary
-bundle containing a native executable and static web assets. A source-building
-formula is possible, but it is a separate packaging investment. It would need
-to build the web app and Rust bridge under Homebrew's dependency and sandbox
-rules, and should only be chosen if the project specifically requires the
-`brew install` formula workflow or eventual Homebrew/core submission.
+This distribution remains independent from the Herdr plugin. It should not
+make plugin installation depend on npm or Homebrew, and it should not transfer
+plugin-managed lifecycle ownership to a package manager.
 
-The existing Herdr plugin plan remains conceptually compatible. The plugin
-should not silently depend on whichever npm or Homebrew copy happens to be on
-`PATH`; it must keep ownership of its bridge binary, static assets, version,
-and service state. A later plugin extension can deliberately add an explicit
-“use an installed distribution” mode or a binary-first installer, using the
-same release assets.
+## Repository and release baseline
 
-## Current repository and release baseline
+The repository is not currently a public npm application package:
 
-The repository is not currently an npm application package:
+- the root `package.json` is private and has version `0.0.0`;
+- `web/package.json` is a private frontend development manifest;
+- root dependencies include development and Android tooling; and
+- application versions are tracked in `release.json`, documentation, and tags.
 
-- The root `package.json` is private and has version `0.0.0`.
-- `web/package.json` is also private and has version `0.0.0`.
-- Root npm dependencies are development and Android-related dependencies; the
-  web dependencies are the frontend build graph, not runtime package
-  dependencies for an installed CLI.
-- Release versions are tracked in `release.json`, public documentation, and
-  GitHub tags. The release helper currently does not publish npm packages.
-
-The existing desktop release is the right payload boundary. For each supported
-platform, `scripts/package-tarball.sh` produces an archive containing:
+The existing `scripts/package-tarball.sh` produces platform archives with this
+shape:
 
 ```text
 herdr-world-vX.Y.Z-PLATFORM/
@@ -67,595 +53,291 @@ herdr-world-vX.Y.Z-PLATFORM/
   README.md
 ```
 
-The current `v0.1.0-rc.1` release archives are approximately 6.2–6.6 MiB
-each. They contain both the bridge and the web output, so they are already
-usable as the canonical binary distribution. The wrapper also preserves the
-important runtime behavior: it serves the bundled web app, uses the selected
-Herdr socket, and does not package Herdr itself.
+The archives are already the right source boundary. They contain the bridge,
+web application, launcher, documentation, and legal assets, and the existing
+verifier checks checksums, archive safety, native format, required files, legal
+manifest closure, launcher help, and a no-session failure path.
 
-The support matrix is currently:
+The current archive sizes are approximately 6.2–6.6 MiB. A universal npm
+package will be larger because it carries three bridges, but it avoids
+duplicated package metadata, publication sequencing, optional dependency
+selection, and platform-package failure modes. Measure the packed size during
+implementation. Split the native payload only if that measurement or an npm
+limit makes the universal package impractical.
 
-| Target | Current artifact | npm package condition | Homebrew artifact condition |
+The support matrix is:
+
+| Target | Existing archive | npm bridge path | Cask archive |
 | --- | --- | --- | --- |
-| Linux x86-64 | `linux-x86_64` | `linux`, `x64`, glibc | Linux, Intel |
-| macOS Apple Silicon | `macos-arm64` | `darwin`, `arm64` | macOS, ARM |
-| macOS Intel | `macos-x86_64` | `darwin`, `x64` | macOS, Intel |
+| Linux x86-64, glibc 2.34+ | `linux-x86_64` | `native/linux-x64/herdr-world-bridge` | Linux archive |
+| macOS ARM64 | `macos-arm64` | `native/darwin-arm64/herdr-world-bridge` | ARM64 archive |
+| macOS x86-64 | `macos-x86_64` | `native/darwin-x64/herdr-world-bridge` | Intel archive |
 
-Linux ARM64, musl-based Linux, Windows, and Android are not included in this
-distribution scope. The package managers must fail clearly on unsupported
-targets rather than selecting a nearby binary.
+Linux ARM64, musl Linux, Windows, and Android remain outside this distribution
+scope.
 
-The current `v0.1.0-rc.1` Linux bridge requires symbols through `GLIBC_2.34`.
-The initial Linux runtime contract is therefore glibc 2.34 or newer unless a
-separate release-build effort deliberately establishes a lower baseline.
-npm's `libc: ["glibc"]` selector identifies the libc family but cannot express
-or enforce a glibc version, so release-time symbol extraction and launcher
-preflight are both required.
+The current `v0.1.0-rc.1` Linux bridge requires symbols through
+`GLIBC_2.34`. The initial Linux runtime contract is therefore glibc 2.34 or
+newer unless a separate build effort establishes a lower baseline. npm's
+`libc` metadata cannot express a version, and the universal package has no
+useful platform selector, so the launcher must perform the runtime check.
 
 ## npm distribution
 
-### Recommended package topology
+### Universal package
 
-Use one user-facing package and one implementation-facing package per native
-target. The selected names are:
+The proposed package is:
 
 ```text
 @ivoryheart/herdr-world
-  ├─ optional @ivoryheart/herdr-world-linux-x64-gnu
-  ├─ optional @ivoryheart/herdr-world-darwin-arm64
-  └─ optional @ivoryheart/herdr-world-darwin-x64
 ```
 
-Ownership of the `@ivoryheart` scope is a publication prerequisite. npm does
-not provide an ordinary placeholder-reservation workflow, so the names should
-be checked and then first published as one real prerelease package set rather
-than occupied by placeholder packages.
+It should be a normal public scoped package with one `herdr-world` command.
+Its manifest should derive the version from `release.json` by removing only
+the leading `v`, declare Node `>=22.14.0`, use the exact repository URL
+`https://github.com/IvoryHeart/herdr-world`, set public scoped-package
+publication access, and use an explicit `files` allowlist.
 
-The user-facing package should contain:
+The package should contain:
 
-- the `herdr-world` executable entrypoint;
-- the bundled `share/herdr-world/web` tree;
-- the existing launcher behavior or a shared launcher invoked with explicit
-  bridge and static-directory paths; and
-- the project license, third-party notices, upstream record, and relevant
-  documentation.
+- the Node entrypoint;
+- the existing shared launcher behavior;
+- `share/herdr-world/web/**`;
+- documentation and the complete legal closure;
+- `native/linux-x64/herdr-world-bridge`;
+- `native/darwin-arm64/herdr-world-bridge`; and
+- `native/darwin-x64/herdr-world-bridge`.
 
-Each platform package should contain only the matching
-`herdr-world-bridge` payload and its complete applicable legal closure. It
-should declare npm's platform selectors:
+It should not contain the root or web development manifests, source-only
+dependencies, tests, CI files, Android output, or an arbitrary
+`node_modules` tree. It should not use `preinstall` or `postinstall` to
+download an archive or run Herdr.
 
-- `os` (`linux` or `darwin`);
-- `cpu` (`x64` or `arm64`); and
-- `libc: ["glibc"]` for the Linux build.
+Each bridge is copied from the matching verified desktop archive. The package
+should preserve the existing notices, license files, upstream record, bundled
+web legal files, `docs/world-assets.md`, `third_party/**`, and
+`vendor/herdr-compat/VENDOR-MANIFEST.toml`. The legal manifest must be closed
+within the package.
 
-This follows npm's package model: `bin` exposes executables, `files` limits
-the published payload, `optionalDependencies` permits platform packages to be
-skipped on other targets, and `os`, `cpu`, and `libc` describe compatibility.
-The main package must detect a missing or omitted optional package and print a
-specific unsupported-platform/install-options message. In particular,
-`npm install --omit=optional` must not result in a confusing “file not found”
-failure.
+### Entrypoint behavior
 
-The main launcher will need a packaging adaptation. The existing shell
-launcher assumes that the bridge and web assets are siblings in one unpacked
-tarball. npm's optional native package is installed in a package dependency
-tree, so the npm entrypoint should resolve the selected native package and
-pass explicit paths to the shared launcher, or the shared launcher should
-accept explicit bridge and static-directory environment variables. It must not
-guess from the current working directory or from a global npm prefix.
+The Node entrypoint should use `process.platform`, `process.arch`, and Linux
+libc detection to select exactly one of the three fixed paths. It should
+resolve paths from its installed package location, never from the current
+working directory, a guessed npm prefix, `PATH`, or a public environment
+override.
 
-The npm package should not use `preinstall` or `postinstall` to download a
-release asset. That would make installation dependent on an additional network
-request, complicate package-manager script policies, and weaken the clear
-registry integrity boundary. The optional package mechanism gives npm the
-platform selection without an install-time downloader.
+It should invoke the shared launcher behavior with the selected bridge and
+static web directory as package-internal paths. This keeps the public contract
+small while retaining the existing runtime behavior. It must preserve
+arguments, standard streams, relevant signals, and child exit status.
 
-### User experience
+Unsupported OS/CPU/libc combinations and missing or damaged bridge files
+should fail before execution with an actionable message. `herdr-world --help`
+should print usage and exit successfully without requiring Herdr, a workspace,
+or a bridge process.
 
-Once scope ownership and package names are confirmed, the intended
-stable-channel experience is
-roughly:
+### Linux compatibility
 
-```bash
-npm install --global <package-name>
-herdr-world
-```
+Release validation should extract the maximum GLIBC symbol version from the
+exact Linux bridge copied from the verified archive and fail if it exceeds
+2.34. The extracted value and bridge digest should be retained as release
+evidence.
 
-The prerelease experience should be explicit, for example:
+At runtime, the launcher should report required 2.34 and detected glibc when
+the host is below the floor. It should identify musl and unknown libc clearly,
+and reject Linux ARM64 before native execution. Tests should cover below,
+exactly at, and above the floor.
 
-```bash
-npm install --global <package-name>@next
-```
+### npm publication
 
-The command still requires a separately installed and running compatible
-Herdr session. npm only installs Herdr World; it must not silently install
-Herdr or change the user's Herdr workspace. The existing launcher guidance
-and exact Herdr `v0.8.2` / terminal protocol `20` admission remain applicable.
+The first release path should be manual and deliberately boring:
 
-`npx` can be documented as a one-off option after the package is stable, but it
-should not be the primary command for a long-running bridge. A global install
-has a more predictable executable and upgrade lifecycle, while a project-local
-install remains available to users who prefer it.
+1. build a clean package directory from the final verified release outputs;
+2. run `npm pack`;
+3. inspect the exact `.tgz` file list and manifest;
+4. install-test that exact `.tgz` on all three supported targets;
+5. record its SHA-256; and
+6. publish the same `.tgz` with standard npm authentication.
 
-### Package contents and metadata
+Prerelease application versions should use the `next` dist-tag. Stable
+versions should use `latest`. The `@ivoryheart` scope must be owned before
+publication, and npm has no ordinary placeholder reservation process, so the
+first publication should be the first real package release rather than a
+placeholder.
 
-The published package should be generated in a clean staging directory, not
-published from the repository root. Its metadata should include:
+npm name/version contents are immutable. If the wrong bytes are published, that
+version cannot be repaired in place; a later application version is required.
+No custom publication state model or staged-publishing workflow is needed for
+the initial package.
 
-- an approved package name and version derived from `release.json` without the
-  leading `v`;
-- a public repository URL matching `IvoryHeart/herdr-world` exactly;
-- the project homepage, license, issue tracker, and description;
-- an explicit `bin` mapping to `herdr-world`;
-- an allowlisted `files` set;
-- an explicit Node engine floor if the launcher uses Node at runtime; and
-- exact optional-dependency versions for all platform packages.
-
-The root and web `package.json` files can remain private development manifests.
-The generated distribution metadata must not cause release automation to bump
-development dependency versions or make the source workspace publishable by
-accident.
-
-The package allowlist should exclude `node_modules`, Rust targets, source
-trees not needed at runtime, test evidence, Android outputs, and repository
-automation. It must include the bundled legal manifest and every file it
-references. Each native package must likewise carry the complete notices and
-license files applicable to its bridge; legal closure is checked per package,
-not only in the main package. `npm pack --dry-run` and a real install from the
-generated tarballs should be mandatory release checks. npm always includes some
-package metadata such as `package.json`, README, and license files; the
-explicit `files` list should still be the primary boundary.
-
-### npm publication and versioning
-
-Publishing needs to account for npm's immutability rule: a given package name
-and version cannot be reused after publication, even if the package is later
-removed. The workflow should therefore assemble, pack, inspect, install-test,
-and hash-record all packages before the first publication call.
-
-The release policy should be:
-
-- stable application tags publish the package set under `latest`;
-- prerelease tags such as `v0.1.0-rc.1` publish under `next` (or an approved
-  equivalent), leaving `latest` on the last stable release; and
-- the top-level package and every platform package use the exact same version.
-
-npm recommends alternate dist-tags such as `next` for prereleases, and an
-ordinary install resolves the `latest` tag. This makes the current release
-candidate safe to publish for testers without making it the default stable
-install.
-
-The first publication cannot use trusted publishing as a bootstrap mechanism
-because each package must already exist. The first real prerelease must
-therefore use an operator-authenticated npm workflow with 2FA, publishing the
-three platform packages before the launcher. Immediately after bootstrap,
-configure GitHub-hosted OIDC trusted publishing separately for all four
-packages, using the exact repository and workflow.
-
-Subsequent releases should use direct trusted publishing from the GitHub-hosted
-workflow. The workflow needs `id-token: write`, Node 22.14.0 or newer, npm
-11.5.1 or newer, one protected GitHub environment approval for the publish job,
-and no long-lived publish token. It should publish the three platform packages
-before the launcher with the intended dist-tag. Staged publishing is optional
-future hardening, not part of the initial release path.
-
-The workflow must publish the platform packages before the top-level package,
-because the latter refers to exact platform package versions. It should not
-publish anything until the existing native archive verification and the npm
-package content checks pass.
-
-Because four npm publications are not atomic, a CI summary or release artifact
-should report the four observed package results, versions, channels, hashes,
-and next safe actions. The npm registry remains authoritative; no custom state
-taxonomy or publication database is needed. Before publication, inspect,
-install-test, and hash all four exact tarballs. Before every retry, query npm;
-retry only a package that is confirmed missing, using its identical inspected
-tarball. A live package with incorrect bytes burns that application version;
-the complete set must advance together, with no divergent repair versions and
-no replacement or mutation of existing contents.
-
-### npm alternatives considered
-
-| Option | Benefits | Costs / risks | Decision |
-| --- | --- | --- | --- |
-| One package containing all three native binaries | Simplest launcher and publishing graph | Every install downloads unused binaries; weaker platform filtering; larger package; awkward unsupported-target behavior | Reject for the first design |
-| One package per target with no top-level package | Simple artifact generation | Poor user experience; users must know target package names; no single `herdr-world` command | Reject |
-| Top-level package plus optional target packages | Normal npm CLI experience; precise npm selectors; no install-time downloader | Requires a small resolver/launcher and four package publications | Recommend |
-| Top-level package with a postinstall release downloader | Small registry package | Extra network and trust boundary; script-policy failures; mutable downloader behavior | Reject |
-| Publish the existing private root package | No new staging layout | Root manifest is not a runtime package and is explicitly private | Reject |
+OIDC and CI publication automation can be evaluated later as ordinary release
+hardening after the manual path has worked.
 
 ## Homebrew distribution
 
-### Package type decision
+### Cask choice
 
-Homebrew's current guidance distinguishes the package types this way:
+A Cask is the appropriate initial Homebrew type because the project already
+publishes platform-specific binary archives. A source-building formula would
+create a second build system and is not justified by the current goal. A binary
+formula is also deferred.
 
-- a formula is for open-source command-line software and libraries that
-  Homebrew can build from source;
-- a Cask is for native macOS applications and supported binary-only software;
-- Casks can target macOS, Linux, or both when their artifact types are
-  supported on those systems.
-
-Herdr World is open source, but the currently available public artifacts are
-platform-specific prebuilt bundles. The release process does not yet provide a
-Homebrew source build with Homebrew-declared Node, Rust, npm, Cargo, and web
-dependency behavior. A Cask therefore matches the immediate distribution
-boundary more closely and avoids compiling a large application during user
-installation.
-
-The official Homebrew Cask repository already has a closely related precedent:
-the `codex` Cask selects macOS/Linux and ARM64/x86-64 release archives and
-exposes a CLI binary. Herdr World needs the same platform selection plus a
-wrapper and static web tree.
-
-This should initially be a third-party Cask in a dedicated public tap, not a
-claim of Homebrew review or endorsement. Homebrew's official Cask policy also
-requires macOS executable artifacts to pass Gatekeeper checks. The repository
-currently documents its macOS artifacts as unsigned and unnotarized, so the
-stable Cask should wait for the signing/notarization work. Local implementation
-and validation may use release-candidate fixtures, but the ordinary stable
-Cask must not point to an RC. If a prerelease Cask is ever needed, it should be
-a separately named and deliberately documented channel.
-
-### Recommended tap and install shape
-
-Create a separate public repository named `IvoryHeart/homebrew-tap`, with a
-layout such as:
-
-```text
-homebrew-tap/
-  Casks/
-    herdr-world.rb
-  README.md
-```
-
-Keeping the tap separate gives the formula/Cask a clean Homebrew repository,
-avoids mixing Ruby package definitions into the application source tree, and
-lets the tap evolve independently. A GitHub repository named
-`homebrew-tap` maps to the standard short tap name `IvoryHeart/tap`.
-
-The intended user command is:
+The public command should be:
 
 ```bash
 brew install --cask IvoryHeart/tap/herdr-world
 ```
 
-Homebrew's direct fully qualified install form automatically adds the tap and
-limits trust to the requested item. The documentation should still explain
-that third-party taps contain executable Ruby package definitions and are not
-reviewed by Homebrew. Users who manually tap the repository should prefer
-item-level trust rather than trusting every future item in the tap.
+This is a third-party tap command, not a Homebrew endorsement or official
+Homebrew package.
 
-### Cask artifact design
+### Direct Cask shape
 
-The Cask should select the existing immutable release archive by OS and CPU:
+The Cask should use the existing immutable GitHub release archives, select the
+URL and SHA-256 by target, and support only macOS ARM64, macOS x86-64, and
+Linux x86-64. It should expose the archive's existing `bin/herdr-world`
+through the normal Cask `binary` mechanism. The bridge must not become a
+second command.
 
-```text
-macOS ARM64  -> herdr-world-vX.Y.Z-macos-arm64.tar.gz
-macOS x86-64 -> herdr-world-vX.Y.Z-macos-x86_64.tar.gz
-Linux x86-64 -> herdr-world-vX.Y.Z-linux-x86_64.tar.gz
-```
+The first implementation should not add a Cask wrapper, path environment
+contract, downloader, daemon, or service supervisor. The direct `binary`
+mapping must be tested after install, upgrade, reinstall, and removal of an
+older version. If direct mapping demonstrably fails because of Caskroom path
+resolution, that is evidence for a later narrowly scoped specification; it is
+not a reason to add an unreviewed wrapper now.
 
-It should carry the SHA-256 for each selected archive, derive URLs only from a
-versioned release tag, and fail for unsupported operating systems or
-architectures. It should not use a moving `latest` URL or an unchecksummed
-download.
+Installation should only unpack and link files. It must not start Herdr or the
+bridge, create or modify a workspace, or weaken the existing bridge security
+defaults. The stable Cask should never use a moving `latest` URL. A
+prerelease Cask, if ever needed, should have a separate name and documented
+channel.
 
-The Cask must expose only `herdr-world`. The archive also contains
-`herdr-world-bridge`, but it is an implementation binary and must not become a
-second global command; it does not provide the static-directory setup that the
-primary wrapper provides.
+### Tap update and signing readiness
 
-There is a path-layout issue to solve explicitly. The current wrapper computes
-the web directory relative to an unpacked bundle root. A Cask stores the
-archive under a versioned Caskroom path and links a `binary` artifact into the
-Homebrew prefix. The packaging implementation must either:
+After the complete GitHub release asset set is available, a maintainer should
+prepare a reviewed tap pull request that changes the Cask version, three
+versioned archive URLs, three checksums, and any necessary Cask metadata. The
+maintainer should run Cask audit/style and install checks on every available
+supported target. The tap should be identified as third-party.
 
-- make the launcher resolve its real staged path reliably;
-- use a Cask `command_wrapper` that passes the staged bridge and static paths;
-  or
-- install a Homebrew-specific wrapper that preserves the same runtime and
-  security behavior.
+MacOS signing, notarization, and applicable Gatekeeper checks are a separate
+stable-release readiness policy. Local Cask implementation and validation may
+use release-candidate fixtures; the ordinary stable Cask should not be
+published until that policy gate passes. The gate does not determine whether
+the distribution uses a Cask or a universal npm package.
 
-The solution must be tested through Cask install, upgrade, reinstall, and
-uninstall, not only by running the binary directly from the downloaded archive.
-It must also preserve the legal files and web assets needed at runtime and
-must not start Herdr, the bridge, or mutate a workspace during installation.
+## Release architecture
 
-The Cask should not start a bridge during installation. Homebrew installation
-owns files; it should not create a Herdr session, select a workspace, or leave
-a background process behind. The user runs `herdr-world` after installing, and
-the Herdr plugin controller remains responsible for plugin-managed lifecycle.
+The release sequence should be:
 
-### Formula/source-build alternative
+1. build all three native archives from the final tag;
+2. run existing archive verification and the stock-Herdr live smoke;
+3. generate the universal npm directory from those verified outputs;
+4. pack, inspect, install-test, and hash the exact npm `.tgz`;
+5. manually publish the exact npm archive under `next` or `latest`;
+6. prepare the reviewed tap change from the immutable release URLs and
+   checksums after signing readiness; and
+7. run Cask audit/style and installation checks.
 
-A Homebrew formula remains a valid later option:
+The desktop archives and Android package remain unchanged. A failed validation
+stops publication. A publication retry must first check the external registry;
+published npm bytes must never be silently replaced.
 
-```text
-source release archive
-  -> Homebrew Node/Rust build dependencies
-  -> npm web build + locked Cargo release build
-  -> formula-installed bridge, wrapper, share/herdr-world/web
-```
+## Relationship to Spec 016
 
-It would provide the conventional `brew install IvoryHeart/tap/herdr-world`
-command and better match the formula source-build model. It also introduces
-substantial work:
+Spec 016 remains source-build-only and owns the plugin's bridge and lifecycle.
+Installing npm or Homebrew must not change plugin ownership or lifecycle.
+Any future plugin use of an external package-manager installation needs a
+separate explicit contract for paths, versions, asset pairing, and ownership.
 
-- declare and test Node and Rust build dependencies;
-- make npm and Cargo dependency resolution work reproducibly under Homebrew's
-  build environment;
-- decide whether the web dependency graph must be represented as Homebrew
-  resources or otherwise made available before the build sandbox runs;
-- provide a meaningful source-build test on macOS and Linux;
-- maintain formula-specific install paths and upgrade behavior; and
-- decide whether the formula is merely a third-party tap package or is intended to
-  meet `homebrew/core` acceptance requirements.
+## Risks and mitigations
 
-A third-party binary formula could be made to install the existing archives,
-but that would blur the formula/Cask boundary and should not be presented as a
-candidate for Homebrew/core. It is explicitly deferred. If the project
-specifically requires the exact `brew install` formula command, this option
-should be designed and validated as its own workstream rather than smuggled
-into the Cask implementation.
+| Risk | Mitigation |
+| --- | --- |
+| Universal npm package grows as more targets are added | Measure packed size; split only with evidence |
+| npm package is installed on unsupported host | Runtime OS/CPU/libc selection and actionable rejection |
+| Linux binary needs newer glibc | Release symbol extraction and runtime 2.34 preflight |
+| Package files drift from verified archives | Generate only from final archives and inspect the exact `.tgz` |
+| Legal file is omitted | Preserve and validate the complete package legal closure |
+| Cask direct binary path does not survive Caskroom relinking | Test lifecycle; defer a wrapper until direct failure is demonstrated |
+| Third-party tap code is trusted too broadly | Use a fully qualified command and review the tap change |
+| Plugin and standalone distribution ownership becomes coupled | Keep the one-sentence Spec 016 boundary |
 
-### Homebrew alternatives considered
-
-| Option | Benefits | Costs / risks | Decision |
-| --- | --- | --- | --- |
-| Third-party Cask from release archives | Reuses verified binaries; no Node/Rust on client; supports current macOS/Linux artifact matrix | `brew install --cask`; Caskroom path adaptation; unsigned macOS limitation | Recommend now |
-| Source-building formula | Conventional formula UX; most aligned with open-source CLI packaging | New Homebrew build system, dependencies, sandbox/resource work, slower installs | Later option |
-| Binary formula in third-party tap | `brew install` UX and easy archive reuse | Not appropriate for Homebrew/core; weaker package-type semantics; still needs path adaptation | Only if exact formula UX is a hard requirement |
-| Cask in the main application repository | One repository | Nonstandard tap setup, mixed concerns, harder independent updates | Reject |
-| Official Homebrew/core or cask submission immediately | Wider discovery and trust | Current unsigned/unnotarized macOS binaries and immature packaging boundary | Defer |
-
-## Shared artifact and release architecture
-
-The three distribution channels should converge on one release artifact graph:
-
-```text
-tagged release commit
-        |
-        +--> native matrix build and live Herdr smoke
-        |       |
-        |       +--> GitHub release archives + SHA-256 files
-        |       +--> npm platform packages
-        |       +--> npm launcher package
-        |       +--> Homebrew Cask version/checksum update
-        |
-        +--> Herdr plugin source-build or future binary-first install
-```
-
-The important invariant is that npm and Homebrew must not rebuild a different
-bridge from a different commit after the desktop archives have passed release
-verification. The existing release matrix should remain the source of native
-truth. The npm packager can extract the verified archive into its staging
-layout; the Cask should reference the immutable archive directly.
-
-Before npm generation, release validation must compare a canonical sorted
-relative-path/SHA-256 manifest for the shared launcher, web assets,
-documentation, and legal payload across all three archives. Platform-specific
-bridge files are excluded from this common-payload identity check. Only after
-that check succeeds may the designated verified Linux x86-64 archive supply the
-common npm payload.
-
-The current release process creates the GitHub release before the archive
-upload workflow completes. Publication sequencing should therefore be explicit:
-
-1. Build and inspect every native archive.
-2. Run the existing stock-Herdr live smoke for every target.
-3. Verify common-payload identity across the three archives.
-4. Upload and verify the complete GitHub release asset set.
-5. Build and inspect npm package tarballs from those verified assets.
-6. Install-test and hash-record the npm tarballs.
-7. Bootstrap-publish, or directly trusted-publish, the npm package set under
-   the selected dist-tag.
-8. Prepare the reviewed Homebrew tap change after its stable/signing gates,
-   then fetch/install-test the Cask.
-
-The Homebrew tap update needs its own authorization and failure behavior. The
-initial release should use a maintainer-prepared pull request from the verified
-release data, with Cask audit/style and install checks and human review. A
-source repository release should not silently rewrite an external tap. The tap
-change should remain a maintainer-prepared, reviewed pull request from the
-verified release data.
-
-All public package versions should derive from the same release tag after
-removing only the leading `v`. The root development package versions should
-remain independent and private. The plugin manifest in Spec 016 already
-introduces a second public versioned surface, so release validation should
-eventually check the plugin manifest, npm package metadata, GitHub tag, and
-Homebrew Cask version together without publishing a package as a side effect
-of a local development build.
-
-## Relationship to the Herdr plugin
-
-The npm and Homebrew packages are standalone distributions; they do not change
-the plugin's product shape. In particular:
-
-- The Herdr plugin remains a thin lifecycle facade around the bridge and web
-  client.
-- The plugin should not use a global npm or Homebrew installation implicitly,
-  because that can pair a controller with a mismatched bridge/static asset
-  version.
-- The plugin's source-build path can remain the deterministic first path from
-  Spec 016.
-- A future plugin binary-first path can download the same GitHub archive and
-  verify its SHA-256 before extracting it.
-- An optional “use external installation” mode should require an explicit path
-  or configuration and should verify the application version and asset pairing.
-- Homebrew must not be made the service supervisor for a bridge tied to a
-  particular Herdr socket. Plugin-managed services belong to the plugin
-  controller; standalone package-manager users run the ordinary launcher.
-
-This means the packaging tranche is related to Spec 016 but is independently
-specified. It should not make npm or Homebrew installation a hidden prerequisite
-for installing the Herdr plugin.
-
-## Security, compatibility, and support risks
-
-### Supply chain
-
-- npm package publication is irreversible at the name/version level; package
-  contents must be inspected before publication.
-- npm trusted publishing and provenance should be configured for all packages,
-  not only the launcher package.
-- Homebrew tap Ruby is executable with the user's privileges. Documentation
-  must explain third-party tap trust and use fully qualified install commands.
-- Homebrew Cask artifacts are upstream-trusted installation inputs. Release
-  archives and checksums must remain immutable and publicly auditable.
-- Neither package manager changes the bridge's security model. The bridge
-  still grants admitted browser clients terminal-equivalent control, and
-  Host/Origin/CSP checks are not authentication.
-
-### Runtime compatibility
-
-- The packages still require Herdr `v0.8.2` or newer and terminal protocol
-  `20`.
-- The packages must preserve loopback defaults and the existing explicit LAN
-  host/origin configuration rules.
-- The launcher must work from npm's dependency tree and Homebrew's Caskroom or
-  keg path, including after upgrades.
-- Uninstalling either distribution must not delete unrelated plugin state or
-  silently stop a bridge that another process owns. Documentation should tell
-  users to stop a managed bridge before uninstalling its distribution.
-
-### Platform lifecycle
-
-- macOS artifacts are currently unsigned and unnotarized. Keep the existing
-  limitation in npm, Homebrew, and release documentation; do not suggest
-  bypassing Gatekeeper. The ordinary `herdr-world` Cask is stable-only until
-  signing, notarization, and applicable Gatekeeper checks pass.
-- Homebrew documents a future phase-out of Intel macOS support after Apple's
-  announced transition. The repository can keep shipping Intel while it is in
-  the tested matrix, but the Homebrew support promise should be reviewed
-  before the next platform policy change.
-- Linux support should state the glibc baseline and distinguish unsupported
-  musl or ARM systems from package-manager failures. The launcher should
-  report required and detected glibc versions before execution.
-
-## Proposed validation matrix for the follow-up spec
+## Focused validation matrix
 
 ### npm
 
-- Generate all packages from the final tagged release artifacts.
-- Assert the exact package file list with `npm pack --dry-run`.
-- Install the launcher package on Linux x86-64, macOS ARM64, and macOS x86-64.
-- Verify each host gets only its matching optional native package.
-- Verify unsupported combinations and `--omit=optional` produce actionable
-  errors.
-- Run `herdr-world --help` without a running Herdr session.
-- Run the existing packaged bridge live smoke against stock Herdr `v0.8.2`.
-- Verify package versions, optional dependency versions, release tag, legal
-  assets in every package, common-payload identity, GLIBC symbol baseline, and
-  npm dist-tag policy.
-- Exercise missing and mismatched platform packages, path overrides, glibc
-  below/at/above the floor, and partial-publication recovery without replacing
-  existing package contents.
-- Exercise a clean publish dry run before any immutable publication.
+- assert the exact allowlisted package files, including all three fixed bridge
+  paths and legal closure;
+- assert public metadata, exact repository, version derivation, Node floor, and
+  only the `herdr-world` command;
+- run `npm pack`, inspect the exact tarball, install it on all three targets,
+  and verify the matching bridge is selected;
+- verify unsupported OS, CPU, musl, unknown libc, missing bridge, and Linux
+  glibc below 2.34 errors;
+- run `herdr-world --help` without Herdr, a workspace, or a bridge;
+- run the existing live smoke against stock Herdr;
+- verify arguments, stdio, signals, and child exit status; and
+- manually publish the exact tested and hashed tarball under the intended tag.
 
 ### Homebrew
 
-- Run Cask audit/style checks from the tap checkout.
-- Fetch all three versioned URLs and independently verify their SHA-256 values.
-- Install and uninstall the Cask on Linux x86-64, macOS ARM64, and macOS
-  x86-64 where those Homebrew targets are available.
-- Verify the `herdr-world` command, wrapper-to-asset resolution, permissions,
-  and `--help` behavior.
-- Upgrade from one Cask version to the next and confirm the command points at
-  the new staged assets.
-- Reinstall and uninstall the Cask and confirm Caskroom/symlink resolution,
-  legal assets, and no daemon or workspace mutation during installation.
-- Run the live Herdr bridge smoke separately from the Homebrew no-daemon test.
-- Document the current unsigned/unnotarized macOS behavior and confirm no
-  installation step weakens Gatekeeper.
+- audit/style the Cask;
+- verify immutable versioned URLs and checksums for all three targets;
+- install, upgrade, reinstall, directly invoke, and uninstall the Cask on each
+  available supported target;
+- verify only `herdr-world` is exposed and no installation step starts a
+  process or mutates a workspace; and
+- block stable publication until the separate signing/readiness policy passes.
 
-### Shared release checks
+### Unchanged behavior
 
-- Confirm all package-manager versions match the release tag without `v`.
-- Confirm all release channels handle prereleases deliberately.
-- Confirm npm, Homebrew, tarball, and future plugin installs use the same
-  compatibility and platform matrix.
-- Confirm the desktop tarball and Android packaging behavior remains unchanged.
+- existing desktop archive verification and launcher behavior remain intact;
+- Android packaging and client behavior remain intact; and
+- Spec 016 plugin installation, ownership, source-build behavior, and lifecycle
+  remain intact.
 
-## Decisions carried into Spec 017
+## Decisions for Spec 017
 
-The follow-up specification resolves the research questions as follows:
-
-1. Use the four scoped names shown above, subject to ownership of the
-   `@ivoryheart` scope. Check name availability as a publication prerequisite;
-   do not publish placeholders because npm has no ordinary name-reservation
-   workflow. Bootstrap with the first real prerelease.
-2. Use a Node 22.14.0-or-newer npm launcher with package-resolution-based
-   platform selection and explicit validated bridge/static paths.
-3. Use `next` for prereleases and `latest` only for stable package sets.
-4. Use the public third-party tap `IvoryHeart/homebrew-tap` and
-   `brew install --cask IvoryHeart/tap/herdr-world`.
-5. Defer both source-building and binary Homebrew formulas.
-6. Keep the ordinary `herdr-world` Cask stable-only until macOS signing,
-   notarization, and Gatekeeper checks pass. A hypothetical prerelease Cask
-   would need a separate name and documented channel.
-7. Preserve Spec 016's source-build-only plugin and defer package-manager
-   discovery or external binary reuse.
-8. Use a maintainer-prepared reviewed tap pull request from verified release
-   data.
-9. Keep npm staged publishing as optional future hardening; it only applies to
-   package names that already exist and is not part of the initial release path.
-
-## Recommended implementation order
-
-1. Establish ownership of the npm scope, select the package names, and create
-   the public Homebrew tap repository.
-2. Extract a shared release-payload staging helper from the current tarball
-   layout, preserving all legal and web assets.
-3. Implement and test the npm launcher plus platform packages.
-4. Implement the Homebrew Cask and solve Caskroom wrapper path resolution.
-5. Add package-manager checks to the tagged release workflow, leaving local
-   source builds and desktop tarballs intact.
-6. Publish the first npm prerelease only under an explicit non-stable tag.
-7. Publish the ordinary Homebrew Cask only after the stable signing and
-   notarization gate; use only separately named prerelease work if that later
-   channel is explicitly specified.
-8. Keep any explicit plugin reuse of installed distributions in a later
-   contract rather than changing Spec 016 implicitly.
+1. Use one public universal npm package:
+   `@ivoryheart/herdr-world`.
+2. Copy all bridges from the corresponding verified archives into fixed
+   target-specific paths.
+3. Use Node 22.14.0 or newer and a fixed Linux glibc 2.34 preflight.
+4. Publish the exact manually tested npm `.tgz`; use `next` for prereleases
+   and `latest` for stable releases.
+5. Use a direct-archive stable Cask in the public third-party tap
+   `IvoryHeart/homebrew-tap`, with a manual reviewed tap change.
+6. Keep OIDC/CI npm automation, platform npm splits, Cask wrappers, formulas,
+   extra targets, and plugin package-manager reuse deferred.
 
 ## Sources
 
+### Repository
+
+- [README](../../README.md)
+- [Web README](../../web/README.md)
+- [Packaging documentation](../packaging.md)
+- [Release documentation](../release.md)
+- [Spec 016](../specs/016-herdr-world-plugin-release-spec.md)
+- [Plugin release analysis](herdr-plugin-release-analysis-2026-08-26.md)
+- [Tarball packaging script](../../scripts/package-tarball.sh)
+- [Shared launcher](../../scripts/herdr-world-launcher.sh)
+- [Desktop package verifier](../../scripts/verify-desktop-package.sh)
+- [Release workflow](../../.github/workflows/release.yml)
+
 ### npm
 
-- [npm `package.json` fields](https://docs.npmjs.com/files/package.json/) —
-  `bin`, `files`, `optionalDependencies`, `os`, `cpu`, and `libc`.
-- [npm publish](https://docs.npmjs.com/cli/commands/npm-publish/) — package
-  contents, dry runs, access, and immutable name/version publication.
-- [npm dist-tags](https://docs.npmjs.com/cli/dist-tag/) — stable `latest` and
-  prerelease tags such as `next`.
-- [npm trusted publishers](https://docs.npmjs.com/trusted-publishers/) — GitHub
-  OIDC setup, Node/npm requirements, and automatic provenance.
-- [npm provenance](https://docs.npmjs.com/generating-provenance-statements/) —
-  repository matching and GitHub Actions requirements.
+- [npm package.json fields](https://docs.npmjs.com/cli/v11/configuring-npm/package-json)
+- [npm publish](https://docs.npmjs.com/cli/v11/commands/npm-publish/)
+- [npm scoped public packages](https://docs.npmjs.com/creating-and-publishing-scoped-public-packages/)
+- [npm distribution tags](https://docs.npmjs.com/cli/v11/commands/npm-dist-tag/)
+- [npm trusted publishers](https://docs.npmjs.com/trusted-publishers/)
 
 ### Homebrew
 
-- [Adding Software to Homebrew](https://docs.brew.sh/Adding-Software-to-Homebrew)
-  — formula versus Cask selection and local validation commands.
-- [Cask Cookbook](https://docs.brew.sh/Cask-Cookbook) — `binary`,
-  `command_wrapper`, checksums, and artifact behavior.
-- [Acceptable Casks](https://docs.brew.sh/Acceptable-Casks) — platform support
-  and macOS Gatekeeper requirements.
-- [Taps](https://docs.brew.sh/Taps) — tap naming and direct installation.
-- [Tap Trust](https://docs.brew.sh/Tap-Trust) — trust scope for third-party tap
-  code.
-- [Official Codex Cask](https://github.com/Homebrew/homebrew-cask/blob/main/Casks/c/codex.rb)
-  — a current macOS/Linux ARM64/x86-64 CLI binary Cask precedent.
-- [Homebrew on Linux](https://docs.brew.sh/Homebrew-on-Linux) — Linux Homebrew
-  installation and glibc/support context.
-
-### Herdr World and Herdr
-
-- [Existing packaging](../packaging.md)
-- [Existing release process](../release.md)
-- [Herdr plugin release analysis](herdr-plugin-release-analysis-2026-08-26.md)
-- [Spec 016](../specs/016-herdr-world-plugin-release-spec.md)
-- [Herdr plugin documentation](https://herdr.dev/docs/plugins/)
-- [Herdr marketplace](https://herdr.dev/docs/marketplace/)
-- [Herdr socket API](https://herdr.dev/docs/socket-api/)
+- [Homebrew Cask Cookbook](https://docs.brew.sh/Cask-Cookbook)
+- [Homebrew taps](https://docs.brew.sh/Taps)
+- [Homebrew acceptable Casks](https://docs.brew.sh/Acceptable-Casks)
+- [Homebrew Tap Trust](https://docs.brew.sh/Tap-Trust)

--- a/docs/analysis/npm-homebrew-distribution-analysis-2026-08-28.md
+++ b/docs/analysis/npm-homebrew-distribution-analysis-2026-08-28.md
@@ -121,7 +121,7 @@ The user-facing package should contain:
   documentation.
 
 Each platform package should contain only the matching
-`herdr-world-bridge` payload, its bridge runtime metadata, and its complete
+`herdr-world-bridge` payload, its generated package metadata, and its complete
 applicable legal closure. It should declare npm's platform selectors:
 
 - `os` (`linux` or `darwin`);

--- a/docs/analysis/npm-homebrew-distribution-analysis-2026-08-28.md
+++ b/docs/analysis/npm-homebrew-distribution-analysis-2026-08-28.md
@@ -1,0 +1,659 @@
+# Herdr World npm and Homebrew distribution analysis
+
+- **Date:** 2026-08-28
+- **Status:** Research complete; implementation not started
+- **Repository:** `IvoryHeart/herdr-world`
+- **Current application release:** `v0.1.0-rc.1`
+- **Current desktop artifacts:** Linux x86-64, macOS ARM64, and macOS x86-64
+- **Related decision record:** [Herdr World plugin release analysis](herdr-plugin-release-analysis-2026-08-26.md)
+- **Related specification:** [Spec 016](../specs/016-herdr-world-plugin-release-spec.md)
+
+## Executive conclusion
+
+Herdr World should add two binary-first user distributions backed by the
+existing verified desktop release artifacts:
+
+1. A public npm launcher package with platform-specific optional packages for
+   the native bridge.
+2. A Homebrew Cask in a separate `IvoryHeart/homebrew-tap` repository, with
+   platform- and architecture-specific URLs pointing at the GitHub release
+   archives.
+
+The npm package and Homebrew Cask should be assembled from the same release
+tarballs that are already built, inspected, checksum-published, and exercised
+against stock Herdr daemons. They should not introduce a second native build
+pipeline or an install-time downloader for release assets.
+
+The recommended Homebrew shape is a Cask rather than a Homebrew/core formula:
+the current distribution is an upstream-provided, platform-specific binary
+bundle containing a native executable and static web assets. A source-building
+formula is possible, but it is a separate packaging investment. It would need
+to build the web app and Rust bridge under Homebrew's dependency and sandbox
+rules, and should only be chosen if the project specifically requires the
+`brew install` formula workflow or eventual Homebrew/core submission.
+
+The existing Herdr plugin plan remains conceptually compatible. The plugin
+should not silently depend on whichever npm or Homebrew copy happens to be on
+`PATH`; it must keep ownership of its bridge binary, static assets, version,
+and service state. A later plugin extension can deliberately add an explicit
+“use an installed distribution” mode or a binary-first installer, using the
+same release assets.
+
+## Current repository and release baseline
+
+The repository is not currently an npm application package:
+
+- The root `package.json` is private and has version `0.0.0`.
+- `web/package.json` is also private and has version `0.0.0`.
+- Root npm dependencies are development and Android-related dependencies; the
+  web dependencies are the frontend build graph, not runtime package
+  dependencies for an installed CLI.
+- Release versions are tracked in `release.json`, public documentation, and
+  GitHub tags. The release helper currently does not publish npm packages.
+
+The existing desktop release is the right payload boundary. For each supported
+platform, `scripts/package-tarball.sh` produces an archive containing:
+
+```text
+herdr-world-vX.Y.Z-PLATFORM/
+  bin/herdr-world
+  bin/herdr-world-bridge
+  share/herdr-world/web/
+  third_party/
+  docs/
+  LICENSE
+  THIRD_PARTY_NOTICES.md
+  UPSTREAM.md
+  README.md
+```
+
+The current `v0.1.0-rc.1` release archives are approximately 6.2–6.6 MiB
+each. They contain both the bridge and the web output, so they are already
+usable as the canonical binary distribution. The wrapper also preserves the
+important runtime behavior: it serves the bundled web app, uses the selected
+Herdr socket, and does not package Herdr itself.
+
+The support matrix is currently:
+
+| Target | Current artifact | npm package condition | Homebrew artifact condition |
+| --- | --- | --- | --- |
+| Linux x86-64 | `linux-x86_64` | `linux`, `x64`, glibc | Linux, Intel |
+| macOS Apple Silicon | `macos-arm64` | `darwin`, `arm64` | macOS, ARM |
+| macOS Intel | `macos-x86_64` | `darwin`, `x64` | macOS, Intel |
+
+Linux ARM64, musl-based Linux, Windows, and Android are not included in this
+distribution scope. The package managers must fail clearly on unsupported
+targets rather than selecting a nearby binary.
+
+The current `v0.1.0-rc.1` Linux bridge requires symbols through `GLIBC_2.34`.
+The initial Linux runtime contract is therefore glibc 2.34 or newer unless a
+separate release-build effort deliberately establishes a lower baseline.
+npm's `libc: ["glibc"]` selector identifies the libc family but cannot express
+or enforce a glibc version, so release-time symbol extraction and launcher
+preflight are both required.
+
+## npm distribution
+
+### Recommended package topology
+
+Use one user-facing package and one implementation-facing package per native
+target. The selected names are:
+
+```text
+@ivoryheart/herdr-world
+  ├─ optional @ivoryheart/herdr-world-linux-x64-gnu
+  ├─ optional @ivoryheart/herdr-world-darwin-arm64
+  └─ optional @ivoryheart/herdr-world-darwin-x64
+```
+
+Ownership of the `@ivoryheart` scope is a publication prerequisite. npm does
+not provide an ordinary placeholder-reservation workflow, so the names should
+be checked and then first published as one real prerelease package set rather
+than occupied by placeholder packages.
+
+The user-facing package should contain:
+
+- the `herdr-world` executable entrypoint;
+- the bundled `share/herdr-world/web` tree;
+- the existing launcher behavior or a shared launcher invoked with explicit
+  bridge and static-directory paths; and
+- the project license, third-party notices, upstream record, and relevant
+  documentation.
+
+Each platform package should contain only the matching
+`herdr-world-bridge` payload, its bridge runtime metadata, and its complete
+applicable legal closure. It should declare npm's platform selectors:
+
+- `os` (`linux` or `darwin`);
+- `cpu` (`x64` or `arm64`); and
+- `libc: ["glibc"]` for the Linux build.
+
+This follows npm's package model: `bin` exposes executables, `files` limits
+the published payload, `optionalDependencies` permits platform packages to be
+skipped on other targets, and `os`, `cpu`, and `libc` describe compatibility.
+The main package must detect a missing or omitted optional package and print a
+specific unsupported-platform/install-options message. In particular,
+`npm install --omit=optional` must not result in a confusing “file not found”
+failure.
+
+The main launcher will need a packaging adaptation. The existing shell
+launcher assumes that the bridge and web assets are siblings in one unpacked
+tarball. npm's optional native package is installed in a package dependency
+tree, so the npm entrypoint should resolve the selected native package and
+pass explicit paths to the shared launcher, or the shared launcher should
+accept explicit bridge and static-directory environment variables. It must not
+guess from the current working directory or from a global npm prefix.
+
+The npm package should not use `preinstall` or `postinstall` to download a
+release asset. That would make installation dependent on an additional network
+request, complicate package-manager script policies, and weaken the clear
+registry integrity boundary. The optional package mechanism gives npm the
+platform selection without an install-time downloader.
+
+### User experience
+
+Once scope ownership and package names are confirmed, the intended
+stable-channel experience is
+roughly:
+
+```bash
+npm install --global <package-name>
+herdr-world
+```
+
+The prerelease experience should be explicit, for example:
+
+```bash
+npm install --global <package-name>@next
+```
+
+The command still requires a separately installed and running compatible
+Herdr session. npm only installs Herdr World; it must not silently install
+Herdr or change the user's Herdr workspace. The existing launcher guidance
+and exact Herdr `v0.8.2` / terminal protocol `20` admission remain applicable.
+
+`npx` can be documented as a one-off option after the package is stable, but it
+should not be the primary command for a long-running bridge. A global install
+has a more predictable executable and upgrade lifecycle, while a project-local
+install remains available to users who prefer it.
+
+### Package contents and metadata
+
+The published package should be generated in a clean staging directory, not
+published from the repository root. Its metadata should include:
+
+- an approved package name and version derived from `release.json` without the
+  leading `v`;
+- a public repository URL matching `IvoryHeart/herdr-world` exactly;
+- the project homepage, license, issue tracker, and description;
+- an explicit `bin` mapping to `herdr-world`;
+- an allowlisted `files` set;
+- an explicit Node engine floor if the launcher uses Node at runtime; and
+- exact optional-dependency versions for all platform packages.
+
+The root and web `package.json` files can remain private development manifests.
+The generated distribution metadata must not cause release automation to bump
+development dependency versions or make the source workspace publishable by
+accident.
+
+The package allowlist should exclude `node_modules`, Rust targets, source
+trees not needed at runtime, test evidence, Android outputs, and repository
+automation. It must include the bundled legal manifest and every file it
+references. Each native package must likewise carry the complete notices and
+license files applicable to its bridge; legal closure is checked per package,
+not only in the main package. `npm pack --dry-run` and a real install from the
+generated tarballs should be mandatory release checks. npm always includes some
+package metadata such as `package.json`, README, and license files; the
+explicit `files` list should still be the primary boundary.
+
+### npm publication and versioning
+
+Publishing needs to account for npm's immutability rule: a given package name
+and version cannot be reused after publication, even if the package is later
+removed. The workflow should therefore stage, pack, inspect, install-test, and
+hash-record all packages before the first publication call.
+
+The release policy should be:
+
+- stable application tags publish the package set under `latest`;
+- prerelease tags such as `v0.1.0-rc.1` publish under `next` (or an approved
+  equivalent), leaving `latest` on the last stable release; and
+- the top-level package and every platform package use the exact same version.
+
+npm recommends alternate dist-tags such as `next` for prereleases, and an
+ordinary install resolves the `latest` tag. This makes the current release
+candidate safe to publish for testers without making it the default stable
+install.
+
+The first publication cannot use staged publishing or trusted publishing as a
+bootstrap mechanism: both require the package to already exist. The first real
+prerelease must therefore use an operator-authenticated npm workflow with 2FA,
+publishing the three platform packages before the launcher. Immediately after
+bootstrap, configure GitHub-hosted OIDC trusted publishing separately for all
+four packages, using the exact repository and workflow and stage-only
+permission where supported.
+
+Subsequent releases should use npm staged publishing from the GitHub-hosted
+workflow. The staged-publishing CLI requires npm 11.15.0 or newer and Node
+22.14.0 or newer, and the package must already exist. The workflow needs
+`id-token: write`, should run `npm stage publish` for all four packages, and
+must download and inspect the actual staged tarballs before human 2FA approval.
+The three platform stages must be approved before the launcher stage. No
+long-lived publish token should be used.
+
+The workflow must publish the platform packages before the top-level package,
+because the latter refers to exact platform package versions. It should not
+publish anything until the existing native archive verification and the npm
+package content checks pass.
+
+Because four npm publications are not atomic, release status must record each
+package's stage, publication result, hash, and next safe action. A transient
+failure before publication may retry the identical inspected tarball. A live
+package with incorrect bytes burns that application version; the complete set
+must advance together, with no divergent repair versions and no replacement
+of existing contents.
+
+### npm alternatives considered
+
+| Option | Benefits | Costs / risks | Decision |
+| --- | --- | --- | --- |
+| One package containing all three native binaries | Simplest launcher and publishing graph | Every install downloads unused binaries; weaker platform filtering; larger package; awkward unsupported-target behavior | Reject for the first design |
+| One package per target with no top-level package | Simple artifact generation | Poor user experience; users must know target package names; no single `herdr-world` command | Reject |
+| Top-level package plus optional target packages | Normal npm CLI experience; precise npm selectors; no install-time downloader | Requires a small resolver/launcher and four package publications | Recommend |
+| Top-level package with a postinstall release downloader | Small registry package | Extra network and trust boundary; script-policy failures; mutable downloader behavior | Reject |
+| Publish the existing private root package | No new staging layout | Root manifest is not a runtime package and is explicitly private | Reject |
+
+## Homebrew distribution
+
+### Package type decision
+
+Homebrew's current guidance distinguishes the package types this way:
+
+- a formula is for open-source command-line software and libraries that
+  Homebrew can build from source;
+- a Cask is for native macOS applications and supported binary-only software;
+- Casks can target macOS, Linux, or both when their artifact types are
+  supported on those systems.
+
+Herdr World is open source, but the currently available public artifacts are
+platform-specific prebuilt bundles. The release process does not yet provide a
+Homebrew source build with Homebrew-declared Node, Rust, npm, Cargo, and web
+dependency behavior. A Cask therefore matches the immediate distribution
+boundary more closely and avoids compiling a large application during user
+installation.
+
+The official Homebrew Cask repository already has a closely related precedent:
+the `codex` Cask selects macOS/Linux and ARM64/x86-64 release archives and
+exposes a CLI binary. Herdr World needs the same platform selection plus a
+wrapper and static web tree.
+
+This should initially be a third-party Cask in a dedicated public tap, not a
+claim of Homebrew review or endorsement. Homebrew's official Cask policy also
+requires macOS executable artifacts to pass Gatekeeper checks. The repository
+currently documents its macOS artifacts as unsigned and unnotarized, so the
+stable Cask should wait for the signing/notarization work. Local implementation
+and validation may use release-candidate fixtures, but the ordinary stable
+Cask must not point to an RC. If a prerelease Cask is ever needed, it should be
+a separately named and deliberately documented channel.
+
+### Recommended tap and install shape
+
+Create a separate public repository named `IvoryHeart/homebrew-tap`, with a
+layout such as:
+
+```text
+homebrew-tap/
+  Casks/
+    herdr-world.rb
+  README.md
+```
+
+Keeping the tap separate gives the formula/Cask a clean Homebrew repository,
+avoids mixing Ruby package definitions into the application source tree, and
+lets the tap evolve independently. A GitHub repository named
+`homebrew-tap` maps to the standard short tap name `IvoryHeart/tap`.
+
+The intended user command is:
+
+```bash
+brew install --cask IvoryHeart/tap/herdr-world
+```
+
+Homebrew's direct fully qualified install form automatically adds the tap and
+limits trust to the requested item. The documentation should still explain
+that third-party taps contain executable Ruby package definitions and are not
+reviewed by Homebrew. Users who manually tap the repository should prefer
+item-level trust rather than trusting every future item in the tap.
+
+### Cask artifact design
+
+The Cask should select the existing immutable release archive by OS and CPU:
+
+```text
+macOS ARM64  -> herdr-world-vX.Y.Z-macos-arm64.tar.gz
+macOS x86-64 -> herdr-world-vX.Y.Z-macos-x86_64.tar.gz
+Linux x86-64 -> herdr-world-vX.Y.Z-linux-x86_64.tar.gz
+```
+
+It should carry the SHA-256 for each selected archive, derive URLs only from a
+versioned release tag, and fail for unsupported operating systems or
+architectures. It should not use a moving `latest` URL or an unchecksummed
+download.
+
+The Cask must expose only `herdr-world`. The archive also contains
+`herdr-world-bridge`, but it is an implementation binary and must not become a
+second global command; it does not provide the static-directory setup that the
+primary wrapper provides.
+
+There is a path-layout issue to solve explicitly. The current wrapper computes
+the web directory relative to an unpacked bundle root. A Cask stores the
+archive under a versioned Caskroom path and links a `binary` artifact into the
+Homebrew prefix. The packaging implementation must either:
+
+- make the launcher resolve its real staged path reliably;
+- use a Cask `command_wrapper` that passes the staged bridge and static paths;
+  or
+- install a Homebrew-specific wrapper that preserves the same runtime and
+  security behavior.
+
+The solution must be tested through Cask install, upgrade, reinstall, and
+uninstall, not only by running the binary directly from the downloaded archive.
+It must also preserve the legal files and web assets needed at runtime and
+must not start Herdr, the bridge, or mutate a workspace during installation.
+
+The Cask should not start a bridge during installation. Homebrew installation
+owns files; it should not create a Herdr session, select a workspace, or leave
+a background process behind. The user runs `herdr-world` after installing, and
+the Herdr plugin controller remains responsible for plugin-managed lifecycle.
+
+### Formula/source-build alternative
+
+A Homebrew formula remains a valid later option:
+
+```text
+source release archive
+  -> Homebrew Node/Rust build dependencies
+  -> npm web build + locked Cargo release build
+  -> formula-installed bridge, wrapper, share/herdr-world/web
+```
+
+It would provide the conventional `brew install IvoryHeart/tap/herdr-world`
+command and better match the formula source-build model. It also introduces
+substantial work:
+
+- declare and test Node and Rust build dependencies;
+- make npm and Cargo dependency resolution work reproducibly under Homebrew's
+  build environment;
+- decide whether the web dependency graph must be represented as Homebrew
+  resources or otherwise made available before the build sandbox runs;
+- provide a meaningful source-build test on macOS and Linux;
+- maintain formula-specific install paths and upgrade behavior; and
+- decide whether the formula is merely a third-party tap package or is intended to
+  meet `homebrew/core` acceptance requirements.
+
+A third-party binary formula could be made to install the existing archives,
+but that would blur the formula/Cask boundary and should not be presented as a
+candidate for Homebrew/core. It is explicitly deferred. If the project
+specifically requires the exact `brew install` formula command, this option
+should be designed and validated as its own workstream rather than smuggled
+into the Cask implementation.
+
+### Homebrew alternatives considered
+
+| Option | Benefits | Costs / risks | Decision |
+| --- | --- | --- | --- |
+| Third-party Cask from release archives | Reuses verified binaries; no Node/Rust on client; supports current macOS/Linux artifact matrix | `brew install --cask`; Caskroom path adaptation; unsigned macOS limitation | Recommend now |
+| Source-building formula | Conventional formula UX; most aligned with open-source CLI packaging | New Homebrew build system, dependencies, sandbox/resource work, slower installs | Later option |
+| Binary formula in third-party tap | `brew install` UX and easy archive reuse | Not appropriate for Homebrew/core; weaker package-type semantics; still needs path adaptation | Only if exact formula UX is a hard requirement |
+| Cask in the main application repository | One repository | Nonstandard tap setup, mixed concerns, harder independent updates | Reject |
+| Official Homebrew/core or cask submission immediately | Wider discovery and trust | Current unsigned/unnotarized macOS binaries and immature packaging boundary | Defer |
+
+## Shared artifact and release architecture
+
+The three distribution channels should converge on one release artifact graph:
+
+```text
+tagged release commit
+        |
+        +--> native matrix build and live Herdr smoke
+        |       |
+        |       +--> GitHub release archives + SHA-256 files
+        |       +--> npm platform packages
+        |       +--> npm launcher package
+        |       +--> Homebrew Cask version/checksum update
+        |
+        +--> Herdr plugin source-build or future binary-first install
+```
+
+The important invariant is that npm and Homebrew must not rebuild a different
+bridge from a different commit after the desktop archives have passed release
+verification. The existing release matrix should remain the source of native
+truth. The npm packager can extract the verified archive into its staging
+layout; the Cask should reference the immutable archive directly.
+
+Before npm generation, release validation must compare the relative path set
+and bytes of the shared launcher, web assets, documentation, and legal payload
+across all three archives. Platform-specific bridge files and their runtime
+metadata are excluded from this common-payload identity check. Only after that
+check succeeds may the designated verified Linux x86-64 archive supply the
+common npm payload.
+
+The current release process creates the GitHub release before the archive
+upload workflow completes. Publication sequencing should therefore be explicit:
+
+1. Build and inspect every native archive.
+2. Run the existing stock-Herdr live smoke for every target.
+3. Verify common-payload identity across the three archives.
+4. Upload and verify the complete GitHub release asset set.
+5. Build and inspect npm package tarballs from those verified assets.
+6. Install-test and hash-record the npm tarballs.
+7. Bootstrap-publish, or stage and approve, the npm package set under the
+   selected dist-tag.
+8. Update or dispatch the Homebrew tap change after its stable/signing gates,
+   then fetch/install-test the Cask.
+
+The Homebrew tap update needs its own authorization and failure behavior. A
+source repository release should not silently rewrite an external tap unless
+the owner explicitly chooses a narrowly scoped bot or GitHub App flow. A safer
+first approach is a generated pull request or a controlled release workflow in
+the tap that updates the version, three checksums, and release URL only after
+the complete source release is available. The PR must pass Cask audit/style
+and install checks and require review.
+
+All public package versions should derive from the same release tag after
+removing only the leading `v`. The root development package versions should
+remain independent and private. The plugin manifest in Spec 016 already
+introduces a second public versioned surface, so the release validation should
+eventually check the plugin manifest, npm staging metadata, GitHub tag, and
+Homebrew Cask version together without publishing a package as a side effect
+of a local development build.
+
+## Relationship to the Herdr plugin
+
+The npm and Homebrew packages are standalone distributions; they do not change
+the plugin's product shape. In particular:
+
+- The Herdr plugin remains a thin lifecycle facade around the bridge and web
+  client.
+- The plugin should not use a global npm or Homebrew installation implicitly,
+  because that can pair a controller with a mismatched bridge/static asset
+  version.
+- The plugin's source-build path can remain the deterministic first path from
+  Spec 016.
+- A future plugin binary-first path can download the same GitHub archive and
+  verify its SHA-256 before extracting it.
+- An optional “use external installation” mode should require an explicit path
+  or configuration and should verify the application version and asset pairing.
+- Homebrew must not be made the service supervisor for a bridge tied to a
+  particular Herdr socket. Plugin-managed services belong to the plugin
+  controller; standalone package-manager users run the ordinary launcher.
+
+This means the packaging tranche is related to Spec 016 but is independently
+specified. It should not make npm or Homebrew installation a hidden prerequisite
+for installing the Herdr plugin.
+
+## Security, compatibility, and support risks
+
+### Supply chain
+
+- npm package publication is irreversible at the name/version level; package
+  contents must be inspected before publication.
+- npm trusted publishing and provenance should be configured for all packages,
+  not only the launcher package.
+- Homebrew tap Ruby is executable with the user's privileges. Documentation
+  must explain third-party tap trust and use fully qualified install commands.
+- Homebrew Cask artifacts are upstream-trusted installation inputs. Release
+  archives and checksums must remain immutable and publicly auditable.
+- Neither package manager changes the bridge's security model. The bridge
+  still grants admitted browser clients terminal-equivalent control, and
+  Host/Origin/CSP checks are not authentication.
+
+### Runtime compatibility
+
+- The packages still require Herdr `v0.8.2` or newer and terminal protocol
+  `20`.
+- The packages must preserve loopback defaults and the existing explicit LAN
+  host/origin configuration rules.
+- The launcher must work from npm's dependency tree and Homebrew's Caskroom or
+  keg path, including after upgrades.
+- Uninstalling either distribution must not delete unrelated plugin state or
+  silently stop a bridge that another process owns. Documentation should tell
+  users to stop a managed bridge before uninstalling its distribution.
+
+### Platform lifecycle
+
+- macOS artifacts are currently unsigned and unnotarized. Keep the existing
+  limitation in npm, Homebrew, and release documentation; do not suggest
+  bypassing Gatekeeper. The ordinary `herdr-world` Cask is stable-only until
+  signing, notarization, and applicable Gatekeeper checks pass.
+- Homebrew documents a future phase-out of Intel macOS support after Apple's
+  announced transition. The repository can keep shipping Intel while it is in
+  the tested matrix, but the Homebrew support promise should be reviewed
+  before the next platform policy change.
+- Linux support should state the glibc baseline and distinguish unsupported
+  musl or ARM systems from package-manager failures. The launcher should
+  report required and detected glibc versions before execution.
+
+## Proposed validation matrix for the follow-up spec
+
+### npm
+
+- Generate all packages from the final tagged release artifacts.
+- Assert the exact package file list with `npm pack --dry-run`.
+- Install the launcher package on Linux x86-64, macOS ARM64, and macOS x86-64.
+- Verify each host gets only its matching optional native package.
+- Verify unsupported combinations and `--omit=optional` produce actionable
+  errors.
+- Run `herdr-world --help` without a running Herdr session.
+- Run the existing packaged bridge live smoke against stock Herdr `v0.8.2`.
+- Verify package versions, optional dependency versions, release tag, legal
+  assets in every package, common-payload identity, GLIBC symbol baseline, and
+  npm dist-tag policy.
+- Exercise missing and mismatched platform packages, path overrides, glibc
+  below/at/above the floor, and partial-publication recovery without replacing
+  existing package contents.
+- Exercise a clean publish dry run before any immutable publication.
+
+### Homebrew
+
+- Run Cask audit/style checks from the tap checkout.
+- Fetch all three versioned URLs and independently verify their SHA-256 values.
+- Install and uninstall the Cask on Linux x86-64, macOS ARM64, and macOS
+  x86-64 where those Homebrew targets are available.
+- Verify the `herdr-world` command, wrapper-to-asset resolution, permissions,
+  and `--help` behavior.
+- Upgrade from one Cask version to the next and confirm the command points at
+  the new staged assets.
+- Reinstall and uninstall the Cask and confirm Caskroom/symlink resolution,
+  legal assets, and no daemon or workspace mutation during installation.
+- Run the live Herdr bridge smoke separately from the Homebrew no-daemon test.
+- Document the current unsigned/unnotarized macOS behavior and confirm no
+  installation step weakens Gatekeeper.
+
+### Shared release checks
+
+- Confirm all package-manager versions match the release tag without `v`.
+- Confirm all release channels handle prereleases deliberately.
+- Confirm npm, Homebrew, tarball, and future plugin installs use the same
+  compatibility and platform matrix.
+- Confirm the desktop tarball and Android packaging behavior remains unchanged.
+
+## Decisions carried into Spec 017
+
+The follow-up specification resolves the research questions as follows:
+
+1. Use the four scoped names shown above, subject to ownership of the
+   `@ivoryheart` scope. Check name availability as a publication prerequisite;
+   do not publish placeholders because npm has no ordinary name-reservation
+   workflow. Bootstrap with the first real prerelease.
+2. Use a Node 22.14.0-or-newer npm launcher with package-resolution-based
+   platform selection and explicit validated bridge/static paths.
+3. Use `next` for prereleases and `latest` only for stable package sets.
+4. Use the public third-party tap `IvoryHeart/homebrew-tap` and
+   `brew install --cask IvoryHeart/tap/herdr-world`.
+5. Defer both source-building and binary Homebrew formulas.
+6. Keep the ordinary `herdr-world` Cask stable-only until macOS signing,
+   notarization, and Gatekeeper checks pass. A hypothetical prerelease Cask
+   would need a separate name and documented channel.
+7. Preserve Spec 016's source-build-only plugin and defer package-manager
+   discovery or external binary reuse.
+8. Use a generated, reviewed tap pull request with narrowly scoped bot or
+   GitHub App credentials.
+
+## Recommended implementation order
+
+1. Establish ownership of the npm scope, select the package names, and create
+   the public Homebrew tap repository.
+2. Extract a shared release-payload staging helper from the current tarball
+   layout, preserving all legal and web assets.
+3. Implement and test the npm launcher plus platform packages.
+4. Implement the Homebrew Cask and solve Caskroom wrapper path resolution.
+5. Add package-manager checks to the tagged release workflow, leaving local
+   source builds and desktop tarballs intact.
+6. Publish the first npm prerelease only under an explicit non-stable tag.
+7. Publish the ordinary Homebrew Cask only after the stable signing and
+   notarization gate; use only separately named prerelease work if that later
+   channel is explicitly specified.
+8. Keep any explicit plugin reuse of installed distributions in a later
+   contract rather than changing Spec 016 implicitly.
+
+## Sources
+
+### npm
+
+- [npm `package.json` fields](https://docs.npmjs.com/files/package.json/) —
+  `bin`, `files`, `optionalDependencies`, `os`, `cpu`, and `libc`.
+- [npm publish](https://docs.npmjs.com/cli/commands/npm-publish/) — package
+  contents, dry runs, access, and immutable name/version publication.
+- [npm dist-tags](https://docs.npmjs.com/cli/dist-tag/) — stable `latest` and
+  prerelease tags such as `next`.
+- [npm trusted publishers](https://docs.npmjs.com/trusted-publishers/) — GitHub
+  OIDC setup, Node/npm requirements, and automatic provenance.
+- [npm provenance](https://docs.npmjs.com/generating-provenance-statements/) —
+  repository matching and GitHub Actions requirements.
+
+### Homebrew
+
+- [Adding Software to Homebrew](https://docs.brew.sh/Adding-Software-to-Homebrew)
+  — formula versus Cask selection and local validation commands.
+- [Cask Cookbook](https://docs.brew.sh/Cask-Cookbook) — `binary`,
+  `command_wrapper`, checksums, and artifact behavior.
+- [Acceptable Casks](https://docs.brew.sh/Acceptable-Casks) — platform support
+  and macOS Gatekeeper requirements.
+- [Taps](https://docs.brew.sh/Taps) — tap naming and direct installation.
+- [Tap Trust](https://docs.brew.sh/Tap-Trust) — trust scope for third-party tap
+  code.
+- [Official Codex Cask](https://github.com/Homebrew/homebrew-cask/blob/main/Casks/c/codex.rb)
+  — a current macOS/Linux ARM64/x86-64 CLI binary Cask precedent.
+- [Homebrew on Linux](https://docs.brew.sh/Homebrew-on-Linux) — Linux Homebrew
+  installation and glibc/support context.
+
+### Herdr World and Herdr
+
+- [Existing packaging](../packaging.md)
+- [Existing release process](../release.md)
+- [Herdr plugin release analysis](herdr-plugin-release-analysis-2026-08-26.md)
+- [Spec 016](../specs/016-herdr-world-plugin-release-spec.md)
+- [Herdr plugin documentation](https://herdr.dev/docs/plugins/)
+- [Herdr marketplace](https://herdr.dev/docs/marketplace/)
+- [Herdr socket API](https://herdr.dev/docs/socket-api/)

--- a/docs/analysis/npm-homebrew-distribution-analysis-2026-08-28.md
+++ b/docs/analysis/npm-homebrew-distribution-analysis-2026-08-28.md
@@ -121,8 +121,8 @@ The user-facing package should contain:
   documentation.
 
 Each platform package should contain only the matching
-`herdr-world-bridge` payload, its generated package metadata, and its complete
-applicable legal closure. It should declare npm's platform selectors:
+`herdr-world-bridge` payload and its complete applicable legal closure. It
+should declare npm's platform selectors:
 
 - `os` (`linux` or `darwin`);
 - `cpu` (`x64` or `arm64`); and
@@ -210,8 +210,8 @@ explicit `files` list should still be the primary boundary.
 
 Publishing needs to account for npm's immutability rule: a given package name
 and version cannot be reused after publication, even if the package is later
-removed. The workflow should therefore stage, pack, inspect, install-test, and
-hash-record all packages before the first publication call.
+removed. The workflow should therefore assemble, pack, inspect, install-test,
+and hash-record all packages before the first publication call.
 
 The release policy should be:
 
@@ -225,33 +225,34 @@ ordinary install resolves the `latest` tag. This makes the current release
 candidate safe to publish for testers without making it the default stable
 install.
 
-The first publication cannot use staged publishing or trusted publishing as a
-bootstrap mechanism: both require the package to already exist. The first real
-prerelease must therefore use an operator-authenticated npm workflow with 2FA,
-publishing the three platform packages before the launcher. Immediately after
-bootstrap, configure GitHub-hosted OIDC trusted publishing separately for all
-four packages, using the exact repository and workflow and stage-only
-permission where supported.
+The first publication cannot use trusted publishing as a bootstrap mechanism
+because each package must already exist. The first real prerelease must
+therefore use an operator-authenticated npm workflow with 2FA, publishing the
+three platform packages before the launcher. Immediately after bootstrap,
+configure GitHub-hosted OIDC trusted publishing separately for all four
+packages, using the exact repository and workflow.
 
-Subsequent releases should use npm staged publishing from the GitHub-hosted
-workflow. The staged-publishing CLI requires npm 11.15.0 or newer and Node
-22.14.0 or newer, and the package must already exist. The workflow needs
-`id-token: write`, should run `npm stage publish` for all four packages, and
-must download and inspect the actual staged tarballs before human 2FA approval.
-The three platform stages must be approved before the launcher stage. No
-long-lived publish token should be used.
+Subsequent releases should use direct trusted publishing from the GitHub-hosted
+workflow. The workflow needs `id-token: write`, Node 22.14.0 or newer, npm
+11.5.1 or newer, one protected GitHub environment approval for the publish job,
+and no long-lived publish token. It should publish the three platform packages
+before the launcher with the intended dist-tag. Staged publishing is optional
+future hardening, not part of the initial release path.
 
 The workflow must publish the platform packages before the top-level package,
 because the latter refers to exact platform package versions. It should not
 publish anything until the existing native archive verification and the npm
 package content checks pass.
 
-Because four npm publications are not atomic, release status must record each
-package's stage, publication result, hash, and next safe action. A transient
-failure before publication may retry the identical inspected tarball. A live
-package with incorrect bytes burns that application version; the complete set
-must advance together, with no divergent repair versions and no replacement
-of existing contents.
+Because four npm publications are not atomic, a CI summary or release artifact
+should report the four observed package results, versions, channels, hashes,
+and next safe actions. The npm registry remains authoritative; no custom state
+taxonomy or publication database is needed. Before publication, inspect,
+install-test, and hash all four exact tarballs. Before every retry, query npm;
+retry only a package that is confirmed missing, using its identical inspected
+tarball. A live package with incorrect bytes burns that application version;
+the complete set must advance together, with no divergent repair versions and
+no replacement or mutation of existing contents.
 
 ### npm alternatives considered
 
@@ -447,23 +448,23 @@ upload workflow completes. Publication sequencing should therefore be explicit:
 4. Upload and verify the complete GitHub release asset set.
 5. Build and inspect npm package tarballs from those verified assets.
 6. Install-test and hash-record the npm tarballs.
-7. Bootstrap-publish, or stage and approve, the npm package set under the
-   selected dist-tag.
+7. Bootstrap-publish, or directly trusted-publish, the npm package set under
+   the selected dist-tag.
 8. Prepare the reviewed Homebrew tap change after its stable/signing gates,
    then fetch/install-test the Cask.
 
 The Homebrew tap update needs its own authorization and failure behavior. The
 initial release should use a maintainer-prepared pull request from the verified
 release data, with Cask audit/style and install checks and human review. A
-source repository release should not silently rewrite an external tap. Bot or
-GitHub App automation is deferred; if introduced later, it should use narrowly
-scoped credentials limited to the required tap pull-request operation.
+source repository release should not silently rewrite an external tap. The tap
+change should remain a maintainer-prepared, reviewed pull request from the
+verified release data.
 
 All public package versions should derive from the same release tag after
 removing only the leading `v`. The root development package versions should
 remain independent and private. The plugin manifest in Spec 016 already
-introduces a second public versioned surface, so the release validation should
-eventually check the plugin manifest, npm staging metadata, GitHub tag, and
+introduces a second public versioned surface, so release validation should
+eventually check the plugin manifest, npm package metadata, GitHub tag, and
 Homebrew Cask version together without publishing a package as a side effect
 of a local development build.
 
@@ -596,8 +597,10 @@ The follow-up specification resolves the research questions as follows:
    would need a separate name and documented channel.
 7. Preserve Spec 016's source-build-only plugin and defer package-manager
    discovery or external binary reuse.
-8. Use a reviewed tap pull request prepared from verified release data; defer
-   bot or GitHub App automation until it is justified by repeated releases.
+8. Use a maintainer-prepared reviewed tap pull request from verified release
+   data.
+9. Keep npm staged publishing as optional future hardening; it only applies to
+   package names that already exist and is not part of the initial release path.
 
 ## Recommended implementation order
 

--- a/docs/analysis/npm-homebrew-distribution-analysis-2026-08-28.md
+++ b/docs/analysis/npm-homebrew-distribution-analysis-2026-08-28.md
@@ -204,8 +204,9 @@ The first implementation should not add a Cask wrapper, path environment
 contract, downloader, daemon, or service supervisor. The direct `binary`
 mapping must be tested after install, upgrade, reinstall, and removal of an
 older version. If direct mapping demonstrably fails because of Caskroom path
-resolution, that is evidence for a later narrowly scoped specification; it is
-not a reason to add an unreviewed wrapper now.
+resolution, use the smallest validated path adaptation and update the
+specification only if the public contract changes. It is not a reason to add
+an unreviewed wrapper now.
 
 Installation should only unpack and link files. It must not start Herdr or the
 bridge, create or modify a workspace, or weaken the existing bridge security

--- a/docs/specs/017-herdr-world-npm-homebrew-distribution-spec.md
+++ b/docs/specs/017-herdr-world-npm-homebrew-distribution-spec.md
@@ -538,7 +538,7 @@ The status projection SHALL report these observable states:
 | `platform-published` | All three exact platform versions exist and match hashes | Stage/approve the launcher |
 | `launcher-pending` | The launcher stage is being inspected or awaits approval | Inspect/approve the launcher stage |
 | `partial` | A publication result is unknown or only part of the intended set is live | Query npm and resume only missing packages with identical tarballs |
-| `complete` | All four live versions exist with matching hashes and tag | Generate the eligible tap PR |
+| `complete` | All four live versions exist with matching hashes and tag | Prepare the eligible tap PR |
 | `burned` | A wrong byte set was published for this version | Advance the complete set to a new application version |
 
 A validation or external-prerequisite failure before publication SHALL be
@@ -642,29 +642,31 @@ signed and notarized and pass the applicable Gatekeeper checks. Cask
 implementation and local validation MAY use release-candidate fixtures before
 that gate, but such fixtures SHALL not be presented as a stable publication.
 
-### Requirement: Generated tap pull request
+### Requirement: Reviewed tap pull request
 
 After the complete GitHub release asset set is available and the stable
-signing gate passes, the tap update mechanism SHALL generate a pull request in
-`IvoryHeart/homebrew-tap`. The change SHALL update only the release version,
-three target URLs, and three corresponding SHA-256 values, plus any reviewed
-metadata required by the Cask.
+signing gate passes, a maintainer SHALL prepare a pull request in
+`IvoryHeart/homebrew-tap` from the verified release data. The initial process
+MAY be manual. The change SHALL update only the release version, three target
+URLs, and three corresponding SHA-256 values, plus any reviewed metadata
+required by the Cask.
 
-The generated pull request SHALL run Homebrew Cask audit/style and installation
-checks for macOS ARM64, macOS x86-64, and Linux x86-64 where those Homebrew
-targets are available. A human review SHALL be required before merge.
+The pull request SHALL run Homebrew Cask audit/style and installation checks
+for macOS ARM64, macOS x86-64, and Linux x86-64 where those Homebrew targets
+are available. A human review SHALL be required before merge.
 
-Automation SHALL use narrowly scoped bot or GitHub App credentials limited to
-the required tap pull-request operation. The source repository SHALL not hold
-an unrestricted credential capable of rewriting the tap. The PR SHALL not be
-generated from a partial GitHub release asset set.
+Bot or GitHub App automation is deferred for the initial release. If it is
+introduced later, it SHALL use narrowly scoped credentials limited to the
+required tap pull-request operation. The source repository SHALL not hold an
+unrestricted credential capable of rewriting the tap. A pull request SHALL not
+be prepared from a partial GitHub release asset set.
 
 #### Scenario: The release has one missing archive
 
 - **GIVEN** the release tag exists but one of the three archives or checksums is
   missing or unverifiable
-- **WHEN** tap update automation is requested
-- **THEN** no tap PR is generated and the release status names the missing asset
+- **WHEN** a tap PR is requested
+- **THEN** no tap PR is prepared and the release status names the missing asset
 
 ### Requirement: Plugin independence
 
@@ -797,9 +799,10 @@ Stage-only permission SHALL be preferred for trusted publishers. Human 2FA
 approval is the boundary that makes a staged package live, with platform
 packages approved before the launcher package.
 
-Homebrew tap automation SHALL use least-privilege credentials and pull requests
-with review. A tap update SHALL be impossible to trigger from an incomplete or
-unverified release asset set.
+If Homebrew tap automation is introduced, it SHALL use least-privilege
+credentials and pull requests with review. The initial maintainer-prepared tap
+PR SHALL be based on the same verified release data. A tap update SHALL be
+impossible to prepare from an incomplete or unverified release asset set.
 
 ### 7.3 Supply-chain evidence
 
@@ -832,8 +835,8 @@ these steps in order:
 7. Inspect and install-test all npm tarballs, and record their hashes.
 8. Bootstrap-publish or stage/approve the npm package set according to whether
    the package names already exist.
-9. Generate a reviewed Homebrew tap PR when the stable and signing gates are
-   satisfied.
+9. Prepare a reviewed Homebrew tap PR from the verified release data when the
+   stable and signing gates are satisfied.
 10. Install-test the resulting Cask from the tap on every supported target.
 
 No later step SHALL make an earlier validation step implicit. In particular,
@@ -934,7 +937,8 @@ Rollout SHALL occur in these gates:
 5. Use staged publishing for later prereleases, with downloaded-stage
    inspection and human platform-before-launcher approval.
 6. Publish the ordinary stable Cask only after macOS signing/notarization and
-   Gatekeeper checks pass; merge only a reviewed generated tap PR.
+   Gatekeeper checks pass; merge only a reviewed tap PR prepared from verified
+   release data.
 7. Monitor the package/release status record for partial publication and
    reconcile before any retry.
 

--- a/docs/specs/017-herdr-world-npm-homebrew-distribution-spec.md
+++ b/docs/specs/017-herdr-world-npm-homebrew-distribution-spec.md
@@ -8,949 +8,395 @@
 - **Approved by:** —
 - **Approved at:** —
 
-This is a standalone distribution contract related to, but independent from,
-[Spec 016](016-herdr-world-plugin-release-spec.md). Its primary research input
-is the [npm and Homebrew distribution analysis](../analysis/npm-homebrew-distribution-analysis-2026-08-28.md).
+This specification is a standalone distribution contract related to, but
+independent from, [Spec 016](016-herdr-world-plugin-release-spec.md). Its
+primary research input is the
+[npm and Homebrew distribution analysis](../analysis/npm-homebrew-distribution-analysis-2026-08-28.md).
 It does not extend the Herdr plugin lifecycle contract.
 
-## 1. Purpose
+## 1. Purpose and outcome
 
-Herdr World currently has verified desktop release archives that contain the
-native bridge, the web application, the launcher, documentation, and legal
-assets. This specification defines how users will obtain the same application
-through npm and Homebrew without creating a second native-build truth or an
-implicit dependency on either package manager.
+Herdr World already produces verified desktop archives containing the native
+bridge, web application, launcher, documentation, and legal assets. This
+specification defines the smallest package-manager distribution that reuses
+those release outputs.
 
 The outcome is:
 
-- one public npm launcher package with one exact-version optional native
-  package for each supported target; and
-- one stable-only Homebrew Cask in the separate public third-party tap
+- one public npm package, `@ivoryheart/herdr-world`, containing the Node
+  entrypoint, shared application payload, and all three supported native
+  bridges; and
+- one binary-first Homebrew Cask in the separate public third-party tap
   `IvoryHeart/homebrew-tap`.
 
-Both distributions SHALL remain compatible with the existing Herdr admission,
-loopback, browser-origin, and terminal-protocol behavior. Installation SHALL
-install files only. It SHALL not install Herdr, start a bridge, create a
-workspace, or silently alter Herdr state.
+Both distributions SHALL remain separate from Herdr itself. Installation SHALL
+install files only: it SHALL not install Herdr, start Herdr or the bridge,
+create a workspace, or change plugin state.
 
-## 2. Scope
+## 2. Scope and support matrix
 
-This specification includes:
+The supported package-manager targets are:
 
-- the verified-release-archive source boundary and common-payload identity
-  check;
-- the four-package npm topology, metadata, package contents, launcher, and
-  platform selection behavior;
-- the Linux glibc compatibility contract;
-- npm prerelease/stable channels, first-publication bootstrap, subsequent
-  trusted publishing, and partial-publication recovery;
-- the binary-first Homebrew Cask shape, tap update contract, Caskroom path
-  handling, and stable/signing gate;
-- the relationship between these standalone distributions and the source-build
-  only initial plugin design in Spec 016;
-- release sequencing, security properties, validation, rollout, and observable
-  failure states.
+| Operating system | CPU | Existing release archive |
+| --- | --- | --- |
+| Linux | x86-64 with glibc 2.34 or newer | `linux-x86_64` |
+| macOS | ARM64 | `macos-arm64` |
+| macOS | x86-64 | `macos-x86_64` |
 
-The initial supported package-manager targets are:
+Linux ARM64, musl Linux, Windows, Android, and other combinations are outside
+this support promise. The npm entrypoint and Cask SHALL fail clearly for
+unsupported operating systems, architectures, or libc implementations.
 
-| Operating system | CPU | Native archive | npm package |
-| --- | --- | --- | --- |
-| Linux | x86-64 | `linux-x86_64` | `@ivoryheart/herdr-world-linux-x64-gnu` |
-| macOS | ARM64 | `macos-arm64` | `@ivoryheart/herdr-world-darwin-arm64` |
-| macOS | x86-64 | `macos-x86_64` | `@ivoryheart/herdr-world-darwin-x64` |
-
-Homebrew SHALL support exactly the same three target combinations. npm and
-Homebrew SHALL reject or fail clearly on every other combination.
+This specification does not implement package generation, npm publication,
+Cask or release-workflow changes, or launcher changes. Those are follow-up
+implementation work.
 
 ## 3. Non-goals
 
-The following are explicitly outside this specification:
+The following are explicitly deferred:
 
-- changing the existing desktop tarball names, layout, launcher defaults, or
-  validation contract;
-- changing Android packaging or the Android companion client;
-- changing the Herdr plugin lifecycle, plugin manifest, plugin-managed service
-  ownership, or Spec 016's initial source-build-only design;
-- making the plugin discover or reuse an npm/Homebrew installation;
-- a plugin binary-first or external-installation mode;
-- Linux ARM64, musl-based Linux, Windows, or any other unsupported target;
-- a source-building Homebrew formula;
-- a binary Homebrew formula;
-- submission to Homebrew/core or the official Homebrew Cask repository;
+- optional npm platform packages or a multi-package publication graph;
+- a second native build pipeline or an install-time release downloader;
+- npm publication states, staged publishing, OIDC/CI publication automation,
+  or a publication database;
+- a Cask wrapper, new public path environment contract, or service supervisor;
+- source-building or binary Homebrew formulas;
+- official Homebrew repository submission;
 - a prerelease Homebrew Cask channel;
-- an npm install-time release downloader;
-- implementation of package generation, npm publication, tap automation,
-  release-workflow changes, or launcher changes in this specification task;
-- macOS signing/notarization implementation. The stable Cask publication gate
-  defined here depends on that work being completed separately.
+- Linux ARM64, musl Linux, Windows, or additional targets;
+- plugin discovery or reuse of npm/Homebrew installations; and
+- changes to desktop tarball layout, Android packaging, or Spec 016.
 
-## 4. Context and constraints
+A later package split MAY be proposed only after measured packed-size evidence or
+an actual npm distribution limit demonstrates that the universal package is
+impractical.
 
-### 4.1 Existing release boundary
+## 4. Settled requirements
 
-The verified GitHub release archives produced by the existing desktop release
-process are the native source of truth. For each target, the archive contains
-the bridge binary and the common launcher/web/documentation/legal payload. npm
-and Homebrew SHALL reuse the bridge binary from the corresponding verified
-archive.
+### 4.1 Verified release reuse
 
-After an archive passes release validation, package-manager generation MUST NOT
-compile another native bridge from source, select a bridge from an unverified
-build, or download a bridge during package installation. A package-manager
-artifact MAY re-layout files from a verified archive, but it SHALL not change
-the native payload.
+The existing GitHub desktop release archives SHALL remain the native source of
+truth. The release process SHALL build all three archives from the final tag
+and verify their contents, legal closure, native format, and SHA-256 checksums
+before creating either package-manager artifact.
 
-The desktop tarballs and Android packaging remain independent products. Adding
-the package-manager distributions SHALL not require their layout or behavior to
-change.
+The npm package SHALL copy each native bridge from its matching verified archive.
+The Cask SHALL use those same immutable release archives. Neither distribution
+MAY compile a second native bridge or download a bridge during installation.
 
-### 4.2 Release versions
+The existing desktop tarballs and Android packaging SHALL remain unchanged.
 
-The application version is derived from `release.json` using exactly one
-transformation: remove one leading `v`. For example,
-`{"current":"v0.1.0-rc.1"}` produces `0.1.0-rc.1`. No other prefix, suffix, or
-prerelease component SHALL be removed or rewritten.
+### 4.2 Universal npm package
 
-The root `package.json` and `web/package.json` remain private development
-manifests. They SHALL not become the published npm manifests and their
-versions SHALL not be changed merely to publish a distribution.
+The package SHALL be named `@ivoryheart/herdr-world`. Ownership of the
+`@ivoryheart` npm scope is an external publication prerequisite. npm package
+names SHALL be checked before the first real publication; placeholder packages
+SHALL not be published merely to reserve names.
 
-### 4.3 Runtime and compatibility baseline
+The package SHALL:
 
-The npm launcher runtime is Node.js. The initial supported Node floor is
-`22.14.0`; the main package SHALL declare `engines.node: ">=22.14.0"`. The
-release and trusted-publishing jobs SHALL use Node `22.14.0` or newer.
-
-The current `v0.1.0-rc.1` Linux bridge requires symbols through
-`GLIBC_2.34`. Unless a separate, approved effort deliberately lowers the
-native baseline, glibc `2.34` is the minimum Linux runtime contract.
-
-npm's `libc: ["glibc"]` metadata expresses the libc family. It does not
-express or enforce a glibc version. The npm launcher therefore has an
-independent version preflight.
-
-The application still requires a separately installed compatible Herdr
-session, Herdr `v0.8.2` or newer, and terminal protocol `20`, as described by
-the existing packaging and release documentation.
-
-## 5. Requirements
-
-### Requirement: Verified archive reuse
-
-The release system SHALL build all three native archives from the final tag and
-shall verify each archive's contents, legal closure, native format, and
-checksum before any npm or Homebrew artifact is generated.
-
-The release system MUST fail if package generation attempts to use a native
-binary that is not byte-identical to the bridge extracted from its matching
-verified archive.
-
-#### Scenario: A second native build is attempted
-
-- **GIVEN** the three tagged desktop archives have passed validation
-- **WHEN** package generation is invoked
-- **THEN** generation extracts the matching bridge from those archives and does
-  not run a second native build
-
-### Requirement: Common payload identity
-
-Before generating npm packages, release validation SHALL compare the common
-payload in all three verified archives. The comparison SHALL normalize away
-only the archive's platform-specific root directory and exclude only the
-platform-specific bridge binary.
-
-The common payload is the byte content and relative path set for:
-
-- the shared launcher;
-- the complete bundled `share/herdr-world/web/` tree;
-- the runtime documentation included by the desktop archive;
-- `README.md`, `LICENSE`, `THIRD_PARTY_NOTICES.md`, and `UPSTREAM.md`;
-- the complete applicable `docs/`, `third_party/`, and legal/inventory trees.
-
-The validator SHALL produce a canonical sorted manifest mapping every common
-relative path to its SHA-256 digest, compare those manifests, and SHALL fail on
-a missing, additional, or different common file or digest. This manifest is the
-release proof that the common payload is byte-identical. One designated
-verified archive, `linux-x86_64`, SHALL supply the common npm payload after this
-check succeeds.
-The designation is a source-selection convenience; it does not relax the
-identity check.
-
-#### Scenario: A platform build changes a common file
-
-- **GIVEN** all three native archives pass their individual checks
-- **WHEN** the common-payload comparison finds different web, launcher,
-  documentation, or legal bytes
-- **THEN** npm generation stops, no package is publishable, and the release is
-  reported as blocked pending a reproducible payload fix
-
-### Requirement: Main npm package identity and topology
-
-The published npm packages SHALL have exactly these names:
+- be public, with `publishConfig.access: "public"`;
+- derive its version from `release.json` by removing only the leading `v`;
+- declare `engines.node: ">=22.14.0"`;
+- use repository metadata resolving exactly to
+  `https://github.com/IvoryHeart/herdr-world`;
+- use an explicit `files` allowlist;
+- expose only the `herdr-world` command;
+- contain the Node entrypoint, shared launcher behavior, bundled web assets,
+  documentation, and complete legal material; and
+- contain all three bridges at these fixed package-relative paths:
 
 ```text
-@ivoryheart/herdr-world
-@ivoryheart/herdr-world-linux-x64-gnu
-@ivoryheart/herdr-world-darwin-arm64
-@ivoryheart/herdr-world-darwin-x64
+native/linux-x64/herdr-world-bridge
+native/darwin-arm64/herdr-world-bridge
+native/darwin-x64/herdr-world-bridge
 ```
 
-Ownership and publication control of the `@ivoryheart` scope is an external
-publication prerequisite. Package names SHALL be selected and checked as part
-of bootstrap; the workflow SHALL not publish placeholder packages merely to
-occupy names.
+The package SHALL not declare optional platform dependencies or platform
+selectors. The root and `web/package.json` files SHALL remain private
+development manifests and SHALL not be published as the runtime package.
 
-The main package SHALL:
+The allowlist SHALL include the package manifest and README, launcher support
+files, `share/herdr-world/web/**`, all three native paths, `LICENSE`,
+`THIRD_PARTY_NOTICES.md`, `UPSTREAM.md`, `docs/world-assets.md`,
+`third_party/**`, and
+`vendor/herdr-compat/VENDOR-MANIFEST.toml`. It SHALL include every file
+referenced by the bundled legal manifest and SHALL not include source-only
+dependencies, tests, CI files, Android outputs, or an arbitrary
+`node_modules` tree.
 
-- be public and non-private;
-- declare `publishConfig` with `access: "public"` and
-  `registry: "https://registry.npmjs.org/"`;
-- declare only one executable mapping, `herdr-world`;
-- contain the shared launcher, the common web assets, runtime documentation,
-  and all common/applicable legal material;
-- declare all three platform packages in `optionalDependencies` at the exact
-  same application version;
-- use an explicit `files` allowlist;
-- derive its version from `release.json` by removing only the leading `v`;
-- declare `engines.node: ">=22.14.0"`; and
-- use repository metadata resolving exactly to
-  `https://github.com/IvoryHeart/herdr-world`.
+The package SHALL not use `preinstall` or `postinstall` to fetch release
+assets, execute Herdr, or create a second native payload.
 
-The generated package manifests and package files SHALL be maintained
-separately from the private root and web development manifests. They SHALL not
-publish the repository root, source-only dependencies, Rust targets, Android
-outputs, tests, CI files, or an arbitrary `node_modules` tree.
+#### Scenario: The npm package is inspected
 
-The main and platform package manifests SHALL not use `preinstall` or
-`postinstall` to download release assets or otherwise create a second native
-payload. Native bridge bytes SHALL arrive only as the already inspected
-platform package tarball.
+- **GIVEN** a package is generated from `v0.1.0-rc.1`
+- **WHEN** its manifest and packed file list are inspected
+- **THEN** the version is `0.1.0-rc.1`, the repository is exact, access is
+  public, only `herdr-world` is exposed, all three fixed bridge paths exist,
+  and the package contains complete applicable legal material
 
-#### Scenario: Main package metadata is inspected
+### 4.3 npm entrypoint and runtime selection
 
-- **GIVEN** a package has been generated from `v0.1.0-rc.1`
-- **WHEN** its `package.json` is inspected
-- **THEN** its version is `0.1.0-rc.1`, its repository identifies
-  `IvoryHeart/herdr-world`, its access is public, its only `bin` key is
-  `herdr-world`, and all three optional dependencies are exactly `0.1.0-rc.1`
+The Node entrypoint SHALL select exactly one fixed bridge path using
+`process.platform`, `process.arch`, and Linux libc information:
 
-### Requirement: Platform npm package contents and selectors
-
-Each platform package SHALL contain only:
-
-- the matching bridge binary extracted from its verified desktop archive;
-- the complete legal material applicable to that bridge payload, including the
-  project license, native dependency inventory, notices, and referenced license
-  files.
-
-The existing desktop legal closure SHALL be copied without path or content
-rewriting into every npm package that carries `THIRD_PARTY_NOTICES.md`. This
-closure includes `LICENSE`, `THIRD_PARTY_NOTICES.md`, `UPSTREAM.md`,
-`docs/world-assets.md`, `vendor/herdr-compat/VENDOR-MANIFEST.toml`, the
-complete `third_party/**` trees, and the bundled web legal files. In a platform
-package, web legal files are legal-only material; the web runtime tree is not
-included. Package generation SHALL not introduce a package-specific notice
-splitting system.
-
-Each platform package SHALL have an explicit `files` allowlist and SHALL have
-the same application version as the main package. It SHALL declare exact
-selectors as follows:
-
-| Package | `os` | `cpu` | `libc` |
+| Platform | Architecture | Runtime result | Bridge path |
 | --- | --- | --- | --- |
-| `@ivoryheart/herdr-world-linux-x64-gnu` | `linux` | `x64` | `glibc` |
-| `@ivoryheart/herdr-world-darwin-arm64` | `darwin` | `arm64` | not applicable |
-| `@ivoryheart/herdr-world-darwin-x64` | `darwin` | `x64` | not applicable |
-
-The platform packages MUST NOT declare a `bin` mapping and MUST NOT expose
-`herdr-world-bridge` as a global command. The bridge SHALL be stored at the
-exact implementation path `native/herdr-world-bridge`, and the main launcher
-SHALL resolve that path through normal Node package resolution, not by a
-current-working-directory guess.
-
-#### Scenario: A platform tarball is inspected
-
-- **GIVEN** the Linux platform package is unpacked
-- **WHEN** its file list and metadata are checked
-- **THEN** it contains its x86-64 bridge and complete applicable legal closure,
-  declares `os: ["linux"]`, `cpu: ["x64"]`,
-  `libc: ["glibc"]`, has no `bin` mapping, and contains no web runtime or
-  launcher payload beyond legal-only files
-
-### Requirement: Explicit npm file boundaries
-
-The generated main and platform package manifests SHALL use explicit
-`files` allowlists. Package generation SHALL reject an allowlist that includes
-unreviewed build output, an install script, a release downloader, credentials,
-or files outside the intended package boundary.
-
-`npm pack --dry-run` SHALL be treated as a release check. The checked file list
-SHALL be recorded with the package version and tarball hash before publication.
-
-Every published package SHALL be independently auditable for its payload's
-legal closure. A legal manifest SHALL not reference a file absent from that
-package, and every applicable native or web dependency notice SHALL be present
-in the package that carries the dependency.
-
-### Requirement: npm platform resolver
-
-The `herdr-world` npm launcher SHALL select the platform package using
-`process.platform`, `process.arch`, and Linux libc information. The supported
-selection table is:
-
-| `process.platform` | `process.arch` | libc result | Selected package |
-| --- | --- | --- | --- |
-| `linux` | `x64` | glibc at or above 2.34 | `@ivoryheart/herdr-world-linux-x64-gnu` |
-| `darwin` | `arm64` | not applicable | `@ivoryheart/herdr-world-darwin-arm64` |
-| `darwin` | `x64` | not applicable | `@ivoryheart/herdr-world-darwin-x64` |
-
-The launcher SHALL reject Linux ARM64, Linux musl, Windows, and every other
-unsupported operating-system/architecture/libc combination before attempting
-to execute a bridge. Linux x64 with glibc below 2.34 SHALL receive a distinct
-minimum-version error.
-
-The launcher SHALL resolve the installed optional package using Node package
-resolution from the main package's own module location. It MUST NOT infer a
-global npm prefix, search the current working directory, or depend on the
-user's `PATH` to find the native package. A missing package, an optional
-dependency omitted with `--omit=optional`, or a package whose installation was
-skipped or failed SHALL produce an actionable error naming the selected
-package, detected target, and a corrective installation command.
-
-The launcher SHALL read the selected platform package's normal `package.json`
-through that same Node package resolution and SHALL reject a version different
-from the main package before executing the fixed `native/herdr-world-bridge`
-path.
-
-#### Scenario: Optional dependencies are omitted
-
-- **GIVEN** the main package is installed with `npm install --omit=optional`
-- **WHEN** `herdr-world` is invoked on a supported host
-- **THEN** it exits nonzero with a clear missing-optional-package diagnostic,
-  names the exact platform package, and does not start Herdr or a bridge
-
-### Requirement: Shared-launcher path contract
-
-The shared launcher SHALL support these exact environment variables:
-
-| Variable | Contract |
-| --- | --- |
-| `HERDR_WORLD_BRIDGE_BIN` | Absolute path to the bridge executable |
-| `HERDR_WORLD_STATIC_DIR` | Absolute path to the static web directory |
-
-The npm launcher and Homebrew wrapper SHALL set both values before invoking the
-shared launcher. Existing desktop tarball calls with these variables unset
-SHALL retain the current relative-bundle behavior.
-
-If either path variable is set, both path variables MUST be set. Each path
-MUST be absolute, MUST exist at invocation time, and MUST have the expected
-type: the bridge MUST be a regular executable file and the static path MUST be
-a directory containing the packaged web entrypoint. Missing, invalid, relative,
-nonexistent, or type-incompatible paths
-SHALL fail closed before any bridge or Herdr process is started. The launcher
-MUST NOT resolve an invalid path relative to the current working directory.
-
-The override contract is intentionally narrow: it supplies only the bridge,
-static directory, and no other runtime inputs. It SHALL not replace Herdr socket,
-workspace, host, origin, or security-policy settings.
-
-#### Scenario: A Cask symlink is invoked after an upgrade
-
-- **GIVEN** Homebrew's `herdr-world` symlink points into a versioned Caskroom
-  directory
-- **WHEN** the command is run after install, upgrade, or reinstall
-- **THEN** the wrapper resolves the active staged bridge and static directory
-  explicitly, validates both absolute paths, and serves assets from that same
-  version without using the caller's working directory
+| `linux` | `x64` | glibc 2.34+ | `native/linux-x64/herdr-world-bridge` |
+| `darwin` | `arm64` | any supported macOS libc | `native/darwin-arm64/herdr-world-bridge` |
+| `darwin` | `x64` | any supported macOS libc | `native/darwin-x64/herdr-world-bridge` |
 
-### Requirement: npm launcher process behavior
-
-The npm launcher SHALL:
+It SHALL reject Linux ARM64, musl or unknown libc, Windows, and every other
+unsupported combination before executing a bridge. Missing or damaged
+package-local bridge files SHALL produce an actionable nonzero error.
 
-- preserve every user argument in order and without shell re-parsing;
-- preserve standard input, standard output, and standard error;
-- forward relevant termination signals to the child bridge/launcher and avoid
-  leaving an orphaned child;
-- return the child's successful exit status unchanged;
-- return a deterministic nonzero status and useful diagnostic for launcher
-  preflight failures; and
-- avoid starting Herdr onboarding, selecting a workspace, or starting a
-  listening bridge for `herdr-world --help`.
-
-For `--help` (including the documented short help form, if supported), the npm
-entrypoint SHALL print its usage and exit without spawning the bridge. Help
-output SHALL be available without a running Herdr session or installed
-optional native package, so an omitted optional dependency does not turn help
-into an opaque native-loader error.
-
-#### Scenario: Arguments and signals are forwarded
-
-- **GIVEN** a supported npm installation and a running compatible Herdr
-- **WHEN** a user passes arbitrary supported bridge arguments, types on stdin,
-  and sends an interrupt or termination signal
-- **THEN** the child receives the same arguments and standard streams, receives
-  the signal once, and `herdr-world` exits with the child's resulting status
+The entrypoint SHALL resolve all package files from its own installed package
+location. It SHALL not use the current working directory, a guessed npm
+prefix, an ambient global executable, or a user-provided path override.
 
-#### Scenario: Help is requested
+The entrypoint SHALL invoke the shared launcher behavior with the selected
+package-local bridge and the package-local static web directory. This
+selection is an internal package implementation detail; this specification
+defines no new public environment-variable path contract.
 
-- **GIVEN** no running Herdr session and no optional native package
-- **WHEN** the user runs `herdr-world --help`
-- **THEN** usage is printed, the command exits successfully, and neither Herdr
-  onboarding nor a bridge process is started
+The entrypoint SHALL preserve arguments, standard input, standard output,
+standard error, relevant child signals, and child exit status. It SHALL not
+start Herdr onboarding, select a workspace, or start a bridge for
+`herdr-world --help`. Help SHALL succeed without a running Herdr session.
 
-### Requirement: Linux glibc release check
-
-For the Linux x86-64 bridge, release validation SHALL extract the maximum
-required GLIBC symbol version from the exact binary copied from the verified
-archive. The check SHALL fail if the maximum required version exceeds the
-declared baseline `2.34`. The extracted value, declared baseline, binary
-digest, and target archive digest SHALL be retained as release evidence.
-
-The check SHALL fail closed if the ELF version information cannot be read. It
-SHALL not infer compatibility only from the build host's glibc version. The
-release evidence SHALL include the extracted maximum symbol, declared minimum,
-binary digest, and target archive digest.
-
-#### Scenario: A bridge requires a newer glibc
-
-- **GIVEN** the extracted Linux binary contains a requirement such as
-  `GLIBC_2.35`
-- **WHEN** the release ABI check runs with baseline `2.34`
-- **THEN** release validation fails before npm or Homebrew generation and the
-  binary is not publishable
-
-### Requirement: Linux glibc launcher preflight
-
-Before executing the Linux bridge, the npm launcher SHALL detect the host's
-actual glibc version and compare it with the required version from the
-fixed initial baseline `2.34`. It SHALL report both the required and detected
-versions before execution when the preflight is evaluated.
-
-The preflight SHALL distinguish:
-
-- glibc below `2.34`, with required and detected versions in the error;
-- glibc at `2.34`, which is supported;
-- glibc above `2.34`, which is supported subject to the other checks; and
-- musl or an unidentifiable libc, which is unsupported for this package.
-
-The initial launcher implementation SHALL own the single required glibc
-baseline constant `2.34`; it SHALL not require a package-manager environment
-override or custom native-package metadata to obtain that value.
-
-The Homebrew Linux wrapper SHALL provide the same preflight result before
-executing the Cask bridge. No path or libc error SHALL fall through to an
-opaque native dynamic-loader failure.
-
-The release validation SHALL include positive execution at the 2.34 floor and
-negative execution below the floor. It SHALL also test clear Linux ARM64 and
-musl rejection. The npm `libc` selector remains a package-install filter only;
-these runtime checks are mandatory.
-
-### Requirement: npm channels and version set
-
-All four packages SHALL use one identical application version and one intended
-publication channel for a release set:
-
-- prerelease versions SHALL use the `next` dist-tag;
-- stable versions SHALL use the `latest` dist-tag; and
-- a prerelease SHALL never move or overwrite `latest`.
-
-The publication command SHALL pass the intended tag explicitly. A package set
-with mixed versions or mixed intended channels SHALL be rejected before
-publication.
-
-### Requirement: First-publication bootstrap
-
-The release process SHALL recognize that trusted publishing requires a package
-that already exists. It cannot be configured as the mechanism for creating all
-four package names for the first time.
-
-The first publication SHALL be the first real prerelease, not a placeholder.
-It SHALL use an operator-authenticated npm workflow with 2FA. Before the first
-publish call, the process SHALL:
-
-1. generate all four package tarballs from the verified release assets;
-2. inspect each tarball's exact file list and metadata;
-3. install-test each tarball on its applicable target;
-4. record a cryptographic hash for each tarball and the release evidence; and
-5. confirm scope ownership, package-name availability, and the `next` channel.
-
-The three platform packages SHALL publish first, in any deterministic order,
-and the main launcher package SHALL publish last. Bootstrap SHALL not use a
-long-lived token stored in the repository or workflow.
-
-Immediately after all four packages exist, trusted publishing SHALL be
-configured separately for every package. Each configuration SHALL identify the
-exact `IvoryHeart/herdr-world` repository and exact release workflow.
-
-#### Scenario: Bootstrap is attempted before scope ownership
-
-- **GIVEN** the `@ivoryheart` scope is not controlled by the project
-- **WHEN** bootstrap validation runs
-- **THEN** publication stops as an external prerequisite failure and no
-  placeholder package is published
-
-### Requirement: Subsequent direct trusted publishing
-
-After bootstrap, the release workflow SHALL use direct GitHub-hosted OIDC
-trusted publishing for every package. It SHALL:
-
-- run with `id-token: write`;
-- use Node `22.14.0` or newer and npm `11.5.1` or newer;
-- use the exact configured `IvoryHeart/herdr-world` repository and release
-  workflow for each package;
-- require one protected GitHub environment approval for the publish job;
-- publish all four packages with `npm publish --tag <channel>`;
-- publish the three platform packages before the launcher package; and
-- use no long-lived npm publishing token.
-
-The workflow SHALL validate that all four tarballs have the same version and
-intended channel before the environment approval. The protected environment
-approval SHALL gate the package-publish job as a whole; it SHALL not require a
-separate approval for each package. Staged publishing is optional deferred
-hardening and is not required by this specification.
-
-#### Scenario: Trusted publisher configuration is wrong
-
-- **GIVEN** a package's trusted publisher configuration names a different
-  repository or workflow
-- **WHEN** the publish job requests OIDC authentication
-- **THEN** publication fails before package bytes are published and the release
-  identifies the exact package configuration that must be corrected
-
-### Requirement: npm publication recovery
-
-npm publication of four packages SHALL be treated as non-atomic. The npm
-registry SHALL remain the authoritative publication state. Before publication,
-the release process SHALL inspect, install-test, and hash all four exact
-tarballs. A CI summary or release artifact SHALL make any partial publication
-visible and actionable by listing each package's observed result, version,
-channel, hash, and next safe action. It SHALL not create a custom publication
-database, state taxonomy, or credential record.
-
-Before the launcher package is published, all three platform package names
-SHALL exist at the exact application version with the inspected bytes. The
-launcher SHALL never be published first.
-
-A transient failure before a package version is published MAY retry only after
-querying npm and confirming that the exact version is absent. The retry SHALL
-use the identical inspected tarball. If a package is already live with correct
-bytes, the process SHALL resume only the missing package and SHALL not
-republish or mutate the existing package. If incorrect bytes are published for
-any package, that application version is burned permanently and the complete
-four-package set MUST advance to a new application version. The process SHALL
-never create divergent package versions to repair one member of the set.
-
-#### Scenario: A package publication times out
-
-- **GIVEN** the platform tarball was inspected and its publication result is
-  unknown
-- **WHEN** the registry cannot immediately confirm whether the exact version is
-  live
-- **THEN** the CI/release summary records the package result as unknown, the
-  registry is queried before retrying, and the process either publishes the
-  missing package with the identical tarball or stops for operator reconciliation
-
-#### Scenario: One package has wrong live bytes
-
-- **GIVEN** one package at version `0.1.0-rc.1` is live with bytes that do not
-  match the inspected tarball
-- **WHEN** release reconciliation detects the mismatch
-- **THEN** version `0.1.0-rc.1` is marked `burned`, no package at that version is
-  replaced, and the next release advances all four packages together
-
-### Requirement: Homebrew third-party Cask
-
-The initial Homebrew distribution SHALL be a Cask in the separate public
-third-party repository `IvoryHeart/homebrew-tap`. The stable user-facing
-command SHALL be:
+#### Scenario: npm target selection succeeds
+
+- **GIVEN** the package is installed on macOS ARM64
+- **WHEN** `herdr-world --help` or a normal invocation runs
+- **THEN** the entrypoint selects only
+  `native/darwin-arm64/herdr-world-bridge` and does not inspect a global
+  installation or the caller's working directory
+
+#### Scenario: npm target is unsupported
+
+- **GIVEN** the package is run on Linux ARM64, musl Linux, Windows, or another
+  unsupported target
+- **WHEN** the entrypoint starts
+- **THEN** it exits before bridge execution with a diagnostic naming the
+  detected operating system, architecture, or libc and the supported matrix
+
+#### Scenario: npm help is requested
+
+- **GIVEN** no Herdr session is running
+- **WHEN** `herdr-world --help` runs
+- **THEN** usage is printed, the command exits successfully, and no Herdr or
+  bridge process starts
+
+### 4.4 Linux glibc baseline
+
+The published `v0.1.0-rc.1` Linux bridge currently requires symbols through
+`GLIBC_2.34`. glibc 2.34 is the initial minimum Linux runtime contract.
+
+Release validation SHALL extract the maximum required GLIBC symbol version from
+the exact Linux bridge copied from the verified archive and SHALL fail if it
+exceeds 2.34. The extracted value and binary digest SHALL be retained as
+release evidence.
+
+The npm entrypoint SHALL detect the host glibc version before executing the
+Linux bridge. It SHALL report both the fixed required version, 2.34, and the
+detected version when the host is below the floor. npm's libc metadata is not
+used because this universal package has no platform selector and npm cannot
+express a glibc version constraint.
+
+Validation SHALL include a positive test at glibc 2.34 and negative tests below
+2.34, on musl, and on Linux ARM64.
+
+#### Scenario: Linux glibc is too old
+
+- **GIVEN** the Linux host reports glibc 2.33
+- **WHEN** `herdr-world` is invoked
+- **THEN** it exits before bridge execution and reports required 2.34 and
+  detected 2.33
+
+### 4.5 Homebrew Cask
+
+The initial Homebrew distribution SHALL be one stable-only Cask in the
+separate public third-party repository `IvoryHeart/homebrew-tap`. The
+user-facing command SHALL be:
 
 ```bash
 brew install --cask IvoryHeart/tap/herdr-world
 ```
 
-The Cask SHALL use the existing immutable GitHub release archives and select
-the URL and SHA-256 by OS and architecture:
+The Cask SHALL select the immutable versioned GitHub release archive and
+matching SHA-256 by OS and architecture:
 
-| Target | Archive URL pattern |
+| Target | Archive |
 | --- | --- |
 | macOS ARM64 | `herdr-world-vX.Y.Z-macos-arm64.tar.gz` |
 | macOS x86-64 | `herdr-world-vX.Y.Z-macos-x86_64.tar.gz` |
 | Linux x86-64 | `herdr-world-vX.Y.Z-linux-x86_64.tar.gz` |
 
-The Cask SHALL derive URLs from an immutable versioned release tag and SHALL
-never use a moving `latest` URL or omit a checksum. It SHALL explicitly reject
-Linux ARM64, musl, Windows, and other unsupported combinations. It SHALL
-expose only `herdr-world`; `herdr-world-bridge` SHALL not become a second
-global command.
+It SHALL support only those three targets, explicitly reject unsupported
+combinations, never use a moving `latest` URL, and expose only the existing
+`herdr-world` archive launcher through the normal Cask `binary` mechanism.
+The bridge SHALL not become a second command.
 
-The installed Cask SHALL preserve the staged bridge, web assets,
-documentation, and legal material. Installation SHALL not execute Herdr, the
-bridge, or a network-time release downloader, and SHALL not create, select, or
-modify a Herdr workspace. The Cask SHALL not act as a service supervisor.
+The initial Cask design SHALL not add a command wrapper, path environment
+contract, downloader, daemon, or service-supervisor behavior. Cask validation
+MUST prove that the direct `binary` mapping resolves the archive launcher and
+continues to work after install, upgrade, reinstall, and removal of an older
+version. If direct mapping demonstrably fails because of Caskroom path
+resolution, implementation SHALL stop and request a later narrowly scoped
+specification; it SHALL not silently add a workaround to this contract.
 
-The Cask command path SHALL use the explicit shared-launcher path contract or a
-narrowly scoped Cask command wrapper. It SHALL not assume that a Homebrew
-symlink's current directory is the Caskroom directory. The path solution SHALL
-continue to work after upgrade, reinstall, and removal of an older Cask
-version. Uninstall SHALL remove only the Cask-owned files and SHALL not delete
-unrelated plugin state.
+Cask installation SHALL preserve the archive's bridge, web assets,
+documentation, and legal material. It SHALL not start Herdr or the bridge,
+create or modify a workspace, or weaken the existing loopback, host, origin, or
+security behavior.
 
-The tap SHALL be described as third-party. It SHALL not be described as
-reviewed, endorsed, or official Homebrew software. Documentation SHALL explain
-that third-party tap definitions execute with user privileges and that a
-fully-qualified item install limits the requested trust scope.
+The ordinary Cask SHALL remain stable-only. A prerelease Cask, if later needed,
+MUST have a separate name and documented channel. Stable Cask publication is
+also gated by the project's separate macOS signing, notarization, and
+applicable Gatekeeper checks. That gate is release readiness policy; it does
+not determine the package architecture.
 
-#### Scenario: Cask installation is observed
+#### Scenario: The Cask is installed
 
-- **GIVEN** a supported target and a complete signed/stable release asset set
+- **GIVEN** a supported target and a complete signed stable release
 - **WHEN** `brew install --cask IvoryHeart/tap/herdr-world` runs
-- **THEN** Homebrew verifies the selected immutable archive and SHA-256,
-  installs one `herdr-world` command with its bridge and web assets, starts no
-  daemon, and makes no Herdr workspace mutation
+- **THEN** Homebrew verifies the selected immutable archive and checksum,
+  installs only `herdr-world`, starts no process, and makes no workspace
+  mutation
 
-### Requirement: Homebrew channel and signing gate
+### 4.6 Homebrew tap update
 
-The ordinary `herdr-world` Cask SHALL be stable-only. It SHALL not point at an
-RC or other prerelease archive. A prerelease Cask, if ever required, SHALL be a
-separately named and deliberately documented channel; it is not part of this
-initial specification.
+After the complete GitHub release asset set is available and the signing gate
+passes, a maintainer SHALL prepare a pull request in
+`IvoryHeart/homebrew-tap`. The pull request SHALL update only the Cask version,
+the three archive URLs, their three SHA-256 values, and reviewed Cask metadata
+if required.
 
-The stable Cask SHALL not be published or merged until the macOS artifacts are
-signed and notarized and pass the applicable Gatekeeper checks. Cask
-implementation and local validation MAY use release-candidate fixtures before
-that gate, but such fixtures SHALL not be presented as a stable publication.
+The maintainer SHALL run Cask audit/style and installation checks on each
+available supported target. Human review SHALL be required before merge. The
+tap SHALL be described as third-party and SHALL not be presented as reviewed,
+endorsed, or official Homebrew software.
 
-### Requirement: Reviewed tap pull request
+### 4.7 npm publication
 
-After the complete GitHub release asset set is available and the stable
-signing gate passes, a maintainer SHALL prepare a pull request in
-`IvoryHeart/homebrew-tap` from the verified release data. The initial process
-MAY be manual. The change SHALL update only the release version, three target
-URLs, and three corresponding SHA-256 values, plus any reviewed metadata
-required by the Cask.
+The npm package SHALL be generated from the final verified release outputs.
+Before publication, the maintainer SHALL:
 
-The pull request SHALL run Homebrew Cask audit/style and installation checks
-for macOS ARM64, macOS x86-64, and Linux x86-64 where those Homebrew targets
-are available. A human review SHALL be required before merge.
+1. create the package staging directory;
+2. run `npm pack` and inspect the exact resulting `.tgz` file list and
+   manifest;
+3. install-test that exact `.tgz` on Linux x64, macOS ARM64, and macOS x64;
+4. record its SHA-256; and
+5. publish that same `.tgz` manually with standard npm authentication.
 
-A pull request SHALL not be prepared from a partial GitHub release asset set.
+Prerelease application versions SHALL use the `next` dist-tag. Stable
+versions SHALL use `latest`. A prerelease SHALL not move `latest`. OIDC and
+CI publication automation, including staged publishing, are deferred until
+the manual path has worked in practice.
 
-#### Scenario: The release has one missing archive
+npm package versions are immutable. If incorrect bytes are published, that
+version SHALL not be reused; a later release SHALL use a new application
+version.
 
-- **GIVEN** the release tag exists but one of the three archives or checksums is
-  missing or unverifiable
-- **WHEN** a tap PR is requested
-- **THEN** no tap PR is prepared and the release status names the missing asset
+### 4.8 Spec 016 independence
 
-### Requirement: Plugin independence
+Spec 016 SHALL remain source-build-only. Installing or running the npm package
+or Homebrew Cask SHALL not alter plugin ownership, plugin-managed service
+lifecycle, or plugin state. Any future plugin mode that uses an external
+distribution requires a separate explicit specification.
 
-Spec 016's initial plugin design SHALL remain source-build-only. The plugin
-MUST NOT:
+## 5. Release sequence
 
-- discover or use an npm or Homebrew installation implicitly;
-- depend on npm, Homebrew, or a package-manager-specific layout;
-- assume that `herdr-world` is on `PATH`;
-- delegate plugin-managed bridge/service ownership to Homebrew; or
-- pair a plugin controller with an externally installed bridge without an
-  explicit contract.
-
-The existing plugin SHALL continue to own or explicitly configure its source
-build, bridge, static assets, Herdr socket, and service lifecycle as defined by
-Spec 016. A future external-installation or binary-first plugin mode SHALL
-require a later specification defining explicit path, version, asset-pairing,
-and lifecycle validation.
-
-#### Scenario: Both distribution types are installed
-
-- **GIVEN** a user has an npm or Homebrew Herdr World installation and the
-  source-build plugin is installed
-- **WHEN** the plugin starts or manages its bridge
-- **THEN** it uses its Spec 016 source-build contract and does not discover,
-  select, or delegate lifecycle ownership to either external installation
-
-## 6. Data and interface contract
-
-### 6.1 Generated npm package layout
-
-The generated main package SHALL have this package-owned layout (in addition to
-the required npm metadata):
-
-```text
-package.json
-README.md
-bin/herdr-world
-share/herdr-world/web/**
-docs/**
-LICENSE
-THIRD_PARTY_NOTICES.md
-UPSTREAM.md
-third_party/**
-vendor/herdr-compat/VENDOR-MANIFEST.toml
-```
-
-The exact allowlist MAY be narrower, but it SHALL contain the complete runtime
-web tree, launcher support files, documentation, and legal closure. It SHALL
-not contain a native bridge binary.
-
-Each platform package SHALL have this package-owned layout:
-
-```text
-package.json
-README.md
-native/herdr-world-bridge
-LICENSE
-THIRD_PARTY_NOTICES.md
-UPSTREAM.md
-docs/world-assets.md
-share/herdr-world/web/legal/**
-third_party/**
-vendor/herdr-compat/VENDOR-MANIFEST.toml
-```
-
-The fixed bridge path SHALL be derived from this package layout by the launcher.
-The Linux baseline SHALL be owned by the launcher implementation as the single
-constant `2.34`; it SHALL not be duplicated in public package metadata. Bridge
-hashes and extracted GLIBC requirements remain release evidence rather than
-runtime configuration.
-
-### 6.2 Package version and dependency contract
-
-For an application version `A`, all package manifests SHALL satisfy:
-
-```text
-main.version = A
-platform.version = A
-main.optionalDependencies[platform] = A
-```
-
-The dependency ranges SHALL be exact strings, not caret, tilde, wildcard, or
-latest ranges. A launcher version mismatch between its own package and the
-selected platform package SHALL be an actionable nonzero failure before bridge
-execution.
-
-### 6.3 Launcher diagnostics
-
-Launcher errors SHALL identify the failed class, detected values, and the safe
-next action. At minimum, diagnostics SHALL distinguish:
-
-- unsupported operating system;
-- unsupported CPU architecture;
-- Linux ARM64;
-- musl or unknown libc;
-- glibc below `2.34`, including required and detected versions;
-- missing or omitted optional platform package;
-- failed optional-package installation;
-- main/platform package version mismatch;
-- invalid, missing, relative, nonexistent, or wrong-type path override; and
-- bridge execution or child-process failure.
-
-Diagnostics SHALL not print authentication tokens, private paths unrelated to
-the package, or arbitrary environment contents.
-
-## 7. Privacy and security
-
-### 7.1 Installation and runtime boundaries
-
-Neither npm nor Homebrew installation SHALL create a Herdr workspace, select a
-Herdr session, start a daemon, or change bridge security configuration. The
-launcher SHALL preserve the existing loopback defaults and explicit host/origin
-configuration rules. These checks are compatibility and browser-admission
-controls; they are not a substitute for authentication.
-
-The package-manager launchers SHALL pass only explicit package-owned paths to
-the shared launcher. They SHALL not use the current directory, a guessed npm
-prefix, an ambient global executable, or an untrusted path from a Cask symlink
-without validation.
-
-### 7.2 Publication credentials and immutability
-
-npm package name/version contents are immutable after publication. All four
-tarballs MUST be inspected, install-tested, and hash-recorded before bootstrap
-or publication. Subsequent publication SHALL use direct short-lived GitHub OIDC
-trusted publishing, one protected GitHub environment approval for the publish
-job, and no long-lived npm token. Bootstrap remains the operator-authenticated
-2FA exception.
-
-The maintainer-prepared tap PR SHALL be based on the same verified release
-data. A tap update SHALL be impossible to prepare from an incomplete or
-unverified release asset set.
-
-### 7.3 Supply-chain evidence
-
-Release evidence SHALL retain, at minimum:
-
-- each native archive SHA-256 and verified file manifest;
-- the common-payload identity result;
-- each bridge SHA-256 and native-format result;
-- the extracted maximum Linux GLIBC symbol and declared baseline;
-- each npm tarball SHA-256 and `npm pack --dry-run` file list;
-- publication result and hash for each package; and
-- the three Homebrew archive SHA-256 values used by the reviewed Cask PR.
-
-## 8. Release mechanics
-
-### 8.1 Required sequence
-
-For every release set, the release operator or trusted workflow SHALL execute
-these steps in order:
+For a release intended for either package-manager distribution:
 
 1. Build all three native archives from the final tag.
-2. Verify contents, legal closure, native format, and checksum for every
-   archive.
-3. Run the stock-Herdr live smoke for all three targets.
-4. Verify common-payload byte identity across all three archives.
-5. Upload and verify the complete immutable GitHub release asset set.
-6. Generate all four npm package tarballs from the verified assets, using the
-   designated common-payload archive.
-7. Inspect and install-test all npm tarballs, and record their hashes.
-8. Bootstrap-publish or directly trusted-publish the npm package set according
-   to whether the package names already exist.
-9. Prepare a reviewed Homebrew tap PR from the verified release data when the
-   stable and signing gates are satisfied.
-10. Install-test the resulting Cask from the tap on every supported target.
+2. Verify archive contents, legal closure, native formats, checksums, and the
+   existing stock-Herdr live smoke for all three targets.
+3. Generate the single universal npm package from those verified outputs.
+4. Pack, inspect, install-test, and hash the exact npm `.tgz`.
+5. Manually publish the exact `.tgz` under `next` or `latest`, as
+   appropriate.
+6. After the complete immutable release assets and signing gate are available,
+   prepare and review the manual Homebrew tap pull request.
+7. Run Cask audit/style and install-test checks before merging the tap change.
 
-No later step SHALL make an earlier validation step implicit. In particular,
-uploading a GitHub archive does not make an npm tarball trusted, and a
-successful npm publication does not make a Cask eligible before signing and
-review.
+A failed validation SHALL stop the sequence before publication. A failed or
+uncertain npm publication SHALL be checked against the npm registry before a
+manual retry; published bytes SHALL never be replaced or silently mutated.
 
-### 8.2 External publication boundaries and retries
+## 6. Security properties
 
-Each external boundary SHALL expose a durable observable result:
+- npm and Homebrew installation SHALL not execute Herdr, a bridge, or a release
+  downloader.
+- The package-manager launchers SHALL preserve the existing loopback defaults
+  and explicit host/origin behavior. These checks are not authentication.
+- The npm package SHALL contain no publish credential, install-time network
+  downloader, or executable exposed other than `herdr-world`.
+- The third-party tap contains executable package definitions and SHALL be
+  installed only with a fully qualified tap/item command after appropriate
+  review.
+- Release archives, the npm `.tgz`, and Cask checksums SHALL be retained as
+  immutable release evidence.
 
-| Boundary | Success evidence | Safe retry |
-| --- | --- | --- |
-| GitHub assets | All three archives and checksums resolve and match recorded hashes | Re-query/re-upload only the missing asset; never replace an immutable asset |
-| npm bootstrap | Each live package version resolves and matches the inspected tarball | Query first; publish only a missing package with the identical tarball |
-| Tap PR | PR contains only reviewed version/URL/checksum changes and passes checks | Regenerate a new PR from the same immutable release data |
-| Cask install | Brew fetch/checksum/install/uninstall checks pass | Fix or close the PR; never point stable Cask at mutable data |
+## 7. Validation and acceptance
 
-An unknown result SHALL be reconciled against the external registry or GitHub
-state before retry. A retry SHALL not assume that a timeout means “not
-published.”
+Implementation SHALL provide the following focused evidence:
 
-## 9. Validation and acceptance evidence
+- `npm pack` contains exactly the allowlisted universal package payload,
+  including all three bridge paths and legal files;
+- the package version, public metadata, repository, Node floor, and sole
+  `herdr-world` command are correct;
+- npm installs and selects the correct bridge on all three supported targets;
+- unsupported OS, CPU, libc, missing bridge, and glibc-below-floor failures are
+  actionable;
+- `herdr-world --help` succeeds without Herdr, a workspace, or a bridge;
+- arguments, stdio, signals, and child exit status are forwarded;
+- the existing live bridge smoke passes against stock Herdr;
+- the exact manually published `.tgz` is the one install-tested and hashed;
+- `next` and `latest` are used only for their intended release classes;
+- Cask audit/style checks pass;
+- Cask installation, upgrade, reinstall, direct launcher invocation, and
+  uninstall pass on every available supported target;
+- Cask installation starts no process and changes no Herdr workspace;
+- Cask URLs are immutable and checksums match;
+- stable Cask publication is blocked until signing/notarization/Gatekeeper
+  checks pass; and
+- desktop tarball, Android, and Spec 016 behavior remain unchanged.
 
-Implementation SHALL provide automated tests and release evidence for the
-following scenarios.
+## 8. Rollout and deferred work
 
-### 9.1 npm package and launcher matrix
+Before implementation, resolve ownership of the `@ivoryheart` scope and create
+the public `IvoryHeart/homebrew-tap` repository. Implement and validate the
+manual npm package and direct Cask against release-candidate fixtures without
+changing desktop or Android outputs.
 
-- exact main and platform package contents and `files` allowlists;
-- package names, public metadata, repository, versions, selectors, exact
-  optional dependency versions, and only the permitted command;
-- optional dependency selection on Linux x64, macOS ARM64, and macOS x64;
-- `npm install --omit=optional` and a simulated optional-install failure;
-- unsupported OS, CPU, Linux ARM64, musl, and unknown libc;
-- glibc below 2.34, exactly 2.34, and above 2.34;
-- maximum GLIBC symbol extraction and release failure above the baseline;
-- missing or mismatched native package version;
-- invalid, relative, missing, nonexistent, and wrong-type path overrides;
-- argument, standard-input/output/error, signal, and exit-status forwarding;
-- `herdr-world --help` with no Herdr and no native package;
-- live smoke against stock Herdr using the packaged bridge;
-- loopback and existing bridge security defaults;
-- common-payload path-set and byte identity;
-- legal closure in the main and every platform tarball;
-- `next` for prereleases and `latest` for stable versions;
-- first-publication bootstrap, including operator 2FA and platform-first order;
-- direct GitHub OIDC trusted publishing with npm 11.5.1+ and Node 22.14.0+,
-  exact per-package publisher configuration, and one protected environment
-  approval for the publish job;
-- timeout, retry, partial publication, burned version, and no-mutation recovery.
+Publish the first npm package manually under `next` only after the exact
+tarball has been installed and tested on the support matrix. Publish the stable
+Cask only after its separate signing/readiness gate passes.
 
-### 9.2 Homebrew matrix
+The following require a later specification or evidence-based extension:
 
-- Cask audit and style checks;
-- immutable URL and SHA-256 selection for all three supported targets;
-- explicit rejection of Linux ARM64, musl, Windows, and other unsupported
-  combinations;
-- Cask install, upgrade, reinstall, and uninstall on macOS ARM64, macOS x64,
-  and Linux x64 where Homebrew targets are available;
-- command exposure limited to `herdr-world`;
-- Caskroom/symlink path resolution after install and upgrade;
-- live bridge smoke separately from installation's no-daemon check;
-- no bridge/Herdr process, workspace creation, or workspace mutation during
-  installation;
-- no service-supervisor behavior;
-- third-party tap trust/documentation behavior;
-- signed/notarized macOS assets and applicable Gatekeeper checks before stable
-  publication; and
-- stable Cask never resolving to an RC archive.
+- splitting npm native payloads into platform packages;
+- OIDC, CI, or staged npm publication;
+- Cask path adaptation if direct `binary` mapping fails;
+- a separately named prerelease Cask;
+- Homebrew formulas or official Homebrew submission;
+- additional platform/libc support; and
+- plugin reuse of an external package-manager installation.
 
-### 9.3 Unchanged-product checks
+## 9. References
 
-The release acceptance run SHALL confirm that:
-
-- existing desktop tarball names, layout, default launcher behavior, and
-  stock-Herdr smoke remain compatible, with the current verifier continuing to
-  pass when package-manager overrides are unset; future release checksums may
-  of course differ when release bytes change;
-- Android packaging and client behavior remain unchanged; and
-- Spec 016 plugin installation, source-build behavior, and plugin-managed
-  lifecycle remain unchanged and do not discover package-manager installs.
-
-## 10. Rollout and operations
-
-Rollout SHALL occur in these gates:
-
-1. Resolve external ownership prerequisites: control of `@ivoryheart`, public
-   creation of `IvoryHeart/homebrew-tap`, and signing/notarization readiness
-   for stable macOS Cask publication.
-2. Implement and validate package generation against release-candidate fixtures
-   without changing desktop or Android outputs.
-3. Perform the first real npm prerelease bootstrap with operator-authenticated
-   2FA, platform packages first and launcher last.
-4. Configure and verify trusted publishing independently for all four existing
-   packages.
-5. Use direct GitHub OIDC trusted publishing for later releases, with one
-   protected environment approval for the package-publish job and no long-lived
-   npm token.
-6. Publish the ordinary stable Cask only after macOS signing/notarization and
-   Gatekeeper checks pass; merge only a reviewed tap PR prepared from verified
-   release data.
-7. Make each package result and hash visible in the release summary, and
-   reconcile against npm before any retry.
-
-Documentation SHALL show the stable npm and Homebrew commands only for stable
-releases, and SHALL clearly label `@next`/`next` installation as prerelease.
-It SHALL identify the Homebrew repository as a third-party tap and SHALL not
-claim Homebrew review or endorsement.
-
-## 11. Deferred decisions
-
-The following are intentionally deferred and require a later specification or
-extension before becoming supported behavior:
-
-- a separately named prerelease Homebrew Cask channel;
-- npm staged publishing as optional future hardening;
-- a Homebrew source-building formula or binary formula;
-- Linux ARM64, musl, Windows, or additional macOS targets;
-- a lower Linux glibc baseline;
-- plugin reuse of an external npm/Homebrew installation;
-- plugin binary-first distribution or external lifecycle ownership; and
-- submission to an official Homebrew repository.
-
-No deferred item SHALL be introduced by changing the stable Cask, silently
-loosening the npm launcher checks, or modifying Spec 016's source-build-only
-plugin behavior.
-
-## 12. Authoritative references
-
-- [npm and Homebrew distribution analysis](../analysis/npm-homebrew-distribution-analysis-2026-08-28.md)
-- [Spec 016: Herdr World plugin release](016-herdr-world-plugin-release-spec.md)
-- [Packaging](../packaging.md)
-- [Release process](../release.md)
-- [npm `package.json` fields](https://docs.npmjs.com/cli/v11/configuring-npm/package-json)
+- [Distribution analysis](../analysis/npm-homebrew-distribution-analysis-2026-08-28.md)
+- [Spec 016](016-herdr-world-plugin-release-spec.md)
+- [Packaging documentation](../packaging.md)
+- [Release documentation](../release.md)
+- [npm package.json fields](https://docs.npmjs.com/cli/v11/configuring-npm/package-json)
+- [npm publish](https://docs.npmjs.com/cli/v11/commands/npm-publish/)
 - [npm scoped public packages](https://docs.npmjs.com/creating-and-publishing-scoped-public-packages/)
-- [npm staged publishing](https://docs.npmjs.com/staged-publishing/)
-- [npm staged publishing CLI](https://docs.npmjs.com/cli/v11/commands/npm-stage/)
-- [npm trusted publishers](https://docs.npmjs.com/trusted-publishers/)
-- [npm trusted publishing configuration](https://docs.npmjs.com/cli/v11/commands/npm-trust/)
 - [npm distribution tags](https://docs.npmjs.com/cli/v11/commands/npm-dist-tag/)
-- [Homebrew: Adding Software](https://docs.brew.sh/Adding-Software-to-Homebrew)
+- [npm trusted publishers](https://docs.npmjs.com/trusted-publishers/)
 - [Homebrew Cask Cookbook](https://docs.brew.sh/Cask-Cookbook)
-- [Homebrew acceptable Casks](https://docs.brew.sh/Acceptable-Casks)
 - [Homebrew taps](https://docs.brew.sh/Taps)
-- [Homebrew tap trust](https://docs.brew.sh/Tap-Trust)
+- [Homebrew acceptable Casks](https://docs.brew.sh/Acceptable-Casks)
+- [Homebrew Tap Trust](https://docs.brew.sh/Tap-Trust)

--- a/docs/specs/017-herdr-world-npm-homebrew-distribution-spec.md
+++ b/docs/specs/017-herdr-world-npm-homebrew-distribution-spec.md
@@ -243,8 +243,9 @@ contract, downloader, daemon, or service-supervisor behavior. Cask validation
 MUST prove that the direct `binary` mapping resolves the archive launcher and
 continues to work after install, upgrade, reinstall, and removal of an older
 version. If direct mapping demonstrably fails because of Caskroom path
-resolution, implementation SHALL stop and request a later narrowly scoped
-specification; it SHALL not silently add a workaround to this contract.
+resolution, implementation SHALL use the smallest validated path adaptation
+and update this specification only if the public contract changes. It SHALL
+not silently add a workaround to this contract.
 
 Cask installation SHALL preserve the archive's bridge, web assets,
 documentation, and legal material. It SHALL not start Herdr or the bridge,
@@ -375,7 +376,7 @@ Publish the first npm package manually under `next` only after the exact
 tarball has been installed and tested on the support matrix. Publish the stable
 Cask only after its separate signing/readiness gate passes.
 
-The following require a later specification or evidence-based extension:
+The following remain deferred until evidence justifies them:
 
 - splitting npm native payloads into platform packages;
 - OIDC, CI, or staged npm publication;

--- a/docs/specs/017-herdr-world-npm-homebrew-distribution-spec.md
+++ b/docs/specs/017-herdr-world-npm-homebrew-distribution-spec.md
@@ -43,7 +43,7 @@ This specification includes:
   platform selection behavior;
 - the Linux glibc compatibility contract;
 - npm prerelease/stable channels, first-publication bootstrap, subsequent
-  staged publishing, and partial-publication recovery;
+  trusted publishing, and partial-publication recovery;
 - the binary-first Homebrew Cask shape, tap update contract, Caskroom path
   handling, and stable/signing gate;
 - the relationship between these standalone distributions and the source-build
@@ -119,7 +119,7 @@ versions SHALL not be changed merely to publish a distribution.
 
 The npm launcher runtime is Node.js. The initial supported Node floor is
 `22.14.0`; the main package SHALL declare `engines.node: ">=22.14.0"`. The
-release and trusted/staged publishing jobs SHALL use Node `22.14.0` or newer.
+release and trusted-publishing jobs SHALL use Node `22.14.0` or newer.
 
 The current `v0.1.0-rc.1` Linux bridge requires symbols through
 `GLIBC_2.34`. Unless a separate, approved effort deliberately lowers the
@@ -216,10 +216,10 @@ The main package SHALL:
 - use repository metadata resolving exactly to
   `https://github.com/IvoryHeart/herdr-world`.
 
-The generated package metadata SHALL be staged separately from the private
-root and web development manifests. It SHALL not publish the repository root,
-source-only dependencies, Rust targets, Android outputs, tests, CI files, or
-an arbitrary `node_modules` tree.
+The generated package manifests and package files SHALL be maintained
+separately from the private root and web development manifests. They SHALL not
+publish the repository root, source-only dependencies, Rust targets, Android
+outputs, tests, CI files, or an arbitrary `node_modules` tree.
 
 The main and platform package manifests SHALL not use `preinstall` or
 `postinstall` to download release assets or otherwise create a second native
@@ -239,7 +239,6 @@ platform package tarball.
 Each platform package SHALL contain only:
 
 - the matching bridge binary extracted from its verified desktop archive;
-- generated package metadata required for launcher preflight; and
 - the complete legal material applicable to that bridge payload, including the
   project license, native dependency inventory, notices, and referenced license
   files.
@@ -266,15 +265,15 @@ selectors as follows:
 The platform packages MUST NOT declare a `bin` mapping and MUST NOT expose
 `herdr-world-bridge` as a global command. The bridge SHALL be stored at the
 exact implementation path `native/herdr-world-bridge`, and the main launcher
-SHALL resolve that path through package metadata, not by a current-working-
-directory guess.
+SHALL resolve that path through normal Node package resolution, not by a
+current-working-directory guess.
 
 #### Scenario: A platform tarball is inspected
 
 - **GIVEN** the Linux platform package is unpacked
 - **WHEN** its file list and metadata are checked
-- **THEN** it contains its x86-64 bridge, generated package metadata, and
-  complete applicable legal closure, declares `os: ["linux"]`, `cpu: ["x64"]`,
+- **THEN** it contains its x86-64 bridge and complete applicable legal closure,
+  declares `os: ["linux"]`, `cpu: ["x64"]`,
   `libc: ["glibc"]`, has no `bin` mapping, and contains no web runtime or
   launcher payload beyond legal-only files
 
@@ -318,6 +317,11 @@ dependency omitted with `--omit=optional`, or a package whose installation was
 skipped or failed SHALL produce an actionable error naming the selected
 package, detected target, and a corrective installation command.
 
+The launcher SHALL read the selected platform package's normal `package.json`
+through that same Node package resolution and SHALL reject a version different
+from the main package before executing the fixed `native/herdr-world-bridge`
+path.
+
 #### Scenario: Optional dependencies are omitted
 
 - **GIVEN** the main package is installed with `npm install --omit=optional`
@@ -333,25 +337,21 @@ The shared launcher SHALL support these exact environment variables:
 | --- | --- |
 | `HERDR_WORLD_BRIDGE_BIN` | Absolute path to the bridge executable |
 | `HERDR_WORLD_STATIC_DIR` | Absolute path to the static web directory |
-| `HERDR_WORLD_REQUIRED_GLIBC` | Optional package-manager ABI value in `major.minor` form on Linux |
 
-The npm launcher SHALL set all three values that apply before invoking the
-shared launcher. The Homebrew wrapper SHALL set the two absolute paths and the
-declared Linux ABI value when running on Linux. Existing desktop tarball calls
-with these variables unset SHALL retain the current relative-bundle behavior.
+The npm launcher and Homebrew wrapper SHALL set both values before invoking the
+shared launcher. Existing desktop tarball calls with these variables unset
+SHALL retain the current relative-bundle behavior.
 
 If either path variable is set, both path variables MUST be set. Each path
 MUST be absolute, MUST exist at invocation time, and MUST have the expected
 type: the bridge MUST be a regular executable file and the static path MUST be
-a directory containing the packaged web entrypoint. A supplied required-glibc
-value MUST be syntactically valid and match the generated Linux package
-metadata or the Cask's recorded release value. Missing, invalid, relative,
+a directory containing the packaged web entrypoint. Missing, invalid, relative,
 nonexistent, or type-incompatible paths
 SHALL fail closed before any bridge or Herdr process is started. The launcher
 MUST NOT resolve an invalid path relative to the current working directory.
 
 The override contract is intentionally narrow: it supplies only the bridge,
-static directory, and ABI preflight inputs. It SHALL not replace Herdr socket,
+static directory, and no other runtime inputs. It SHALL not replace Herdr socket,
 workspace, host, origin, or security-policy settings.
 
 #### Scenario: A Cask symlink is invoked after an upgrade
@@ -403,8 +403,8 @@ into an opaque native-loader error.
 For the Linux x86-64 bridge, release validation SHALL extract the maximum
 required GLIBC symbol version from the exact binary copied from the verified
 archive. The check SHALL fail if the maximum required version exceeds the
-declared baseline `2.34`, and SHALL write the verified requirement into the
-Linux platform package metadata.
+declared baseline `2.34`. The extracted value, declared baseline, binary
+digest, and target archive digest SHALL be retained as release evidence.
 
 The check SHALL fail closed if the ELF version information cannot be read. It
 SHALL not infer compatibility only from the build host's glibc version. The
@@ -423,8 +423,8 @@ binary digest, and target archive digest.
 
 Before executing the Linux bridge, the npm launcher SHALL detect the host's
 actual glibc version and compare it with the required version from the
-generated Linux platform package metadata. It SHALL report both the required
-and detected versions before execution when the preflight is evaluated.
+fixed initial baseline `2.34`. It SHALL report both the required and detected
+versions before execution when the preflight is evaluated.
 
 The preflight SHALL distinguish:
 
@@ -432,6 +432,10 @@ The preflight SHALL distinguish:
 - glibc at `2.34`, which is supported;
 - glibc above `2.34`, which is supported subject to the other checks; and
 - musl or an unidentifiable libc, which is unsupported for this package.
+
+The initial launcher implementation SHALL own the single required glibc
+baseline constant `2.34`; it SHALL not require a package-manager environment
+override or custom native-package metadata to obtain that value.
 
 The Homebrew Linux wrapper SHALL provide the same preflight result before
 executing the Cask bridge. No path or libc error SHALL fall through to an
@@ -451,15 +455,15 @@ publication channel for a release set:
 - stable versions SHALL use the `latest` dist-tag; and
 - a prerelease SHALL never move or overwrite `latest`.
 
-The publication command or staged approval SHALL pass the intended tag
-explicitly. A package set with mixed versions or mixed intended channels SHALL
-be rejected before publication.
+The publication command SHALL pass the intended tag explicitly. A package set
+with mixed versions or mixed intended channels SHALL be rejected before
+publication.
 
 ### Requirement: First-publication bootstrap
 
-The release process SHALL recognize that trusted publishing and staged
-publishing require a package that already exists. They cannot be configured as
-the mechanism for creating all four package names for the first time.
+The release process SHALL recognize that trusted publishing requires a package
+that already exists. It cannot be configured as the mechanism for creating all
+four package names for the first time.
 
 The first publication SHALL be the first real prerelease, not a placeholder.
 It SHALL use an operator-authenticated npm workflow with 2FA. Before the first
@@ -477,8 +481,7 @@ long-lived token stored in the repository or workflow.
 
 Immediately after all four packages exist, trusted publishing SHALL be
 configured separately for every package. Each configuration SHALL identify the
-exact `IvoryHeart/herdr-world` repository and exact release workflow. The
-configuration SHALL grant stage-only permission where npm supports it.
+exact `IvoryHeart/herdr-world` repository and exact release workflow.
 
 #### Scenario: Bootstrap is attempted before scope ownership
 
@@ -487,90 +490,66 @@ configuration SHALL grant stage-only permission where npm supports it.
 - **THEN** publication stops as an external prerequisite failure and no
   placeholder package is published
 
-### Requirement: Subsequent trusted staged publishing
+### Requirement: Subsequent direct trusted publishing
 
-After bootstrap, the release workflow SHALL use GitHub-hosted OIDC trusted
-publishing for every package. It SHALL:
+After bootstrap, the release workflow SHALL use direct GitHub-hosted OIDC
+trusted publishing for every package. It SHALL:
 
 - run with `id-token: write`;
-- use Node `22.14.0` or newer and npm `11.15.0` or newer;
-- use the exact configured repository and workflow for each package;
-- grant only stage publishing permission where supported;
-- invoke `npm stage publish` for all four packages;
-- download and inspect the actual staged tarball for every package before
-  approval;
-- require human 2FA approval of all three platform stages before approving the
-  launcher stage; and
+- use Node `22.14.0` or newer and npm `11.5.1` or newer;
+- use the exact configured `IvoryHeart/herdr-world` repository and release
+  workflow for each package;
+- require one protected GitHub environment approval for the publish job;
+- publish all four packages with `npm publish --tag <channel>`;
+- publish the three platform packages before the launcher package; and
 - use no long-lived npm publishing token.
 
-The stage tag and package/version identity SHALL be recorded with every
-downloaded staged tarball. Approval SHALL be refused if the downloaded bytes,
-metadata, file list, or hash differ from the pre-stage inspected tarball.
+The workflow SHALL validate that all four tarballs have the same version and
+intended channel before the environment approval. The protected environment
+approval SHALL gate the package-publish job as a whole; it SHALL not require a
+separate approval for each package. Staged publishing is optional deferred
+hardening and is not required by this specification.
 
-The workflow SHALL not assume that a stage is available for a package that has
-never been published. A missing-package response SHALL select the bootstrap
-path and stop the staged path safely.
+#### Scenario: Trusted publisher configuration is wrong
 
-#### Scenario: A staged tarball differs from the inspected tarball
+- **GIVEN** a package's trusted publisher configuration names a different
+  repository or workflow
+- **WHEN** the publish job requests OIDC authentication
+- **THEN** publication fails before package bytes are published and the release
+  identifies the exact package configuration that must be corrected
 
-- **GIVEN** a package has been staged through trusted publishing
-- **WHEN** the downloaded staged tarball does not match the pre-recorded hash
-- **THEN** approval is refused, the release is marked failed, and no retry
-  SHALL replace or mutate either tarball silently
+### Requirement: npm publication recovery
 
-### Requirement: npm partial-publication recovery
-
-npm publication of four packages SHALL be modeled as a non-atomic state
-machine. npm's registry and staged-publishing records SHALL remain the
-authoritative publication state. The release process SHALL emit an
-operator-visible status projection for each attempt, such as a CI summary or
-release artifact, containing the application version, channel, package states,
-tarball hashes, stage identifiers where applicable, and the next safe action.
-This projection SHALL not become a second publication database and SHALL not
-record credentials.
-
-The status projection SHALL report these observable states:
-
-| State | Meaning | Safe next action |
-| --- | --- | --- |
-| `prepared` | All four tarballs inspected, tested, and hash-recorded | Start bootstrap or stage platform packages |
-| `platform-pending` | Platform stages are being inspected or await human 2FA approval | Inspect/approve platform stages only |
-| `platform-published` | All three exact platform versions exist and match hashes | Stage/approve the launcher |
-| `launcher-pending` | The launcher stage is being inspected or awaits approval | Inspect/approve the launcher stage |
-| `partial` | A publication result is unknown or only part of the intended set is live | Query npm and resume only missing packages with identical tarballs |
-| `complete` | All four live versions exist with matching hashes and tag | Prepare the eligible tap PR |
-| `burned` | A wrong byte set was published for this version | Advance the complete set to a new application version |
-
-A validation or external-prerequisite failure before publication SHALL be
-reported as `blocked` with its reason and safe remediation; it is not a new
-npm registry state.
+npm publication of four packages SHALL be treated as non-atomic. The npm
+registry SHALL remain the authoritative publication state. Before publication,
+the release process SHALL inspect, install-test, and hash all four exact
+tarballs. A CI summary or release artifact SHALL make any partial publication
+visible and actionable by listing each package's observed result, version,
+channel, hash, and next safe action. It SHALL not create a custom publication
+database, state taxonomy, or credential record.
 
 Before the launcher package is published, all three platform package names
 SHALL exist at the exact application version with the inspected bytes. The
 launcher SHALL never be published first.
 
-A transient failure before a package version is published MAY retry the
-identical inspected tarball. If a package is already live with correct bytes,
-the process SHALL resume the missing package and SHALL not republish or mutate
-the existing package. If incorrect bytes are published for any package, that
-application version is burned permanently and the complete four-package set
-MUST advance to a new application version. The process SHALL never create
-divergent package versions to repair one member of the set.
+A transient failure before a package version is published MAY retry only after
+querying npm and confirming that the exact version is absent. The retry SHALL
+use the identical inspected tarball. If a package is already live with correct
+bytes, the process SHALL resume only the missing package and SHALL not
+republish or mutate the existing package. If incorrect bytes are published for
+any package, that application version is burned permanently and the complete
+four-package set MUST advance to a new application version. The process SHALL
+never create divergent package versions to repair one member of the set.
 
-An incorrect staged package that has not been approved MAY be rejected; any
-replacement stage SHALL be newly generated, re-inspected, and explicitly
-associated with the same version without silently overwriting the rejected
-stage. Once incorrect bytes are live, the `burned` rule applies.
-
-#### Scenario: A platform publication times out
+#### Scenario: A package publication times out
 
 - **GIVEN** the platform tarball was inspected and its publication result is
   unknown
 - **WHEN** the registry cannot immediately confirm whether the exact version is
   live
-- **THEN** the release enters `partial` or an equivalent unknown substate,
-  queries the registry before retrying, and either resumes the missing package
-  with the identical hash or stops for operator reconciliation
+- **THEN** the CI/release summary records the package result as unknown, the
+  registry is queried before retrying, and the process either publishes the
+  missing package with the identical tarball or stops for operator reconciliation
 
 #### Scenario: One package has wrong live bytes
 
@@ -655,11 +634,7 @@ The pull request SHALL run Homebrew Cask audit/style and installation checks
 for macOS ARM64, macOS x86-64, and Linux x86-64 where those Homebrew targets
 are available. A human review SHALL be required before merge.
 
-Bot or GitHub App automation is deferred for the initial release. If it is
-introduced later, it SHALL use narrowly scoped credentials limited to the
-required tap pull-request operation. The source repository SHALL not hold an
-unrestricted credential capable of rewriting the tap. A pull request SHALL not
-be prepared from a partial GitHub release asset set.
+A pull request SHALL not be prepared from a partial GitHub release asset set.
 
 #### Scenario: The release has one missing archive
 
@@ -733,11 +708,11 @@ third_party/**
 vendor/herdr-compat/VENDOR-MANIFEST.toml
 ```
 
-Each platform `package.json` SHALL include a generated `herdrWorld` metadata
-object containing the fixed bridge path `native/herdr-world-bridge` and, for
-Linux, the required glibc version `2.34`. The Linux value SHALL be generated
-from and checked against the verified bridge; it is not user input. Bridge
-hashes remain release evidence rather than runtime configuration.
+The fixed bridge path SHALL be derived from this package layout by the launcher.
+The Linux baseline SHALL be owned by the launcher implementation as the single
+constant `2.34`; it SHALL not be duplicated in public package metadata. Bridge
+hashes and extracted GLIBC requirements remain release evidence rather than
+runtime configuration.
 
 ### 6.2 Package version and dependency contract
 
@@ -766,7 +741,7 @@ next action. At minimum, diagnostics SHALL distinguish:
 - glibc below `2.34`, including required and detected versions;
 - missing or omitted optional platform package;
 - failed optional-package installation;
-- main/platform package or generated platform metadata mismatch;
+- main/platform package version mismatch;
 - invalid, missing, relative, nonexistent, or wrong-type path override; and
 - bridge execution or child-process failure.
 
@@ -790,19 +765,16 @@ without validation.
 
 ### 7.2 Publication credentials and immutability
 
-npm package name/version contents are immutable after publication. All tarballs
-MUST be inspected, install-tested, and hash-recorded before bootstrap or
-staging. Subsequent publication SHALL use short-lived GitHub OIDC trusted
-publishing and no long-lived npm token.
+npm package name/version contents are immutable after publication. All four
+tarballs MUST be inspected, install-tested, and hash-recorded before bootstrap
+or publication. Subsequent publication SHALL use direct short-lived GitHub OIDC
+trusted publishing, one protected GitHub environment approval for the publish
+job, and no long-lived npm token. Bootstrap remains the operator-authenticated
+2FA exception.
 
-Stage-only permission SHALL be preferred for trusted publishers. Human 2FA
-approval is the boundary that makes a staged package live, with platform
-packages approved before the launcher package.
-
-If Homebrew tap automation is introduced, it SHALL use least-privilege
-credentials and pull requests with review. The initial maintainer-prepared tap
-PR SHALL be based on the same verified release data. A tap update SHALL be
-impossible to prepare from an incomplete or unverified release asset set.
+The maintainer-prepared tap PR SHALL be based on the same verified release
+data. A tap update SHALL be impossible to prepare from an incomplete or
+unverified release asset set.
 
 ### 7.3 Supply-chain evidence
 
@@ -813,8 +785,7 @@ Release evidence SHALL retain, at minimum:
 - each bridge SHA-256 and native-format result;
 - the extracted maximum Linux GLIBC symbol and declared baseline;
 - each npm tarball SHA-256 and `npm pack --dry-run` file list;
-- staged tarball hashes and stage identifiers, when applicable;
-- publication status for each package; and
+- publication result and hash for each package; and
 - the three Homebrew archive SHA-256 values used by the reviewed Cask PR.
 
 ## 8. Release mechanics
@@ -833,8 +804,8 @@ these steps in order:
 6. Generate all four npm package tarballs from the verified assets, using the
    designated common-payload archive.
 7. Inspect and install-test all npm tarballs, and record their hashes.
-8. Bootstrap-publish or stage/approve the npm package set according to whether
-   the package names already exist.
+8. Bootstrap-publish or directly trusted-publish the npm package set according
+   to whether the package names already exist.
 9. Prepare a reviewed Homebrew tap PR from the verified release data when the
    stable and signing gates are satisfied.
 10. Install-test the resulting Cask from the tap on every supported target.
@@ -852,8 +823,6 @@ Each external boundary SHALL expose a durable observable result:
 | --- | --- | --- |
 | GitHub assets | All three archives and checksums resolve and match recorded hashes | Re-query/re-upload only the missing asset; never replace an immutable asset |
 | npm bootstrap | Each live package version resolves and matches the inspected tarball | Query first; publish only a missing package with the identical tarball |
-| npm stage | Stage identifier and downloaded bytes match the inspected tarball | Resume or reject the exact stage; never silently overwrite it |
-| npm approval | Registry shows the exact approved package/version/hash | Approve an outstanding exact stage or stop for reconciliation |
 | Tap PR | PR contains only reviewed version/URL/checksum changes and passes checks | Regenerate a new PR from the same immutable release data |
 | Cask install | Brew fetch/checksum/install/uninstall checks pass | Fix or close the PR; never point stable Cask at mutable data |
 
@@ -876,7 +845,7 @@ following scenarios.
 - unsupported OS, CPU, Linux ARM64, musl, and unknown libc;
 - glibc below 2.34, exactly 2.34, and above 2.34;
 - maximum GLIBC symbol extraction and release failure above the baseline;
-- missing or mismatched native package/generated platform metadata;
+- missing or mismatched native package version;
 - invalid, relative, missing, nonexistent, and wrong-type path overrides;
 - argument, standard-input/output/error, signal, and exit-status forwarding;
 - `herdr-world --help` with no Herdr and no native package;
@@ -886,8 +855,9 @@ following scenarios.
 - legal closure in the main and every platform tarball;
 - `next` for prereleases and `latest` for stable versions;
 - first-publication bootstrap, including operator 2FA and platform-first order;
-- trusted staged publishing with npm 11.15.0+ and Node 22.14.0+;
-- downloaded staged tarball inspection and platform-before-launcher approval;
+- direct GitHub OIDC trusted publishing with npm 11.5.1+ and Node 22.14.0+,
+  exact per-package publisher configuration, and one protected environment
+  approval for the publish job;
 - timeout, retry, partial publication, burned version, and no-mutation recovery.
 
 ### 9.2 Homebrew matrix
@@ -934,13 +904,14 @@ Rollout SHALL occur in these gates:
    2FA, platform packages first and launcher last.
 4. Configure and verify trusted publishing independently for all four existing
    packages.
-5. Use staged publishing for later prereleases, with downloaded-stage
-   inspection and human platform-before-launcher approval.
+5. Use direct GitHub OIDC trusted publishing for later releases, with one
+   protected environment approval for the package-publish job and no long-lived
+   npm token.
 6. Publish the ordinary stable Cask only after macOS signing/notarization and
    Gatekeeper checks pass; merge only a reviewed tap PR prepared from verified
    release data.
-7. Monitor the package/release status record for partial publication and
-   reconcile before any retry.
+7. Make each package result and hash visible in the release summary, and
+   reconcile against npm before any retry.
 
 Documentation SHALL show the stable npm and Homebrew commands only for stable
 releases, and SHALL clearly label `@next`/`next` installation as prerelease.
@@ -953,6 +924,7 @@ The following are intentionally deferred and require a later specification or
 extension before becoming supported behavior:
 
 - a separately named prerelease Homebrew Cask channel;
+- npm staged publishing as optional future hardening;
 - a Homebrew source-building formula or binary formula;
 - Linux ARM64, musl, Windows, or additional macOS targets;
 - a lower Linux glibc baseline;

--- a/docs/specs/017-herdr-world-npm-homebrew-distribution-spec.md
+++ b/docs/specs/017-herdr-world-npm-homebrew-distribution-spec.md
@@ -1,0 +1,961 @@
+# Herdr World npm and Homebrew distribution
+
+- **Spec ID:** `017-herdr-world-npm-homebrew-distribution`
+- **Status:** Draft
+- **Created:** 2026-08-28
+- **Owner:** IvoryHeart
+- **Reviewers:** —
+- **Approved by:** —
+- **Approved at:** —
+
+> This document may be edited only while its status is `Draft` or `In review`.
+> After approval it is immutable. After implementation completes, record
+> delivery and drift in `017-herdr-world-npm-homebrew-distribution-spec-summary.md`;
+> put later intended changes in a numbered extension.
+
+This is a standalone distribution contract related to, but independent from,
+[Spec 016](016-herdr-world-plugin-release-spec.md). Its primary research input
+is the [npm and Homebrew distribution analysis](../analysis/npm-homebrew-distribution-analysis-2026-08-28.md).
+It does not extend the Herdr plugin lifecycle contract.
+
+## 1. Purpose
+
+Herdr World currently has verified desktop release archives that contain the
+native bridge, the web application, the launcher, documentation, and legal
+assets. This specification defines how users will obtain the same application
+through npm and Homebrew without creating a second native-build truth or an
+implicit dependency on either package manager.
+
+The outcome is:
+
+- one public npm launcher package with one exact-version optional native
+  package for each supported target; and
+- one stable-only Homebrew Cask in the separate public third-party tap
+  `IvoryHeart/homebrew-tap`.
+
+Both distributions SHALL remain compatible with the existing Herdr admission,
+loopback, browser-origin, and terminal-protocol behavior. Installation SHALL
+install files only. It SHALL not install Herdr, start a bridge, create a
+workspace, or silently alter Herdr state.
+
+## 2. Scope
+
+This specification includes:
+
+- the verified-release-archive source boundary and common-payload identity
+  check;
+- the four-package npm topology, metadata, package contents, launcher, and
+  platform selection behavior;
+- the Linux glibc compatibility contract;
+- npm prerelease/stable channels, first-publication bootstrap, subsequent
+  staged publishing, and partial-publication recovery;
+- the binary-first Homebrew Cask shape, tap update contract, Caskroom path
+  handling, and stable/signing gate;
+- the relationship between these standalone distributions and the source-build
+  only initial plugin design in Spec 016;
+- release sequencing, security properties, validation, rollout, and observable
+  failure states.
+
+The initial supported package-manager targets are:
+
+| Operating system | CPU | Native archive | npm package |
+| --- | --- | --- | --- |
+| Linux | x86-64 | `linux-x86_64` | `@ivoryheart/herdr-world-linux-x64-gnu` |
+| macOS | ARM64 | `macos-arm64` | `@ivoryheart/herdr-world-darwin-arm64` |
+| macOS | x86-64 | `macos-x86_64` | `@ivoryheart/herdr-world-darwin-x64` |
+
+Homebrew SHALL support exactly the same three target combinations. npm and
+Homebrew SHALL reject or fail clearly on every other combination.
+
+## 3. Non-goals
+
+The following are explicitly outside this specification:
+
+- changing the existing desktop tarball names, layout, launcher defaults, or
+  validation contract;
+- changing Android packaging or the Android companion client;
+- changing the Herdr plugin lifecycle, plugin manifest, plugin-managed service
+  ownership, or Spec 016's initial source-build-only design;
+- making the plugin discover or reuse an npm/Homebrew installation;
+- a plugin binary-first or external-installation mode;
+- Linux ARM64, musl-based Linux, Windows, or any other unsupported target;
+- a source-building Homebrew formula;
+- a binary Homebrew formula;
+- submission to Homebrew/core or the official Homebrew Cask repository;
+- a prerelease Homebrew Cask channel;
+- an npm install-time release downloader;
+- implementation of package generation, npm publication, tap automation,
+  release-workflow changes, or launcher changes in this specification task;
+- macOS signing/notarization implementation. The stable Cask publication gate
+  defined here depends on that work being completed separately.
+
+## 4. Context and constraints
+
+### 4.1 Existing release boundary
+
+The verified GitHub release archives produced by the existing desktop release
+process are the native source of truth. For each target, the archive contains
+the bridge binary and the common launcher/web/documentation/legal payload. npm
+and Homebrew SHALL reuse the bridge binary from the corresponding verified
+archive.
+
+After an archive passes release validation, package-manager generation MUST NOT
+compile another native bridge from source, select a bridge from an unverified
+build, or download a bridge during package installation. A package-manager
+artifact MAY re-layout files from a verified archive, but it SHALL not change
+the native payload.
+
+The desktop tarballs and Android packaging remain independent products. Adding
+the package-manager distributions SHALL not require their layout or behavior to
+change.
+
+### 4.2 Release versions
+
+The application version is derived from `release.json` using exactly one
+transformation: remove one leading `v`. For example,
+`{"current":"v0.1.0-rc.1"}` produces `0.1.0-rc.1`. No other prefix, suffix, or
+prerelease component SHALL be removed or rewritten.
+
+The root `package.json` and `web/package.json` remain private development
+manifests. They SHALL not become the published npm manifests and their
+versions SHALL not be changed merely to publish a distribution.
+
+### 4.3 Runtime and compatibility baseline
+
+The npm launcher runtime is Node.js. The initial supported Node floor is
+`22.14.0`; the main package SHALL declare `engines.node: ">=22.14.0"`. The
+release and trusted/staged publishing jobs SHALL use Node `22.14.0` or newer.
+
+The current `v0.1.0-rc.1` Linux bridge requires symbols through
+`GLIBC_2.34`. Unless a separate, approved effort deliberately lowers the
+native baseline, glibc `2.34` is the minimum Linux runtime contract.
+
+npm's `libc: ["glibc"]` metadata expresses the libc family. It does not
+express or enforce a glibc version. The npm launcher therefore has an
+independent version preflight.
+
+The application still requires a separately installed compatible Herdr
+session, Herdr `v0.8.2` or newer, and terminal protocol `20`, as described by
+the existing packaging and release documentation.
+
+## 5. Requirements
+
+### Requirement: Verified archive reuse
+
+The release system SHALL build all three native archives from the final tag and
+shall verify each archive's contents, legal closure, native format, and
+checksum before any npm or Homebrew artifact is generated.
+
+The release system MUST fail if package generation attempts to use a native
+binary that is not byte-identical to the bridge extracted from its matching
+verified archive.
+
+#### Scenario: A second native build is attempted
+
+- **GIVEN** the three tagged desktop archives have passed validation
+- **WHEN** package generation is invoked
+- **THEN** generation extracts the matching bridge from those archives and does
+  not run a second native build
+
+### Requirement: Common payload identity
+
+Before generating npm packages, release validation SHALL compare the common
+payload in all three verified archives. The comparison SHALL normalize away
+only the archive's platform-specific root directory and exclude only the
+platform-specific bridge binary and its platform-specific runtime metadata.
+
+The common payload is the byte content and relative path set for:
+
+- the shared launcher;
+- the complete bundled `share/herdr-world/web/` tree;
+- the runtime documentation included by the desktop archive;
+- `README.md`, `LICENSE`, `THIRD_PARTY_NOTICES.md`, and `UPSTREAM.md`;
+- the complete applicable `docs/`, `third_party/`, and legal/inventory trees.
+
+The validator SHALL compare every common relative path and its bytes (using a
+cryptographic digest plus byte comparison), and SHALL fail on a missing,
+additional, or different common file. One designated verified archive,
+`linux-x86_64`, SHALL supply the common npm payload after this check succeeds.
+The designation is a source-selection convenience; it does not relax the
+identity check.
+
+#### Scenario: A platform build changes a common file
+
+- **GIVEN** all three native archives pass their individual checks
+- **WHEN** the common-payload comparison finds different web, launcher,
+  documentation, or legal bytes
+- **THEN** npm generation stops, no package is publishable, and the release is
+  reported as blocked pending a reproducible payload fix
+
+### Requirement: Main npm package identity and topology
+
+The published npm packages SHALL have exactly these names:
+
+```text
+@ivoryheart/herdr-world
+@ivoryheart/herdr-world-linux-x64-gnu
+@ivoryheart/herdr-world-darwin-arm64
+@ivoryheart/herdr-world-darwin-x64
+```
+
+Ownership and publication control of the `@ivoryheart` scope is an external
+publication prerequisite. Package names SHALL be selected and checked as part
+of bootstrap; the workflow SHALL not publish placeholder packages merely to
+occupy names.
+
+The main package SHALL:
+
+- be public and non-private;
+- declare `publishConfig` with `access: "public"` and
+  `registry: "https://registry.npmjs.org/"`;
+- declare only one executable mapping, `herdr-world`;
+- contain the shared launcher, the common web assets, runtime documentation,
+  and all common/applicable legal material;
+- declare all three platform packages in `optionalDependencies` at the exact
+  same application version;
+- use an explicit `files` allowlist;
+- derive its version from `release.json` by removing only the leading `v`;
+- declare `engines.node: ">=22.14.0"`; and
+- use repository metadata resolving exactly to
+  `https://github.com/IvoryHeart/herdr-world`.
+
+The generated package metadata SHALL be staged separately from the private
+root and web development manifests. It SHALL not publish the repository root,
+source-only dependencies, Rust targets, Android outputs, tests, CI files, or
+an arbitrary `node_modules` tree.
+
+The main and platform package manifests SHALL not use `preinstall` or
+`postinstall` to download release assets or otherwise create a second native
+payload. Native bridge bytes SHALL arrive only as the already inspected
+platform package tarball.
+
+#### Scenario: Main package metadata is inspected
+
+- **GIVEN** a package has been generated from `v0.1.0-rc.1`
+- **WHEN** its `package.json` is inspected
+- **THEN** its version is `0.1.0-rc.1`, its repository identifies
+  `IvoryHeart/herdr-world`, its access is public, its only `bin` key is
+  `herdr-world`, and all three optional dependencies are exactly `0.1.0-rc.1`
+
+### Requirement: Platform npm package contents and selectors
+
+Each platform package SHALL contain only:
+
+- the matching bridge binary extracted from its verified desktop archive;
+- bridge runtime metadata required for launcher preflight; and
+- the complete legal material applicable to that bridge payload, including the
+  project license, native dependency inventory, notices, and referenced license
+  files.
+
+Each platform package SHALL have an explicit `files` allowlist and SHALL have
+the same application version as the main package. It SHALL declare exact
+selectors as follows:
+
+| Package | `os` | `cpu` | `libc` |
+| --- | --- | --- | --- |
+| `@ivoryheart/herdr-world-linux-x64-gnu` | `linux` | `x64` | `glibc` |
+| `@ivoryheart/herdr-world-darwin-arm64` | `darwin` | `arm64` | not applicable |
+| `@ivoryheart/herdr-world-darwin-x64` | `darwin` | `x64` | not applicable |
+
+The platform packages MUST NOT declare a `bin` mapping and MUST NOT expose
+`herdr-world-bridge` as a global command. The bridge SHALL be stored at the
+exact implementation path `native/herdr-world-bridge`, and the main launcher
+SHALL resolve that path through package metadata, not by a current-working-
+directory guess.
+
+#### Scenario: A platform tarball is inspected
+
+- **GIVEN** the Linux platform package is unpacked
+- **WHEN** its file list and metadata are checked
+- **THEN** it contains its x86-64 bridge, runtime metadata, and complete
+  applicable legal closure, declares `os: ["linux"]`, `cpu: ["x64"]`,
+  `libc: ["glibc"]`, has no `bin` mapping, and contains no web or launcher
+  payload
+
+### Requirement: Explicit npm file boundaries
+
+The generated main and platform package manifests SHALL use explicit
+`files` allowlists. Package generation SHALL reject an allowlist that includes
+unreviewed build output, an install script, a release downloader, credentials,
+or files outside the intended package boundary.
+
+`npm pack --dry-run` SHALL be treated as a release check. The checked file list
+SHALL be recorded with the package version and tarball hash before publication.
+
+Every published package SHALL be independently auditable for its payload's
+legal closure. A legal manifest SHALL not reference a file absent from that
+package, and every applicable native or web dependency notice SHALL be present
+in the package that carries the dependency.
+
+### Requirement: npm platform resolver
+
+The `herdr-world` npm launcher SHALL select the platform package using
+`process.platform`, `process.arch`, and Linux libc information. The supported
+selection table is:
+
+| `process.platform` | `process.arch` | libc result | Selected package |
+| --- | --- | --- | --- |
+| `linux` | `x64` | glibc at or above 2.34 | `@ivoryheart/herdr-world-linux-x64-gnu` |
+| `darwin` | `arm64` | not applicable | `@ivoryheart/herdr-world-darwin-arm64` |
+| `darwin` | `x64` | not applicable | `@ivoryheart/herdr-world-darwin-x64` |
+
+The launcher SHALL reject Linux ARM64, Linux musl, Windows, and every other
+unsupported operating-system/architecture/libc combination before attempting
+to execute a bridge. Linux x64 with glibc below 2.34 SHALL receive a distinct
+minimum-version error.
+
+The launcher SHALL resolve the installed optional package using Node package
+resolution from the main package's own module location. It MUST NOT infer a
+global npm prefix, search the current working directory, or depend on the
+user's `PATH` to find the native package. A missing package, an optional
+dependency omitted with `--omit=optional`, or a package whose installation was
+skipped or failed SHALL produce an actionable error naming the selected
+package, detected target, and a corrective installation command.
+
+#### Scenario: Optional dependencies are omitted
+
+- **GIVEN** the main package is installed with `npm install --omit=optional`
+- **WHEN** `herdr-world` is invoked on a supported host
+- **THEN** it exits nonzero with a clear missing-optional-package diagnostic,
+  names the exact platform package, and does not start Herdr or a bridge
+
+### Requirement: Shared-launcher path contract
+
+The shared launcher SHALL support these exact environment variables:
+
+| Variable | Contract |
+| --- | --- |
+| `HERDR_WORLD_BRIDGE_BIN` | Absolute path to the bridge executable |
+| `HERDR_WORLD_STATIC_DIR` | Absolute path to the static web directory |
+| `HERDR_WORLD_REQUIRED_GLIBC` | Optional package-manager ABI value in `major.minor` form on Linux |
+
+The npm launcher SHALL set all three values that apply before invoking the
+shared launcher. The Homebrew wrapper SHALL set the two absolute paths and the
+declared Linux ABI value when running on Linux. Existing desktop tarball calls
+with these variables unset SHALL retain the current relative-bundle behavior.
+
+If either path variable is set, both path variables MUST be set. Each path
+MUST be absolute, MUST exist at invocation time, and MUST have the expected
+type: the bridge MUST be a regular executable file and the static path MUST be
+a directory containing the packaged web entrypoint. A supplied required-glibc
+value MUST be syntactically valid and match the package's verified runtime
+metadata. Missing, invalid, relative, nonexistent, or type-incompatible paths
+SHALL fail closed before any bridge or Herdr process is started. The launcher
+MUST NOT resolve an invalid path relative to the current working directory.
+
+The override contract is intentionally narrow: it supplies only the bridge,
+static directory, and ABI preflight inputs. It SHALL not replace Herdr socket,
+workspace, host, origin, or security-policy settings.
+
+#### Scenario: A Cask symlink is invoked after an upgrade
+
+- **GIVEN** Homebrew's `herdr-world` symlink points into a versioned Caskroom
+  directory
+- **WHEN** the command is run after install, upgrade, or reinstall
+- **THEN** the wrapper resolves the active staged bridge and static directory
+  explicitly, validates both absolute paths, and serves assets from that same
+  version without using the caller's working directory
+
+### Requirement: npm launcher process behavior
+
+The npm launcher SHALL:
+
+- preserve every user argument in order and without shell re-parsing;
+- preserve standard input, standard output, and standard error;
+- forward relevant termination signals to the child bridge/launcher and avoid
+  leaving an orphaned child;
+- return the child's successful exit status unchanged;
+- return a deterministic nonzero status and useful diagnostic for launcher
+  preflight failures; and
+- avoid starting Herdr onboarding, selecting a workspace, or starting a
+  listening bridge for `herdr-world --help`.
+
+For `--help` (including the documented short help form, if supported), the npm
+entrypoint SHALL print its usage and exit without spawning the bridge. Help
+output SHALL be available without a running Herdr session or installed
+optional native package, so an omitted optional dependency does not turn help
+into an opaque native-loader error.
+
+#### Scenario: Arguments and signals are forwarded
+
+- **GIVEN** a supported npm installation and a running compatible Herdr
+- **WHEN** a user passes arbitrary supported bridge arguments, types on stdin,
+  and sends an interrupt or termination signal
+- **THEN** the child receives the same arguments and standard streams, receives
+  the signal once, and `herdr-world` exits with the child's resulting status
+
+#### Scenario: Help is requested
+
+- **GIVEN** no running Herdr session and no optional native package
+- **WHEN** the user runs `herdr-world --help`
+- **THEN** usage is printed, the command exits successfully, and neither Herdr
+  onboarding nor a bridge process is started
+
+### Requirement: Linux glibc release check
+
+For the Linux x86-64 bridge, release validation SHALL extract the maximum
+required GLIBC symbol version from the exact binary copied from the verified
+archive. The check SHALL fail if the maximum required version exceeds the
+declared baseline `2.34`, and SHALL write the verified requirement into the
+platform package runtime metadata.
+
+The check SHALL fail closed if the ELF version information cannot be read. It
+SHALL not infer compatibility only from the build host's glibc version. The
+release evidence SHALL include the extracted maximum symbol, declared minimum,
+binary digest, and target archive digest.
+
+#### Scenario: A bridge requires a newer glibc
+
+- **GIVEN** the extracted Linux binary contains a requirement such as
+  `GLIBC_2.35`
+- **WHEN** the release ABI check runs with baseline `2.34`
+- **THEN** release validation fails before npm or Homebrew generation and the
+  binary is not publishable
+
+### Requirement: Linux glibc launcher preflight
+
+Before executing the Linux bridge, the npm launcher SHALL detect the host's
+actual glibc version and compare it with the required version from the
+verified platform metadata. It SHALL report both the required and detected
+versions before execution when the preflight is evaluated.
+
+The preflight SHALL distinguish:
+
+- glibc below `2.34`, with required and detected versions in the error;
+- glibc at `2.34`, which is supported;
+- glibc above `2.34`, which is supported subject to the other checks; and
+- musl or an unidentifiable libc, which is unsupported for this package.
+
+The Homebrew Linux wrapper SHALL provide the same preflight result before
+executing the Cask bridge. No path or libc error SHALL fall through to an
+opaque native dynamic-loader failure.
+
+The release validation SHALL include positive execution at the 2.34 floor and
+negative execution below the floor. It SHALL also test clear Linux ARM64 and
+musl rejection. The npm `libc` selector remains a package-install filter only;
+these runtime checks are mandatory.
+
+### Requirement: npm channels and version set
+
+All four packages SHALL use one identical application version and one intended
+publication channel for a release set:
+
+- prerelease versions SHALL use the `next` dist-tag;
+- stable versions SHALL use the `latest` dist-tag; and
+- a prerelease SHALL never move or overwrite `latest`.
+
+The publication command or staged approval SHALL pass the intended tag
+explicitly. A package set with mixed versions or mixed intended channels SHALL
+be rejected before publication.
+
+### Requirement: First-publication bootstrap
+
+The release process SHALL recognize that trusted publishing and staged
+publishing require a package that already exists. They cannot be configured as
+the mechanism for creating all four package names for the first time.
+
+The first publication SHALL be the first real prerelease, not a placeholder.
+It SHALL use an operator-authenticated npm workflow with 2FA. Before the first
+publish call, the process SHALL:
+
+1. generate all four package tarballs from the verified release assets;
+2. inspect each tarball's exact file list and metadata;
+3. install-test each tarball on its applicable target;
+4. record a cryptographic hash for each tarball and the release evidence; and
+5. confirm scope ownership, package-name availability, and the `next` channel.
+
+The three platform packages SHALL publish first, in any deterministic order,
+and the main launcher package SHALL publish last. Bootstrap SHALL not use a
+long-lived token stored in the repository or workflow.
+
+Immediately after all four packages exist, trusted publishing SHALL be
+configured separately for every package. Each configuration SHALL identify the
+exact `IvoryHeart/herdr-world` repository and exact release workflow. The
+configuration SHALL grant stage-only permission where npm supports it.
+
+#### Scenario: Bootstrap is attempted before scope ownership
+
+- **GIVEN** the `@ivoryheart` scope is not controlled by the project
+- **WHEN** bootstrap validation runs
+- **THEN** publication stops as an external prerequisite failure and no
+  placeholder package is published
+
+### Requirement: Subsequent trusted staged publishing
+
+After bootstrap, the release workflow SHALL use GitHub-hosted OIDC trusted
+publishing for every package. It SHALL:
+
+- run with `id-token: write`;
+- use Node `22.14.0` or newer and npm `11.15.0` or newer;
+- use the exact configured repository and workflow for each package;
+- grant only stage publishing permission where supported;
+- invoke `npm stage publish` for all four packages;
+- download and inspect the actual staged tarball for every package before
+  approval;
+- require human 2FA approval of all three platform stages before approving the
+  launcher stage; and
+- use no long-lived npm publishing token.
+
+The stage tag and package/version identity SHALL be recorded with every
+downloaded staged tarball. Approval SHALL be refused if the downloaded bytes,
+metadata, file list, or hash differ from the pre-stage inspected tarball.
+
+The workflow SHALL not assume that a stage is available for a package that has
+never been published. A missing-package response SHALL select the bootstrap
+path and stop the staged path safely.
+
+#### Scenario: A staged tarball differs from the inspected tarball
+
+- **GIVEN** a package has been staged through trusted publishing
+- **WHEN** the downloaded staged tarball does not match the pre-recorded hash
+- **THEN** approval is refused, the release is marked failed, and no retry
+  SHALL replace or mutate either tarball silently
+
+### Requirement: npm partial-publication recovery
+
+npm publication of four packages SHALL be modeled as a non-atomic state
+machine. The release system SHALL persist an operator-visible status record
+containing the application version, channel, package states, tarball hashes,
+stage identifiers where applicable, and the next safe action. It SHALL not
+record credentials in that status.
+
+The states SHALL include:
+
+| State | Meaning | Safe next action |
+| --- | --- | --- |
+| `prepared` | All four tarballs inspected, tested, and hash-recorded | Start bootstrap or stage platform packages |
+| `staged` | A stage exists and its downloaded bytes passed inspection | Approve or reject that exact stage |
+| `platform-approval-pending` | Platform stages are ready for human 2FA approval | Approve platform packages only |
+| `platform-published` | All three exact platform versions exist and match hashes | Stage/approve the launcher |
+| `partial` | Some live package versions exist and others do not | Resume only missing packages with identical inspected tarballs |
+| `complete` | All four live versions exist with matching hashes and tag | Generate the eligible tap PR |
+| `burned` | A wrong byte set was published for this version | Advance the complete set to a new application version |
+| `blocked` | An external prerequisite or validation gate is unmet | Resolve the named blocker; do not publish |
+
+Before the launcher package is published, all three platform package names
+SHALL exist at the exact application version with the inspected bytes. The
+launcher SHALL never be published first.
+
+A transient failure before a package version is published MAY retry the
+identical inspected tarball. If a package is already live with correct bytes,
+the process SHALL resume the missing package and SHALL not republish or mutate
+the existing package. If incorrect bytes are published for any package, that
+application version is burned permanently and the complete four-package set
+MUST advance to a new application version. The process SHALL never create
+divergent package versions to repair one member of the set.
+
+An incorrect staged package that has not been approved MAY be rejected; any
+replacement stage SHALL be newly generated, re-inspected, and explicitly
+associated with the same version without silently overwriting the rejected
+stage. Once incorrect bytes are live, the `burned` rule applies.
+
+#### Scenario: A platform publication times out
+
+- **GIVEN** the platform tarball was inspected and its publication result is
+  unknown
+- **WHEN** the registry cannot immediately confirm whether the exact version is
+  live
+- **THEN** the release enters `partial` or an equivalent unknown substate,
+  queries the registry before retrying, and either resumes the missing package
+  with the identical hash or stops for operator reconciliation
+
+#### Scenario: One package has wrong live bytes
+
+- **GIVEN** one package at version `0.1.0-rc.1` is live with bytes that do not
+  match the inspected tarball
+- **WHEN** release reconciliation detects the mismatch
+- **THEN** version `0.1.0-rc.1` is marked `burned`, no package at that version is
+  replaced, and the next release advances all four packages together
+
+### Requirement: Homebrew third-party Cask
+
+The initial Homebrew distribution SHALL be a Cask in the separate public
+third-party repository `IvoryHeart/homebrew-tap`. The stable user-facing
+command SHALL be:
+
+```bash
+brew install --cask IvoryHeart/tap/herdr-world
+```
+
+The Cask SHALL use the existing immutable GitHub release archives and select
+the URL and SHA-256 by OS and architecture:
+
+| Target | Archive URL pattern |
+| --- | --- |
+| macOS ARM64 | `herdr-world-vX.Y.Z-macos-arm64.tar.gz` |
+| macOS x86-64 | `herdr-world-vX.Y.Z-macos-x86_64.tar.gz` |
+| Linux x86-64 | `herdr-world-vX.Y.Z-linux-x86_64.tar.gz` |
+
+The Cask SHALL derive URLs from an immutable versioned release tag and SHALL
+never use a moving `latest` URL or omit a checksum. It SHALL explicitly reject
+Linux ARM64, musl, Windows, and other unsupported combinations. It SHALL
+expose only `herdr-world`; `herdr-world-bridge` SHALL not become a second
+global command.
+
+The installed Cask SHALL preserve the staged bridge, web assets,
+documentation, and legal material. Installation SHALL not execute Herdr, the
+bridge, or a network-time release downloader, and SHALL not create, select, or
+modify a Herdr workspace. The Cask SHALL not act as a service supervisor.
+
+The Cask command path SHALL use the explicit shared-launcher path contract or a
+narrowly scoped Cask command wrapper. It SHALL not assume that a Homebrew
+symlink's current directory is the Caskroom directory. The path solution SHALL
+continue to work after upgrade, reinstall, and removal of an older Cask
+version. Uninstall SHALL remove only the Cask-owned files and SHALL not delete
+unrelated plugin state.
+
+The tap SHALL be described as third-party. It SHALL not be described as
+reviewed, endorsed, or official Homebrew software. Documentation SHALL explain
+that third-party tap definitions execute with user privileges and that a
+fully-qualified item install limits the requested trust scope.
+
+#### Scenario: Cask installation is observed
+
+- **GIVEN** a supported target and a complete signed/stable release asset set
+- **WHEN** `brew install --cask IvoryHeart/tap/herdr-world` runs
+- **THEN** Homebrew verifies the selected immutable archive and SHA-256,
+  installs one `herdr-world` command with its bridge and web assets, starts no
+  daemon, and makes no Herdr workspace mutation
+
+### Requirement: Homebrew channel and signing gate
+
+The ordinary `herdr-world` Cask SHALL be stable-only. It SHALL not point at an
+RC or other prerelease archive. A prerelease Cask, if ever required, SHALL be a
+separately named and deliberately documented channel; it is not part of this
+initial specification.
+
+The stable Cask SHALL not be published or merged until the macOS artifacts are
+signed and notarized and pass the applicable Gatekeeper checks. Cask
+implementation and local validation MAY use release-candidate fixtures before
+that gate, but such fixtures SHALL not be presented as a stable publication.
+
+### Requirement: Generated tap pull request
+
+After the complete GitHub release asset set is available and the stable
+signing gate passes, the tap update mechanism SHALL generate a pull request in
+`IvoryHeart/homebrew-tap`. The change SHALL update only the release version,
+three target URLs, and three corresponding SHA-256 values, plus any reviewed
+metadata required by the Cask.
+
+The generated pull request SHALL run Homebrew Cask audit/style and installation
+checks for macOS ARM64, macOS x86-64, and Linux x86-64 where those Homebrew
+targets are available. A human review SHALL be required before merge.
+
+Automation SHALL use narrowly scoped bot or GitHub App credentials limited to
+the required tap pull-request operation. The source repository SHALL not hold
+an unrestricted credential capable of rewriting the tap. The PR SHALL not be
+generated from a partial GitHub release asset set.
+
+#### Scenario: The release has one missing archive
+
+- **GIVEN** the release tag exists but one of the three archives or checksums is
+  missing or unverifiable
+- **WHEN** tap update automation is requested
+- **THEN** no tap PR is generated and the release status names the missing asset
+
+### Requirement: Plugin independence
+
+Spec 016's initial plugin design SHALL remain source-build-only. The plugin
+MUST NOT:
+
+- discover or use an npm or Homebrew installation implicitly;
+- depend on npm, Homebrew, or a package-manager-specific layout;
+- assume that `herdr-world` is on `PATH`;
+- delegate plugin-managed bridge/service ownership to Homebrew; or
+- pair a plugin controller with an externally installed bridge without an
+  explicit contract.
+
+The existing plugin SHALL continue to own or explicitly configure its source
+build, bridge, static assets, Herdr socket, and service lifecycle as defined by
+Spec 016. A future external-installation or binary-first plugin mode SHALL
+require a later specification defining explicit path, version, asset-pairing,
+and lifecycle validation.
+
+#### Scenario: Both distribution types are installed
+
+- **GIVEN** a user has an npm or Homebrew Herdr World installation and the
+  source-build plugin is installed
+- **WHEN** the plugin starts or manages its bridge
+- **THEN** it uses its Spec 016 source-build contract and does not discover,
+  select, or delegate lifecycle ownership to either external installation
+
+## 6. Data and interface contract
+
+### 6.1 Generated npm package layout
+
+The generated main package SHALL have this package-owned layout (in addition to
+the required npm metadata):
+
+```text
+package.json
+README.md
+bin/herdr-world
+share/herdr-world/web/**
+docs/**
+LICENSE
+THIRD_PARTY_NOTICES.md
+UPSTREAM.md
+third_party/**
+```
+
+The exact allowlist MAY be narrower, but it SHALL contain the complete runtime
+web tree, launcher support files, documentation, and legal closure. It SHALL
+not contain a native bridge binary.
+
+Each platform package SHALL have this package-owned layout:
+
+```text
+package.json
+README.md
+native/herdr-world-bridge
+native/runtime.json
+LICENSE
+THIRD_PARTY_NOTICES.md
+UPSTREAM.md
+third_party/**
+```
+
+`native/runtime.json` SHALL identify at least the application version, target,
+bridge relative path, bridge SHA-256, and (for Linux) required glibc version.
+The value SHALL be generated from and checked against the verified archive; it
+is not user input.
+
+### 6.2 Package version and dependency contract
+
+For an application version `A`, all package manifests SHALL satisfy:
+
+```text
+main.version = A
+platform.version = A
+main.optionalDependencies[platform] = A
+```
+
+The dependency ranges SHALL be exact strings, not caret, tilde, wildcard, or
+latest ranges. A launcher version mismatch between its own package, the
+selected platform package, and `native/runtime.json` SHALL be an actionable
+nonzero failure before bridge execution.
+
+### 6.3 Launcher diagnostics
+
+Launcher errors SHALL identify the failed class, detected values, and the safe
+next action. At minimum, diagnostics SHALL distinguish:
+
+- unsupported operating system;
+- unsupported CPU architecture;
+- Linux ARM64;
+- musl or unknown libc;
+- glibc below `2.34`, including required and detected versions;
+- missing or omitted optional platform package;
+- failed optional-package installation;
+- main/platform/runtime metadata version mismatch;
+- invalid, missing, relative, nonexistent, or wrong-type path override; and
+- bridge execution or child-process failure.
+
+Diagnostics SHALL not print authentication tokens, private paths unrelated to
+the package, or arbitrary environment contents.
+
+## 7. Privacy and security
+
+### 7.1 Installation and runtime boundaries
+
+Neither npm nor Homebrew installation SHALL create a Herdr workspace, select a
+Herdr session, start a daemon, or change bridge security configuration. The
+launcher SHALL preserve the existing loopback defaults and explicit host/origin
+configuration rules. These checks are compatibility and browser-admission
+controls; they are not a substitute for authentication.
+
+The package-manager launchers SHALL pass only explicit package-owned paths to
+the shared launcher. They SHALL not use the current directory, a guessed npm
+prefix, an ambient global executable, or an untrusted path from a Cask symlink
+without validation.
+
+### 7.2 Publication credentials and immutability
+
+npm package name/version contents are immutable after publication. All tarballs
+MUST be inspected, install-tested, and hash-recorded before bootstrap or
+staging. Subsequent publication SHALL use short-lived GitHub OIDC trusted
+publishing and no long-lived npm token.
+
+Stage-only permission SHALL be preferred for trusted publishers. Human 2FA
+approval is the boundary that makes a staged package live, with platform
+packages approved before the launcher package.
+
+Homebrew tap automation SHALL use least-privilege credentials and pull requests
+with review. A tap update SHALL be impossible to trigger from an incomplete or
+unverified release asset set.
+
+### 7.3 Supply-chain evidence
+
+Release evidence SHALL retain, at minimum:
+
+- each native archive SHA-256 and verified file manifest;
+- the common-payload identity result;
+- each bridge SHA-256 and native-format result;
+- the extracted maximum Linux GLIBC symbol and declared baseline;
+- each npm tarball SHA-256 and `npm pack --dry-run` file list;
+- staged tarball hashes and stage identifiers, when applicable;
+- publication status for each package; and
+- the three Homebrew archive SHA-256 values used by the reviewed Cask PR.
+
+## 8. Release mechanics
+
+### 8.1 Required sequence
+
+For every release set, the release operator or trusted workflow SHALL execute
+these steps in order:
+
+1. Build all three native archives from the final tag.
+2. Verify contents, legal closure, native format, and checksum for every
+   archive.
+3. Run the stock-Herdr live smoke for all three targets.
+4. Verify common-payload byte identity across all three archives.
+5. Upload and verify the complete immutable GitHub release asset set.
+6. Generate all four npm package tarballs from the verified assets, using the
+   designated common-payload archive.
+7. Inspect and install-test all npm tarballs, and record their hashes.
+8. Bootstrap-publish or stage/approve the npm package set according to whether
+   the package names already exist.
+9. Generate a reviewed Homebrew tap PR when the stable and signing gates are
+   satisfied.
+10. Install-test the resulting Cask from the tap on every supported target.
+
+No later step SHALL make an earlier validation step implicit. In particular,
+uploading a GitHub archive does not make an npm tarball trusted, and a
+successful npm publication does not make a Cask eligible before signing and
+review.
+
+### 8.2 External publication boundaries and retries
+
+Each external boundary SHALL expose a durable observable result:
+
+| Boundary | Success evidence | Safe retry |
+| --- | --- | --- |
+| GitHub assets | All three archives and checksums resolve and match recorded hashes | Re-query/re-upload only the missing asset; never replace an immutable asset |
+| npm bootstrap | Each live package version resolves and matches the inspected tarball | Query first; publish only a missing package with the identical tarball |
+| npm stage | Stage identifier and downloaded bytes match the inspected tarball | Resume or reject the exact stage; never silently overwrite it |
+| npm approval | Registry shows the exact approved package/version/hash | Approve an outstanding exact stage or stop for reconciliation |
+| Tap PR | PR contains only reviewed version/URL/checksum changes and passes checks | Regenerate a new PR from the same immutable release data |
+| Cask install | Brew fetch/checksum/install/uninstall checks pass | Fix or close the PR; never point stable Cask at mutable data |
+
+An unknown result SHALL be reconciled against the external registry or GitHub
+state before retry. A retry SHALL not assume that a timeout means “not
+published.”
+
+## 9. Validation and acceptance evidence
+
+Implementation SHALL provide automated tests and release evidence for the
+following scenarios.
+
+### 9.1 npm package and launcher matrix
+
+- exact main and platform package contents and `files` allowlists;
+- package names, public metadata, repository, versions, selectors, exact
+  optional dependency versions, and only the permitted command;
+- optional dependency selection on Linux x64, macOS ARM64, and macOS x64;
+- `npm install --omit=optional` and a simulated optional-install failure;
+- unsupported OS, CPU, Linux ARM64, musl, and unknown libc;
+- glibc below 2.34, exactly 2.34, and above 2.34;
+- maximum GLIBC symbol extraction and release failure above the baseline;
+- missing or mismatched native package/runtime metadata;
+- invalid, relative, missing, nonexistent, and wrong-type path overrides;
+- argument, standard-input/output/error, signal, and exit-status forwarding;
+- `herdr-world --help` with no Herdr and no native package;
+- live smoke against stock Herdr using the packaged bridge;
+- loopback and existing bridge security defaults;
+- common-payload path-set and byte identity;
+- legal closure in the main and every platform tarball;
+- `next` for prereleases and `latest` for stable versions;
+- first-publication bootstrap, including operator 2FA and platform-first order;
+- trusted staged publishing with npm 11.15.0+ and Node 22.14.0+;
+- downloaded staged tarball inspection and platform-before-launcher approval;
+- timeout, retry, partial publication, burned version, and no-mutation recovery.
+
+### 9.2 Homebrew matrix
+
+- Cask audit and style checks;
+- immutable URL and SHA-256 selection for all three supported targets;
+- explicit rejection of Linux ARM64, musl, Windows, and other unsupported
+  combinations;
+- Cask install, upgrade, reinstall, and uninstall on macOS ARM64, macOS x64,
+  and Linux x64 where Homebrew targets are available;
+- command exposure limited to `herdr-world`;
+- Caskroom/symlink path resolution after install and upgrade;
+- live bridge smoke separately from installation's no-daemon check;
+- no bridge/Herdr process, workspace creation, or workspace mutation during
+  installation;
+- no service-supervisor behavior;
+- third-party tap trust/documentation behavior;
+- signed/notarized macOS assets and applicable Gatekeeper checks before stable
+  publication; and
+- stable Cask never resolving to an RC archive.
+
+### 9.3 Unchanged-product checks
+
+The release acceptance run SHALL confirm that:
+
+- existing desktop tarball names, contents, checksums, launcher defaults, and
+  stock-Herdr smoke remain unchanged;
+- Android packaging and client behavior remain unchanged; and
+- Spec 016 plugin installation, source-build behavior, and plugin-managed
+  lifecycle remain unchanged and do not discover package-manager installs.
+
+## 10. Rollout and operations
+
+Rollout SHALL occur in these gates:
+
+1. Resolve external ownership prerequisites: control of `@ivoryheart`, public
+   creation of `IvoryHeart/homebrew-tap`, and signing/notarization readiness
+   for stable macOS Cask publication.
+2. Implement and validate package generation against release-candidate fixtures
+   without changing desktop or Android outputs.
+3. Perform the first real npm prerelease bootstrap with operator-authenticated
+   2FA, platform packages first and launcher last.
+4. Configure and verify trusted publishing independently for all four existing
+   packages.
+5. Use staged publishing for later prereleases, with downloaded-stage
+   inspection and human platform-before-launcher approval.
+6. Publish the ordinary stable Cask only after macOS signing/notarization and
+   Gatekeeper checks pass; merge only a reviewed generated tap PR.
+7. Monitor the package/release status record for partial publication and
+   reconcile before any retry.
+
+Documentation SHALL show the stable npm and Homebrew commands only for stable
+releases, and SHALL clearly label `@next`/`next` installation as prerelease.
+It SHALL identify the Homebrew repository as a third-party tap and SHALL not
+claim Homebrew review or endorsement.
+
+## 11. Deferred decisions
+
+The following are intentionally deferred and require a later specification or
+extension before becoming supported behavior:
+
+- a separately named prerelease Homebrew Cask channel;
+- a Homebrew source-building formula or binary formula;
+- Linux ARM64, musl, Windows, or additional macOS targets;
+- a lower Linux glibc baseline;
+- plugin reuse of an external npm/Homebrew installation;
+- plugin binary-first distribution or external lifecycle ownership; and
+- submission to an official Homebrew repository.
+
+No deferred item SHALL be introduced by changing the stable Cask, silently
+loosening the npm launcher checks, or modifying Spec 016's source-build-only
+plugin behavior.
+
+## 12. Authoritative references
+
+- [npm and Homebrew distribution analysis](../analysis/npm-homebrew-distribution-analysis-2026-08-28.md)
+- [Spec 016: Herdr World plugin release](016-herdr-world-plugin-release-spec.md)
+- [Packaging](../packaging.md)
+- [Release process](../release.md)
+- [npm `package.json` fields](https://docs.npmjs.com/cli/v11/configuring-npm/package-json)
+- [npm scoped public packages](https://docs.npmjs.com/creating-and-publishing-scoped-public-packages/)
+- [npm staged publishing](https://docs.npmjs.com/staged-publishing/)
+- [npm staged publishing CLI](https://docs.npmjs.com/cli/v11/commands/npm-stage/)
+- [npm trusted publishers](https://docs.npmjs.com/trusted-publishers/)
+- [npm trusted publishing configuration](https://docs.npmjs.com/cli/v11/commands/npm-trust/)
+- [npm distribution tags](https://docs.npmjs.com/cli/v11/commands/npm-dist-tag/)
+- [Homebrew: Adding Software](https://docs.brew.sh/Adding-Software-to-Homebrew)
+- [Homebrew Cask Cookbook](https://docs.brew.sh/Cask-Cookbook)
+- [Homebrew acceptable Casks](https://docs.brew.sh/Acceptable-Casks)
+- [Homebrew taps](https://docs.brew.sh/Taps)
+- [Homebrew tap trust](https://docs.brew.sh/Tap-Trust)

--- a/docs/specs/017-herdr-world-npm-homebrew-distribution-spec.md
+++ b/docs/specs/017-herdr-world-npm-homebrew-distribution-spec.md
@@ -8,11 +8,6 @@
 - **Approved by:** —
 - **Approved at:** —
 
-> This document may be edited only while its status is `Draft` or `In review`.
-> After approval it is immutable. After implementation completes, record
-> delivery and drift in `017-herdr-world-npm-homebrew-distribution-spec-summary.md`;
-> put later intended changes in a numbered extension.
-
 This is a standalone distribution contract related to, but independent from,
 [Spec 016](016-herdr-world-plugin-release-spec.md). Its primary research input
 is the [npm and Homebrew distribution analysis](../analysis/npm-homebrew-distribution-analysis-2026-08-28.md).
@@ -162,7 +157,7 @@ verified archive.
 Before generating npm packages, release validation SHALL compare the common
 payload in all three verified archives. The comparison SHALL normalize away
 only the archive's platform-specific root directory and exclude only the
-platform-specific bridge binary and its platform-specific runtime metadata.
+platform-specific bridge binary.
 
 The common payload is the byte content and relative path set for:
 
@@ -242,10 +237,19 @@ platform package tarball.
 Each platform package SHALL contain only:
 
 - the matching bridge binary extracted from its verified desktop archive;
-- bridge runtime metadata required for launcher preflight; and
+- generated package metadata required for launcher preflight; and
 - the complete legal material applicable to that bridge payload, including the
   project license, native dependency inventory, notices, and referenced license
   files.
+
+The existing desktop legal closure SHALL be copied without path or content
+rewriting into every npm package that carries `THIRD_PARTY_NOTICES.md`. This
+closure includes `LICENSE`, `THIRD_PARTY_NOTICES.md`, `UPSTREAM.md`,
+`docs/world-assets.md`, `vendor/herdr-compat/VENDOR-MANIFEST.toml`, the
+complete `third_party/**` trees, and the bundled web legal files. In a platform
+package, web legal files are legal-only material; the web runtime tree is not
+included. Package generation SHALL not introduce a package-specific notice
+splitting system.
 
 Each platform package SHALL have an explicit `files` allowlist and SHALL have
 the same application version as the main package. It SHALL declare exact
@@ -267,10 +271,10 @@ directory guess.
 
 - **GIVEN** the Linux platform package is unpacked
 - **WHEN** its file list and metadata are checked
-- **THEN** it contains its x86-64 bridge, runtime metadata, and complete
-  applicable legal closure, declares `os: ["linux"]`, `cpu: ["x64"]`,
-  `libc: ["glibc"]`, has no `bin` mapping, and contains no web or launcher
-  payload
+- **THEN** it contains its x86-64 bridge, generated package metadata, and
+  complete applicable legal closure, declares `os: ["linux"]`, `cpu: ["x64"]`,
+  `libc: ["glibc"]`, has no `bin` mapping, and contains no web runtime or
+  launcher payload beyond legal-only files
 
 ### Requirement: Explicit npm file boundaries
 
@@ -338,8 +342,9 @@ If either path variable is set, both path variables MUST be set. Each path
 MUST be absolute, MUST exist at invocation time, and MUST have the expected
 type: the bridge MUST be a regular executable file and the static path MUST be
 a directory containing the packaged web entrypoint. A supplied required-glibc
-value MUST be syntactically valid and match the package's verified runtime
-metadata. Missing, invalid, relative, nonexistent, or type-incompatible paths
+value MUST be syntactically valid and match the generated Linux package
+metadata or the Cask's recorded release value. Missing, invalid, relative,
+nonexistent, or type-incompatible paths
 SHALL fail closed before any bridge or Herdr process is started. The launcher
 MUST NOT resolve an invalid path relative to the current working directory.
 
@@ -397,7 +402,7 @@ For the Linux x86-64 bridge, release validation SHALL extract the maximum
 required GLIBC symbol version from the exact binary copied from the verified
 archive. The check SHALL fail if the maximum required version exceeds the
 declared baseline `2.34`, and SHALL write the verified requirement into the
-platform package runtime metadata.
+Linux platform package metadata.
 
 The check SHALL fail closed if the ELF version information cannot be read. It
 SHALL not infer compatibility only from the build host's glibc version. The
@@ -416,8 +421,8 @@ binary digest, and target archive digest.
 
 Before executing the Linux bridge, the npm launcher SHALL detect the host's
 actual glibc version and compare it with the required version from the
-verified platform metadata. It SHALL report both the required and detected
-versions before execution when the preflight is evaluated.
+generated Linux platform package metadata. It SHALL report both the required
+and detected versions before execution when the preflight is evaluated.
 
 The preflight SHALL distinguish:
 
@@ -514,23 +519,29 @@ path and stop the staged path safely.
 ### Requirement: npm partial-publication recovery
 
 npm publication of four packages SHALL be modeled as a non-atomic state
-machine. The release system SHALL persist an operator-visible status record
-containing the application version, channel, package states, tarball hashes,
-stage identifiers where applicable, and the next safe action. It SHALL not
-record credentials in that status.
+machine. npm's registry and staged-publishing records SHALL remain the
+authoritative publication state. The release process SHALL emit an
+operator-visible status projection for each attempt, such as a CI summary or
+release artifact, containing the application version, channel, package states,
+tarball hashes, stage identifiers where applicable, and the next safe action.
+This projection SHALL not become a second publication database and SHALL not
+record credentials.
 
-The states SHALL include:
+The status projection SHALL report these observable states:
 
 | State | Meaning | Safe next action |
 | --- | --- | --- |
 | `prepared` | All four tarballs inspected, tested, and hash-recorded | Start bootstrap or stage platform packages |
-| `staged` | A stage exists and its downloaded bytes passed inspection | Approve or reject that exact stage |
-| `platform-approval-pending` | Platform stages are ready for human 2FA approval | Approve platform packages only |
+| `platform-pending` | Platform stages are being inspected or await human 2FA approval | Inspect/approve platform stages only |
 | `platform-published` | All three exact platform versions exist and match hashes | Stage/approve the launcher |
-| `partial` | Some live package versions exist and others do not | Resume only missing packages with identical inspected tarballs |
+| `launcher-pending` | The launcher stage is being inspected or awaits approval | Inspect/approve the launcher stage |
+| `partial` | A publication result is unknown or only part of the intended set is live | Query npm and resume only missing packages with identical tarballs |
 | `complete` | All four live versions exist with matching hashes and tag | Generate the eligible tap PR |
 | `burned` | A wrong byte set was published for this version | Advance the complete set to a new application version |
-| `blocked` | An external prerequisite or validation gate is unmet | Resolve the named blocker; do not publish |
+
+A validation or external-prerequisite failure before publication SHALL be
+reported as `blocked` with its reason and safe remediation; it is not a new
+npm registry state.
 
 Before the launcher package is published, all three platform package names
 SHALL exist at the exact application version with the inspected bytes. The
@@ -696,6 +707,7 @@ LICENSE
 THIRD_PARTY_NOTICES.md
 UPSTREAM.md
 third_party/**
+vendor/herdr-compat/VENDOR-MANIFEST.toml
 ```
 
 The exact allowlist MAY be narrower, but it SHALL contain the complete runtime
@@ -708,17 +720,20 @@ Each platform package SHALL have this package-owned layout:
 package.json
 README.md
 native/herdr-world-bridge
-native/runtime.json
 LICENSE
 THIRD_PARTY_NOTICES.md
 UPSTREAM.md
+docs/world-assets.md
+share/herdr-world/web/legal/**
 third_party/**
+vendor/herdr-compat/VENDOR-MANIFEST.toml
 ```
 
-`native/runtime.json` SHALL identify at least the application version, target,
-bridge relative path, bridge SHA-256, and (for Linux) required glibc version.
-The value SHALL be generated from and checked against the verified archive; it
-is not user input.
+Each platform `package.json` SHALL include a generated `herdrWorld` metadata
+object containing the fixed bridge path `native/herdr-world-bridge` and, for
+Linux, the required glibc version `2.34`. The Linux value SHALL be generated
+from and checked against the verified bridge; it is not user input. Bridge
+hashes remain release evidence rather than runtime configuration.
 
 ### 6.2 Package version and dependency contract
 
@@ -731,9 +746,9 @@ main.optionalDependencies[platform] = A
 ```
 
 The dependency ranges SHALL be exact strings, not caret, tilde, wildcard, or
-latest ranges. A launcher version mismatch between its own package, the
-selected platform package, and `native/runtime.json` SHALL be an actionable
-nonzero failure before bridge execution.
+latest ranges. A launcher version mismatch between its own package and the
+selected platform package SHALL be an actionable nonzero failure before bridge
+execution.
 
 ### 6.3 Launcher diagnostics
 
@@ -747,7 +762,7 @@ next action. At minimum, diagnostics SHALL distinguish:
 - glibc below `2.34`, including required and detected versions;
 - missing or omitted optional platform package;
 - failed optional-package installation;
-- main/platform/runtime metadata version mismatch;
+- main/platform package or generated platform metadata mismatch;
 - invalid, missing, relative, nonexistent, or wrong-type path override; and
 - bridge execution or child-process failure.
 
@@ -856,7 +871,7 @@ following scenarios.
 - unsupported OS, CPU, Linux ARM64, musl, and unknown libc;
 - glibc below 2.34, exactly 2.34, and above 2.34;
 - maximum GLIBC symbol extraction and release failure above the baseline;
-- missing or mismatched native package/runtime metadata;
+- missing or mismatched native package/generated platform metadata;
 - invalid, relative, missing, nonexistent, and wrong-type path overrides;
 - argument, standard-input/output/error, signal, and exit-status forwarding;
 - `herdr-world --help` with no Herdr and no native package;
@@ -893,8 +908,10 @@ following scenarios.
 
 The release acceptance run SHALL confirm that:
 
-- existing desktop tarball names, contents, checksums, launcher defaults, and
-  stock-Herdr smoke remain unchanged;
+- existing desktop tarball names, layout, default launcher behavior, and
+  stock-Herdr smoke remain compatible, with the current verifier continuing to
+  pass when package-manager overrides are unset; future release checksums may
+  of course differ when release bytes change;
 - Android packaging and client behavior remain unchanged; and
 - Spec 016 plugin installation, source-build behavior, and plugin-managed
   lifecycle remain unchanged and do not discover package-manager installs.

--- a/docs/specs/017-herdr-world-npm-homebrew-distribution-spec.md
+++ b/docs/specs/017-herdr-world-npm-homebrew-distribution-spec.md
@@ -167,10 +167,12 @@ The common payload is the byte content and relative path set for:
 - `README.md`, `LICENSE`, `THIRD_PARTY_NOTICES.md`, and `UPSTREAM.md`;
 - the complete applicable `docs/`, `third_party/`, and legal/inventory trees.
 
-The validator SHALL compare every common relative path and its bytes (using a
-cryptographic digest plus byte comparison), and SHALL fail on a missing,
-additional, or different common file. One designated verified archive,
-`linux-x86_64`, SHALL supply the common npm payload after this check succeeds.
+The validator SHALL produce a canonical sorted manifest mapping every common
+relative path to its SHA-256 digest, compare those manifests, and SHALL fail on
+a missing, additional, or different common file or digest. This manifest is the
+release proof that the common payload is byte-identical. One designated
+verified archive, `linux-x86_64`, SHALL supply the common npm payload after this
+check succeeds.
 The designation is a source-selection convenience; it does not relax the
 identity check.
 


### PR DESCRIPTION
## Summary

- add Spec 017 for standalone npm and Homebrew distribution of Herdr World
- define verified-release reuse, common-payload identity, npm package topology, Node launcher, glibc floor, staged publication, and partial-failure recovery
- define the stable-only third-party Homebrew Cask/tap contract and preserve Spec 016's source-build-only plugin design
- correct the 2026-08-28 distribution analysis to match the settled contract

## Scope

Documentation only. This PR does not implement package generation, npm publication, a Homebrew tap, release workflow changes, or launcher changes.

## Validation

- `git diff --cached --check` before commit
- verified local and authoritative external Markdown links
- verified only `docs/analysis/` and `docs/specs/` changed
- verified Spec 017 numbering and required sections

## External prerequisites recorded by the spec

- ownership/control of the `@ivoryheart` npm scope
- first real prerelease bootstrap through an operator-authenticated 2FA npm workflow
- creation of the public `IvoryHeart/homebrew-tap` repository
- macOS signing, notarization, and Gatekeeper validation before stable Cask publication
