### PR TITLE
docs: publish npm package and update Homebrew tap from CI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,11 @@
+Use the agent's capacity to deliver complete, coherent outcomes without reducing scope or splitting
+work merely because it would be costly for a human. Be exhaustive in reasoning and validation, but
+economical in design: prefer the smallest clear solution that fully meets current requirements and
+fits the existing architecture. Add complexity only when required by the requested outcome, an
+existing contract, an external constraint, or concrete evidence. Simple means elegant and
+complete—not basic, fragmented, or speculative. Reviews should raise material problems, not turn
+optional hardening into requirements.
+
 # Repository delivery workflow
 
 Specifications are decision aids, not a gate on ordinary engineering work.

--- a/docs/analysis/npm-homebrew-distribution-analysis-2026-08-28.md
+++ b/docs/analysis/npm-homebrew-distribution-analysis-2026-08-28.md
@@ -48,10 +48,12 @@ For every intentional final tag:
 1. build all native archives;
 2. verify contents, legal closure, formats, checksums, and live smoke;
 3. expose the verified outputs to the release adapters;
-4. generate, inspect, install-test, hash, and publish the exact npm package;
-5. for a stable release, generate, validate, and write the Cask update to the
-   third-party tap; and
-6. run any future adapters against the same version and outputs.
+4. generate, inspect, install-test, and hash the exact npm package;
+5. for a prerelease, publish npm under its prerelease channel without updating
+   the stable Cask; for a stable release, generate and complete Cask validation,
+   then publish npm under the stable channel and write the validated Cask update
+   to the third-party tap; and
+6. run any future adapters against the same version and release record.
 
 Prereleases use the npm prerelease channel and leave the stable Cask unchanged.
 Stable releases use the stable npm channel and update the ordinary Cask.
@@ -85,9 +87,11 @@ shows the universal package is impractical.
 
 The Cask is stable-only and references the immutable GitHub release archives and
 checksums for the existing supported desktop targets. CI generates, validates,
-and writes the small Cask metadata update to `IvoryHeart/homebrew-tap` after the
-release gates pass. There is no separate binary upload, installer daemon,
-workspace mutation, or moving `latest` URL.
+and, after stable npm publication, writes the small validated Cask metadata
+update to `IvoryHeart/homebrew-tap`. There is no separate binary upload,
+installer daemon, workspace mutation, or moving `latest` URL.
+On retry, CI compares the complete generated Cask with the tap and no-ops when
+they already match.
 
 The tap is third-party and must not be described as reviewed or endorsed by
 Homebrew. A source formula, binary formula, or separately named prerelease Cask
@@ -112,7 +116,7 @@ ownership.
 | --- | --- |
 | A channel builds different native bytes | Require every adapter to consume verified release outputs |
 | A release version drifts between channels | Derive every channel version from the final tag |
-| A failed retry overwrites immutable content | Check the channel before retry; no-op when exact, use a new version when different |
+| A failed retry overwrites immutable content | Check the channel before retry; no-op when exact, compare the complete generated Cask, and use a new version when different |
 | A future channel expands release complexity | Require a small adapter with the same release inputs |
 | Package installation changes runtime state | Test no downloader, daemon, workspace mutation, or Herdr startup |
 

--- a/docs/analysis/npm-homebrew-distribution-analysis-2026-08-28.md
+++ b/docs/analysis/npm-homebrew-distribution-analysis-2026-08-28.md
@@ -164,18 +164,17 @@ npm publish <tested-package.tgz> --tag <next-or-latest>
 The first publication still needs a bootstrap credential because npm trusted
 publishing cannot be configured until the package exists. It should run in the
 same GitHub-hosted CI job with a temporary or granular npm publish token stored
-as a GitHub Actions secret, and it should publish the first real prerelease
-with explicit public access:
+as a GitHub Actions secret. The bootstrap job should grant `contents: read` and
+`id-token: write`, use Node 22.14.0+ and npm 11.5.1+, and publish the first real
+prerelease with npm provenance and explicit public access:
 
 ```bash
-npm publish <tested-package.tgz> --access public --tag next
+npm publish <tested-package.tgz> --provenance --access public --tag next
 ```
 
-Where supported by the selected npm CLI, the bootstrap job should enable npm
-provenance. After the package exists, configure trusted publishing for the
-exact `IvoryHeart/herdr-world` repository and exact workflow filename
-`release.yml`, allow direct `npm publish`, and remove/revoke the bootstrap
-token.
+After the package exists, configure trusted publishing for the exact
+`IvoryHeart/herdr-world` repository and exact workflow filename `release.yml`,
+allow direct `npm publish`, and remove/revoke the bootstrap token.
 
 Prerelease application versions should use the `next` dist-tag. Stable
 versions should use `latest`. The `@ivoryheart` scope must be owned before
@@ -246,9 +245,11 @@ that pull request. CI must not merge it or upload a separate Homebrew binary.
 Opening the pull request needs only a fine-grained credential restricted to the
 `IvoryHeart/homebrew-tap` repository with the contents and pull-request
 permissions required to create the branch and pull request. It should be held
-as a GitHub Actions secret and must not grant access to other repositories or
-merge the tap change. No bot service, GitHub App deployment, state database, or
-broader cross-repository credential is required.
+as a GitHub Actions secret and must not grant access to other repositories. The
+workflow should only create the branch and pull request and must never invoke
+merge; a maintainer reviews and merges the tap change. No bot service, GitHub
+App deployment, state database, or broader cross-repository credential is
+required.
 
 MacOS signing, notarization, and applicable Gatekeeper checks are a separate
 stable-release readiness policy. Local Cask implementation and validation may
@@ -312,7 +313,8 @@ separate explicit contract for paths, versions, asset pairing, and ownership.
 - run the existing live smoke against stock Herdr;
 - verify arguments, stdio, signals, and child exit status;
 - publish the exact tested and hashed tarball from CI under the intended tag;
-- verify the bootstrap public-access token path and its removal/revocation;
+- verify the bootstrap public-access token path with `--provenance`,
+  `contents: read`, and `id-token: write`, then verify its removal/revocation;
 - verify later trusted publishing with GitHub OIDC, `id-token: write`,
   `contents: read`, and automatic provenance.
 

--- a/docs/analysis/npm-homebrew-distribution-analysis-2026-08-28.md
+++ b/docs/analysis/npm-homebrew-distribution-analysis-2026-08-28.md
@@ -15,7 +15,7 @@ binary-first Homebrew Cask:
 
 1. `@ivoryheart/herdr-world` contains the Node entrypoint, the shared
    launcher/web/documentation/legal payload, and all three native bridges.
-2. `IvoryHeart/homebrew-tap` contains one manually prepared, reviewed Cask
+2. `IvoryHeart/homebrew-tap` contains one CI-prepared, maintainer-reviewed Cask
    that selects an existing immutable GitHub release archive.
 
 The existing verified desktop archives remain the only native source. Package
@@ -151,14 +151,31 @@ exactly at, and above the floor.
 
 ### npm publication
 
-The first release path should be manual and deliberately boring:
+The normal release path should run in CI only for an intentional final version
+tag or published release, never for an ordinary branch or pull request. The
+job should consume the final verified release outputs, generate the universal
+package, run `npm pack`, inspect and hash the exact `.tgz`, install-test that
+same file on all three supported targets, and publish that exact file:
 
-1. build a clean package directory from the final verified release outputs;
-2. run `npm pack`;
-3. inspect the exact `.tgz` file list and manifest;
-4. install-test that exact `.tgz` on all three supported targets;
-5. record its SHA-256; and
-6. publish the same `.tgz` with standard npm authentication.
+```bash
+npm publish <tested-package.tgz> --tag <next-or-latest>
+```
+
+The first publication still needs a bootstrap credential because npm trusted
+publishing cannot be configured until the package exists. It should run in the
+same GitHub-hosted CI job with a temporary or granular npm publish token stored
+as a GitHub Actions secret, and it should publish the first real prerelease
+with explicit public access:
+
+```bash
+npm publish <tested-package.tgz> --access public --tag next
+```
+
+Where supported by the selected npm CLI, the bootstrap job should enable npm
+provenance. After the package exists, configure trusted publishing for the
+exact `IvoryHeart/herdr-world` repository and exact workflow filename
+`release.yml`, allow direct `npm publish`, and remove/revoke the bootstrap
+token.
 
 Prerelease application versions should use the `next` dist-tag. Stable
 versions should use `latest`. The `@ivoryheart` scope must be owned before
@@ -168,11 +185,14 @@ placeholder.
 
 npm name/version contents are immutable. If the wrong bytes are published, that
 version cannot be repaired in place; a later application version is required.
-No custom publication state model or staged-publishing workflow is needed for
-the initial package.
+Before retrying a failed publication, CI should check npm; if the version is
+already live, it should not attempt to replace it. No custom publication state
+model, staged-publishing workflow, or separate publishing service is needed.
 
-OIDC and CI publication automation can be evaluated later as ordinary release
-hardening after the manual path has worked.
+Subsequent publication should use npm trusted publishing from a GitHub-hosted
+runner with Node 22.14.0 or newer, npm 11.5.1 or newer, `id-token: write`, and
+`contents: read`. npm automatically generates provenance for trusted GitHub
+publishing, and no long-lived npm publishing token is needed.
 
 ## Homebrew distribution
 
@@ -216,11 +236,19 @@ channel.
 
 ### Tap update and signing readiness
 
-After the complete GitHub release asset set is available, a maintainer should
-prepare a reviewed tap pull request that changes the Cask version, three
-versioned archive URLs, three checksums, and any necessary Cask metadata. The
-maintainer should run Cask audit/style and install checks on every available
-supported target. The tap should be identified as third-party.
+For an eligible stable release, after the complete GitHub release asset set
+and signing readiness gate are satisfied, CI should read the final version,
+three archive URLs, and three checksums; generate the small Cask metadata
+change; open a pull request in `IvoryHeart/homebrew-tap`; and run Cask
+audit/style and available installation checks. A maintainer reviews and merges
+that pull request. CI must not merge it or upload a separate Homebrew binary.
+
+Opening the pull request needs only a fine-grained credential restricted to the
+`IvoryHeart/homebrew-tap` repository with the contents and pull-request
+permissions required to create the branch and pull request. It should be held
+as a GitHub Actions secret and must not grant access to other repositories or
+merge the tap change. No bot service, GitHub App deployment, state database, or
+broader cross-repository credential is required.
 
 MacOS signing, notarization, and applicable Gatekeeper checks are a separate
 stable-release readiness policy. Local Cask implementation and validation may
@@ -236,10 +264,11 @@ The release sequence should be:
 2. run existing archive verification and the stock-Herdr live smoke;
 3. generate the universal npm directory from those verified outputs;
 4. pack, inspect, install-test, and hash the exact npm `.tgz`;
-5. manually publish the exact npm archive under `next` or `latest`;
-6. prepare the reviewed tap change from the immutable release URLs and
-   checksums after signing readiness; and
-7. run Cask audit/style and installation checks.
+5. publish the exact npm archive from tag/release CI under `next` or `latest`;
+6. for an eligible stable release, have CI prepare the reviewed tap change
+   from the immutable release URLs and checksums after signing readiness; and
+7. run Cask audit/style and installation checks, leaving tap merge to a
+   maintainer.
 
 The desktop archives and Android package remain unchanged. A failed validation
 stops publication. A publication retry must first check the external registry;
@@ -263,6 +292,8 @@ separate explicit contract for paths, versions, asset pairing, and ownership.
 | Legal file is omitted | Preserve and validate the complete package legal closure |
 | Cask direct binary path does not survive Caskroom relinking | Test lifecycle; defer a wrapper until direct failure is demonstrated |
 | Third-party tap code is trusted too broadly | Use a fully qualified command and review the tap change |
+| CI publishes a wrong or unintended npm version | Gate publication on an intentional final tag/release, publish the inspected `.tgz`, and check npm before retry |
+| CI can modify the tap too broadly | Store a fine-grained tap-only contents/pull-request credential and leave merge to a maintainer |
 | Plugin and standalone distribution ownership becomes coupled | Keep the one-sentence Spec 016 boundary |
 
 ## Focused validation matrix
@@ -279,8 +310,11 @@ separate explicit contract for paths, versions, asset pairing, and ownership.
   glibc below 2.34 errors;
 - run `herdr-world --help` without Herdr, a workspace, or a bridge;
 - run the existing live smoke against stock Herdr;
-- verify arguments, stdio, signals, and child exit status; and
-- manually publish the exact tested and hashed tarball under the intended tag.
+- verify arguments, stdio, signals, and child exit status;
+- publish the exact tested and hashed tarball from CI under the intended tag;
+- verify the bootstrap public-access token path and its removal/revocation;
+- verify later trusted publishing with GitHub OIDC, `id-token: write`,
+  `contents: read`, and automatic provenance.
 
 ### Homebrew
 
@@ -306,12 +340,13 @@ separate explicit contract for paths, versions, asset pairing, and ownership.
 2. Copy all bridges from the corresponding verified archives into fixed
    target-specific paths.
 3. Use Node 22.14.0 or newer and a fixed Linux glibc 2.34 preflight.
-4. Publish the exact manually tested npm `.tgz`; use `next` for prereleases
-   and `latest` for stable releases.
+4. Publish the exact tested npm `.tgz` from CI; use `next` for prereleases and
+   `latest` for stable releases. Bootstrap uses a temporary/granular token,
+   then later releases use trusted publishing with GitHub OIDC.
 5. Use a direct-archive stable Cask in the public third-party tap
-   `IvoryHeart/homebrew-tap`, with a manual reviewed tap change.
-6. Keep OIDC/CI npm automation, platform npm splits, Cask wrappers, formulas,
-   extra targets, and plugin package-manager reuse deferred.
+   `IvoryHeart/homebrew-tap`, with a CI-prepared, maintainer-reviewed tap change.
+6. Keep staged publishing, platform npm splits, Cask wrappers, formulas, extra
+   targets, and plugin package-manager reuse deferred.
 
 ## Sources
 
@@ -335,6 +370,13 @@ separate explicit contract for paths, versions, asset pairing, and ownership.
 - [npm scoped public packages](https://docs.npmjs.com/creating-and-publishing-scoped-public-packages/)
 - [npm distribution tags](https://docs.npmjs.com/cli/v11/commands/npm-dist-tag/)
 - [npm trusted publishers](https://docs.npmjs.com/trusted-publishers/)
+- [npm provenance](https://docs.npmjs.com/generating-provenance-statements/)
+
+### GitHub Actions
+
+- [OpenID Connect reference](https://docs.github.com/en/actions/reference/security/oidc)
+- [Workflow syntax and tag filters](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax)
+- [Fine-grained token permissions](https://docs.github.com/en/rest/authentication/permissions-required-for-fine-grained-personal-access-tokens)
 
 ### Homebrew
 

--- a/docs/analysis/npm-homebrew-distribution-analysis-2026-08-28.md
+++ b/docs/analysis/npm-homebrew-distribution-analysis-2026-08-28.md
@@ -3,360 +3,126 @@
 - **Date:** 2026-08-28
 - **Status:** Research complete; implementation not started
 - **Repository:** `IvoryHeart/herdr-world`
-- **Current application release:** `v0.1.0-rc.1`
-- **Current desktop artifacts:** Linux x86-64, macOS ARM64, and macOS x86-64
 - **Related specification:** [Spec 017](../specs/017-herdr-world-npm-homebrew-distribution-spec.md)
 - **Related research:** [Herdr plugin release analysis](herdr-plugin-release-analysis-2026-08-26.md)
 
-## Executive conclusion
+## Conclusion
 
-The smallest useful distribution is one public universal npm package and one
-binary-first Homebrew Cask:
+The right release model is one release pipeline with small channel adapters. A
+final tag produces and validates the native archives once, then supplies the
+same release version and verified release record to npm, Homebrew, and future
+distribution channels. Package-manager channels reuse the native outputs; the
+Herdr plugin remains governed by Spec 016 and its source-build contract.
 
-1. `@ivoryheart/herdr-world` contains the Node entrypoint, the shared
-   launcher/web/documentation/legal payload, and all three native bridges.
-2. `IvoryHeart/homebrew-tap` contains one CI-written Cask update that selects
-   an existing immutable GitHub release archive.
+The current `v0.1.0-rc.1` release is useful as an installation test fixture. It
+must not become a special case or a version assumption in future release work.
 
-The existing verified desktop archives remain the only native source. Package
-generation should re-layout those outputs, not compile a second bridge or
-download release assets during installation. A universal npm package avoids a
-four-package publication graph and is adequate while the current release
-artifacts remain small. A later platform split should require measured evidence.
+The initial package-manager channels are:
 
-This distribution remains independent from the Herdr plugin. It should not
-make plugin installation depend on npm or Homebrew, and it should not transfer
-plugin-managed lifecycle ownership to a package manager.
+1. one universal public npm package, `@ivoryheart/herdr-world`, containing the
+   shared payload and all three desktop bridges; and
+2. one stable-only direct-archive Cask in the public third-party tap
+   `IvoryHeart/homebrew-tap`.
 
-## Repository and release baseline
+## Findings
 
-The repository is not currently a public npm application package:
+The repository already produces desktop archives with the native bridge, web
+assets, launcher, documentation, and legal material. Those verified archives
+should remain the only native source. Rebuilding a bridge for npm or Homebrew
+would create drift and another release path.
 
-- the root `package.json` is private and has version `0.0.0`;
-- `web/package.json` is a private frontend development manifest;
-- root dependencies include development and Android tooling; and
-- application versions are tracked in `release.json`, documentation, and tags.
+The universal npm package is the smallest initial topology. It avoids a
+platform-package graph while retaining one command and one version. The Cask
+can use the existing immutable archives directly; it does not need a second
+Homebrew binary or a source build.
 
-The existing `scripts/package-tarball.sh` produces platform archives with this
-shape:
+The exact supported targets and runtime checks belong in the existing packaging
+and release documentation. They should be tested by the release pipeline, but
+they should not turn this distribution contract into a copy of every launcher,
+libc, or workflow detail.
 
-```text
-herdr-world-vX.Y.Z-PLATFORM/
-  bin/herdr-world
-  bin/herdr-world-bridge
-  share/herdr-world/web/
-  third_party/
-  docs/
-  LICENSE
-  THIRD_PARTY_NOTICES.md
-  UPSTREAM.md
-  README.md
-```
+## Recommended release flow
 
-The archives are already the right source boundary. They contain the bridge,
-web application, launcher, documentation, and legal assets, and the existing
-verifier checks checksums, archive safety, native format, required files, legal
-manifest closure, launcher help, and a no-session failure path.
+For every intentional final tag:
 
-The current archive sizes are approximately 6.2–6.6 MiB. A universal npm
-package will be larger because it carries three bridges, but it avoids
-duplicated package metadata, publication sequencing, optional dependency
-selection, and platform-package failure modes. Measure the packed size during
-implementation. Split the native payload only if that measurement or an npm
-limit makes the universal package impractical.
+1. build all native archives;
+2. verify contents, legal closure, formats, checksums, and live smoke;
+3. expose the verified outputs to the release adapters;
+4. generate, inspect, install-test, hash, and publish the exact npm package;
+5. for a stable release, generate, validate, and write the Cask update to the
+   third-party tap; and
+6. run any future adapters against the same version and outputs.
 
-The support matrix is:
+Prereleases use the npm prerelease channel and leave the stable Cask unchanged.
+Stable releases use the stable npm channel and update the ordinary Cask.
+Branches and pull requests never publish.
 
-| Target | Existing archive | npm bridge path | Cask archive |
-| --- | --- | --- | --- |
-| Linux x86-64, glibc 2.34+ | `linux-x86_64` | `native/linux-x64/herdr-world-bridge` | Linux archive |
-| macOS ARM64 | `macos-arm64` | `native/darwin-arm64/herdr-world-bridge` | ARM64 archive |
-| macOS x86-64 | `macos-x86_64` | `native/darwin-x64/herdr-world-bridge` | Intel archive |
+The release tag is the version source. No future release should require editing
+the same fixed version in multiple manifests or repeating a special bootstrap
+procedure. Publication credentials and npm scope/tap ownership are setup
+prerequisites; they should not create per-release manual work.
 
-Linux ARM64, musl Linux, Windows, and Android remain outside this distribution
-scope.
+Retries are deliberately simple. An adapter may check whether the exact version
+and contents are already present and no-op. Published bytes are immutable; a
+wrong publication uses a new release version. No publication database, staged
+workflow, or recovery service is needed for the initial design.
 
-The current `v0.1.0-rc.1` Linux bridge requires symbols through
-`GLIBC_2.34`. The initial Linux runtime contract is therefore glibc 2.34 or
-newer unless a separate build effort establishes a lower baseline. npm's
-`libc` metadata cannot express a version, and the universal package has no
-useful platform selector, so the launcher must perform the runtime check.
+## Channel contracts
 
-## npm distribution
+### npm
 
-### Universal package
+The package contains the shared launcher behavior, web assets, documentation,
+legal assets, and all three native bridges. It exposes only `herdr-world`,
+selects the bridge for the supported host, and never downloads or builds a
+bridge during installation.
 
-The proposed package is:
+The package is packed and tested before publication, and the published tarball
+is the tested tarball. The public package version comes from the final release
+tag. Platform-specific npm packages remain deferred until measured evidence
+shows the universal package is impractical.
 
-```text
-@ivoryheart/herdr-world
-```
+### Homebrew
 
-It should be a normal public scoped package with one `herdr-world` command.
-Its manifest should derive the version from `release.json` by removing only
-the leading `v`, declare Node `>=22.14.0`, use the exact repository URL
-`https://github.com/IvoryHeart/herdr-world`, set public scoped-package
-publication access, and use an explicit `files` allowlist.
+The Cask is stable-only and references the immutable GitHub release archives and
+checksums for the existing supported desktop targets. CI generates, validates,
+and writes the small Cask metadata update to `IvoryHeart/homebrew-tap` after the
+release gates pass. There is no separate binary upload, installer daemon,
+workspace mutation, or moving `latest` URL.
 
-The package should contain:
+The tap is third-party and must not be described as reviewed or endorsed by
+Homebrew. A source formula, binary formula, or separately named prerelease Cask
+is deferred.
 
-- the Node entrypoint;
-- the existing shared launcher behavior;
-- `share/herdr-world/web/**`;
-- documentation and the complete legal closure;
-- `native/linux-x64/herdr-world-bridge`;
-- `native/darwin-arm64/herdr-world-bridge`; and
-- `native/darwin-x64/herdr-world-bridge`.
+### Future channels and plugin boundary
 
-It should not contain the root or web development manifests, source-only
-dependencies, tests, CI files, Android output, or an arbitrary
-`node_modules` tree. It should not use `preinstall` or `postinstall` to
-download an archive or run Herdr.
+A future distribution channel should consume the same release version and
+verified release record through one adapter, reusing the artifact set where its
+own contract permits. It should add its credentials, metadata, validation, and
+publication step without changing native archive production or existing
+channels.
 
-Each bridge is copied from the matching verified desktop archive. The package
-should preserve the existing notices, license files, upstream record, bundled
-web legal files, `docs/world-assets.md`, `third_party/**`, and
-`vendor/herdr-compat/VENDOR-MANIFEST.toml`. The legal manifest must be closed
-within the package.
-
-### Entrypoint behavior
-
-The Node entrypoint should use `process.platform`, `process.arch`, and Linux
-libc detection to select exactly one of the three fixed paths. It should
-resolve paths from its installed package location, never from the current
-working directory, a guessed npm prefix, `PATH`, or a public environment
-override.
-
-It should invoke the shared launcher behavior with the selected bridge and
-static web directory as package-internal paths. This keeps the public contract
-small while retaining the existing runtime behavior. It must preserve
-arguments, standard streams, relevant signals, and child exit status.
-
-Unsupported OS/CPU/libc combinations and missing or damaged bridge files
-should fail before execution with an actionable message. `herdr-world --help`
-should print usage and exit successfully without requiring Herdr, a workspace,
-or a bridge process.
-
-### Linux compatibility
-
-Release validation should extract the maximum GLIBC symbol version from the
-exact Linux bridge copied from the verified archive and fail if it exceeds
-2.34. The extracted value and bridge digest should be retained as release
-evidence.
-
-At runtime, the launcher should report required 2.34 and detected glibc when
-the host is below the floor. It should identify musl and unknown libc clearly,
-and reject Linux ARM64 before native execution. Tests should cover below,
-exactly at, and above the floor.
-
-### npm publication
-
-The normal release path should run in CI only for an intentional final version
-tag or published release, never for an ordinary branch or pull request. The
-job should consume the final verified release outputs, generate the universal
-package, run `npm pack`, inspect and hash the exact `.tgz`, install-test that
-same file on all three supported targets, and publish that exact file:
-
-```bash
-npm publish <tested-package.tgz> --tag <next-or-latest>
-```
-
-The first publication still needs a bootstrap credential because npm trusted
-publishing cannot be configured until the package exists. It should run in the
-same GitHub-hosted CI job with a temporary or granular npm publish token stored
-as a GitHub Actions secret. The bootstrap job should grant `contents: read` and
-`id-token: write`, use Node 22.14.0+ and npm 11.5.1+, and publish the first real
-prerelease with npm provenance and explicit public access:
-
-```bash
-npm publish <tested-package.tgz> --provenance --access public --tag next
-```
-
-After the package exists, configure trusted publishing for the exact
-`IvoryHeart/herdr-world` repository and exact workflow filename `release.yml`,
-allow direct `npm publish`, and remove/revoke the bootstrap token.
-
-Prerelease application versions should use the `next` dist-tag. Stable
-versions should use `latest`. The `@ivoryheart` scope must be owned before
-publication, and npm has no ordinary placeholder reservation process, so the
-first publication should be the first real package release rather than a
-placeholder.
-
-npm name/version contents are immutable. If the wrong bytes are published, that
-version cannot be repaired in place; a later application version is required.
-Before retrying a failed publication, CI should check npm; if the version is
-already live, it should not attempt to replace it. No custom publication state
-model, staged-publishing workflow, or separate publishing service is needed.
-
-Subsequent publication should use npm trusted publishing from a GitHub-hosted
-runner with Node 22.14.0 or newer, npm 11.5.1 or newer, `id-token: write`, and
-`contents: read`. npm automatically generates provenance for trusted GitHub
-publishing, and no long-lived npm publishing token is needed.
-
-## Homebrew distribution
-
-### Cask choice
-
-A Cask is the appropriate initial Homebrew type because the project already
-publishes platform-specific binary archives. A source-building formula would
-create a second build system and is not justified by the current goal. A binary
-formula is also deferred.
-
-The public command should be:
-
-```bash
-brew install --cask IvoryHeart/tap/herdr-world
-```
-
-This is a third-party tap command, not a Homebrew endorsement or official
-Homebrew package.
-
-### Direct Cask shape
-
-The Cask should use the existing immutable GitHub release archives, select the
-URL and SHA-256 by target, and support only macOS ARM64, macOS x86-64, and
-Linux x86-64. It should expose the archive's existing `bin/herdr-world`
-through the normal Cask `binary` mechanism. The bridge must not become a
-second command.
-
-The first implementation should not add a Cask wrapper, path environment
-contract, downloader, daemon, or service supervisor. The direct `binary`
-mapping must be tested after install, upgrade, reinstall, and removal of an
-older version. If direct mapping demonstrably fails because of Caskroom path
-resolution, use the smallest validated path adaptation and update the
-specification only if the public contract changes. It is not a reason to add
-an unreviewed wrapper now.
-
-Installation should only unpack and link files. It must not start Herdr or the
-bridge, create or modify a workspace, or weaken the existing bridge security
-defaults. The stable Cask should never use a moving `latest` URL. A
-prerelease Cask, if ever needed, should have a separate name and documented
-channel.
-
-### Tap update and signing readiness
-
-For an eligible stable release, after the complete GitHub release asset set
-and signing readiness gate are satisfied, CI should read the final version,
-three archive URLs, and three checksums; generate and validate the small Cask
-metadata change; and directly commit that change to
-`IvoryHeart/homebrew-tap` as part of the same release. The commit should update
-only the Cask version, URLs, and checksums. There is no separate Homebrew
-binary upload. A prerelease publishes npm under `next` and does not update the
-stable Cask.
-
-The cross-repository credential should be a fine-grained credential restricted
-to the `IvoryHeart/homebrew-tap` repository with only the `Contents: write`
-repository permission. It should be held as a GitHub Actions secret and must
-not grant access to other repositories; no pull-request permission is needed.
-No bot service, GitHub App deployment, state database, or broader
-cross-repository credential is required.
-
-If the stable tap update is retried, CI should compare the tap's current Cask
-version and three SHA-256 values with the intended release and no-op when they
-are already current.
-
-MacOS signing, notarization, and applicable Gatekeeper checks are a separate
-stable-release readiness policy. Local Cask implementation and validation may
-use release-candidate fixtures; the ordinary stable Cask should not be
-published until that policy gate passes. The gate does not determine whether
-the distribution uses a Cask or a universal npm package.
-
-## Release architecture
-
-The release sequence should be:
-
-1. build all three native archives from the final tag;
-2. run existing archive verification and the stock-Herdr live smoke;
-3. generate the universal npm directory from those verified outputs;
-4. pack, inspect, install-test, and hash the exact npm `.tgz`;
-5. for a prerelease, publish the exact npm archive from tag/release CI under
-   `next` and do not update the stable Cask; or
-6. for an eligible stable release, after the complete assets and signing
-   readiness gate, publish npm under `latest`, validate the generated Cask
-   change, and directly commit it to the tap.
-
-The desktop archives and Android package remain unchanged. A failed validation
-stops publication. A publication retry must first check the external registry;
-published npm bytes must never be silently replaced. A tap retry must compare
-the current Cask version and checksums and no-op when already current.
-
-## Relationship to Spec 016
-
-Spec 016 remains source-build-only and owns the plugin's bridge and lifecycle.
-Installing npm or Homebrew must not change plugin ownership or lifecycle.
-Any future plugin use of an external package-manager installation needs a
-separate explicit contract for paths, versions, asset pairing, and ownership.
+Spec 016 remains source-build-only and owns plugin lifecycle. The plugin does
+not discover npm or Homebrew installations implicitly. Any external-installation
+mode needs an explicit plugin contract covering paths, versions, pairing, and
+ownership.
 
 ## Risks and mitigations
 
 | Risk | Mitigation |
 | --- | --- |
-| Universal npm package grows as more targets are added | Measure packed size; split only with evidence |
-| npm package is installed on unsupported host | Runtime OS/CPU/libc selection and actionable rejection |
-| Linux binary needs newer glibc | Release symbol extraction and runtime 2.34 preflight |
-| Package files drift from verified archives | Generate only from final archives and inspect the exact `.tgz` |
-| Legal file is omitted | Preserve and validate the complete package legal closure |
-| Cask direct binary path does not survive Caskroom relinking | Test lifecycle; defer a wrapper until direct failure is demonstrated |
-| Third-party tap code is trusted too broadly | Use a fully qualified command and restrict CI writes to the intended Cask change |
-| CI publishes a wrong or unintended npm version | Gate publication on an intentional final tag/release, publish the inspected `.tgz`, and check npm before retry |
-| CI can modify the tap too broadly | Store a fine-grained tap-only credential with only `Contents: write`; write only the intended Cask change and no-op when current |
-| Plugin and standalone distribution ownership becomes coupled | Keep the one-sentence Spec 016 boundary |
+| A channel builds different native bytes | Require every adapter to consume verified release outputs |
+| A release version drifts between channels | Derive every channel version from the final tag |
+| A failed retry overwrites immutable content | Check the channel before retry; no-op when exact, use a new version when different |
+| A future channel expands release complexity | Require a small adapter with the same release inputs |
+| Package installation changes runtime state | Test no downloader, daemon, workspace mutation, or Herdr startup |
 
-## Focused validation matrix
+## Deferred decisions
 
-### npm
-
-- assert the exact allowlisted package files, including all three fixed bridge
-  paths and legal closure;
-- assert public metadata, exact repository, version derivation, Node floor, and
-  only the `herdr-world` command;
-- run `npm pack`, inspect the exact tarball, install it on all three targets,
-  and verify the matching bridge is selected;
-- verify unsupported OS, CPU, musl, unknown libc, missing bridge, and Linux
-  glibc below 2.34 errors;
-- run `herdr-world --help` without Herdr, a workspace, or a bridge;
-- run the existing live smoke against stock Herdr;
-- verify arguments, stdio, signals, and child exit status;
-- publish the exact tested and hashed tarball from CI under the intended tag;
-- verify the bootstrap public-access token path with `--provenance`,
-  `contents: read`, and `id-token: write`, then verify its removal/revocation;
-- verify later trusted publishing with GitHub OIDC, `id-token: write`,
-  `contents: read`, and automatic provenance.
-
-### Homebrew
-
-- audit/style the Cask;
-- verify immutable versioned URLs and checksums for all three targets;
-- install, upgrade, reinstall, directly invoke, and uninstall the Cask on each
-  available supported target;
-- verify only `herdr-world` is exposed and no installation step starts a
-  process or mutates a workspace; and
-- block stable publication until the separate signing/readiness policy passes.
-- validate and directly commit only the generated stable Cask update to the tap;
-- verify prereleases leave the stable Cask unchanged.
-
-### Unchanged behavior
-
-- existing desktop archive verification and launcher behavior remain intact;
-- Android packaging and client behavior remain intact; and
-- Spec 016 plugin installation, ownership, source-build behavior, and lifecycle
-  remain intact.
-
-## Decisions for Spec 017
-
-1. Use one public universal npm package:
-   `@ivoryheart/herdr-world`.
-2. Copy all bridges from the corresponding verified archives into fixed
-   target-specific paths.
-3. Use Node 22.14.0 or newer and a fixed Linux glibc 2.34 preflight.
-4. Publish the exact tested npm `.tgz` from CI; use `next` for prereleases and
-   `latest` for stable releases. Bootstrap uses a temporary/granular token,
-   then later releases use trusted publishing with GitHub OIDC.
-5. Use a direct-archive stable Cask in the public third-party tap
-   `IvoryHeart/homebrew-tap`, with a CI-validated, directly committed Cask
-   change only for eligible stable releases.
-6. Keep staged publishing, platform npm splits, Cask wrappers, formulas, extra
-   targets, and plugin package-manager reuse deferred.
+- platform-specific npm packages;
+- staged publication and publication state tracking;
+- source-building Homebrew formulas;
+- unsupported targets such as Linux ARM64, musl Linux, and Windows; and
+- plugin reuse of external package-manager installations.
 
 ## Sources
 
@@ -364,33 +130,14 @@ separate explicit contract for paths, versions, asset pairing, and ownership.
 
 - [README](../../README.md)
 - [Web README](../../web/README.md)
-- [Packaging documentation](../packaging.md)
-- [Release documentation](../release.md)
+- [Packaging](../packaging.md)
+- [Release](../release.md)
 - [Spec 016](../specs/016-herdr-world-plugin-release-spec.md)
-- [Plugin release analysis](herdr-plugin-release-analysis-2026-08-26.md)
-- [Tarball packaging script](../../scripts/package-tarball.sh)
-- [Shared launcher](../../scripts/herdr-world-launcher.sh)
-- [Desktop package verifier](../../scripts/verify-desktop-package.sh)
-- [Release workflow](../../.github/workflows/release.yml)
 
-### npm
+### npm and Homebrew
 
-- [npm package.json fields](https://docs.npmjs.com/cli/v11/configuring-npm/package-json)
+- [npm package.json](https://docs.npmjs.com/cli/v11/configuring-npm/package-json)
 - [npm publish](https://docs.npmjs.com/cli/v11/commands/npm-publish/)
-- [npm scoped public packages](https://docs.npmjs.com/creating-and-publishing-scoped-public-packages/)
-- [npm distribution tags](https://docs.npmjs.com/cli/v11/commands/npm-dist-tag/)
 - [npm trusted publishers](https://docs.npmjs.com/trusted-publishers/)
-- [npm provenance](https://docs.npmjs.com/generating-provenance-statements/)
-
-### GitHub Actions
-
-- [OpenID Connect reference](https://docs.github.com/en/actions/reference/security/oidc)
-- [Workflow syntax and tag filters](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax)
-- [Fine-grained token permissions](https://docs.github.com/en/rest/authentication/permissions-required-for-fine-grained-personal-access-tokens)
-
-### Homebrew
-
 - [Homebrew Cask Cookbook](https://docs.brew.sh/Cask-Cookbook)
 - [Homebrew taps](https://docs.brew.sh/Taps)
-- [Homebrew acceptable Casks](https://docs.brew.sh/Acceptable-Casks)
-- [Homebrew Tap Trust](https://docs.brew.sh/Tap-Trust)

--- a/docs/analysis/npm-homebrew-distribution-analysis-2026-08-28.md
+++ b/docs/analysis/npm-homebrew-distribution-analysis-2026-08-28.md
@@ -15,8 +15,8 @@ binary-first Homebrew Cask:
 
 1. `@ivoryheart/herdr-world` contains the Node entrypoint, the shared
    launcher/web/documentation/legal payload, and all three native bridges.
-2. `IvoryHeart/homebrew-tap` contains one CI-prepared, maintainer-reviewed Cask
-   that selects an existing immutable GitHub release archive.
+2. `IvoryHeart/homebrew-tap` contains one CI-written Cask update that selects
+   an existing immutable GitHub release archive.
 
 The existing verified desktop archives remain the only native source. Package
 generation should re-layout those outputs, not compile a second bridge or
@@ -237,19 +237,23 @@ channel.
 
 For an eligible stable release, after the complete GitHub release asset set
 and signing readiness gate are satisfied, CI should read the final version,
-three archive URLs, and three checksums; generate the small Cask metadata
-change; open a pull request in `IvoryHeart/homebrew-tap`; and run Cask
-audit/style and available installation checks. A maintainer reviews and merges
-that pull request. CI must not merge it or upload a separate Homebrew binary.
+three archive URLs, and three checksums; generate and validate the small Cask
+metadata change; and directly commit that change to
+`IvoryHeart/homebrew-tap` as part of the same release. The commit should update
+only the Cask version, URLs, and checksums. There is no separate Homebrew
+binary upload. A prerelease publishes npm under `next` and does not update the
+stable Cask.
 
-Opening the pull request needs only a fine-grained credential restricted to the
-`IvoryHeart/homebrew-tap` repository with the contents and pull-request
-permissions required to create the branch and pull request. It should be held
-as a GitHub Actions secret and must not grant access to other repositories. The
-workflow should only create the branch and pull request and must never invoke
-merge; a maintainer reviews and merges the tap change. No bot service, GitHub
-App deployment, state database, or broader cross-repository credential is
-required.
+The cross-repository credential should be a fine-grained credential restricted
+to the `IvoryHeart/homebrew-tap` repository with only the `Contents: write`
+repository permission. It should be held as a GitHub Actions secret and must
+not grant access to other repositories; no pull-request permission is needed.
+No bot service, GitHub App deployment, state database, or broader
+cross-repository credential is required.
+
+If the stable tap update is retried, CI should compare the tap's current Cask
+version and three SHA-256 values with the intended release and no-op when they
+are already current.
 
 MacOS signing, notarization, and applicable Gatekeeper checks are a separate
 stable-release readiness policy. Local Cask implementation and validation may
@@ -265,15 +269,16 @@ The release sequence should be:
 2. run existing archive verification and the stock-Herdr live smoke;
 3. generate the universal npm directory from those verified outputs;
 4. pack, inspect, install-test, and hash the exact npm `.tgz`;
-5. publish the exact npm archive from tag/release CI under `next` or `latest`;
-6. for an eligible stable release, have CI prepare the reviewed tap change
-   from the immutable release URLs and checksums after signing readiness; and
-7. run Cask audit/style and installation checks, leaving tap merge to a
-   maintainer.
+5. for a prerelease, publish the exact npm archive from tag/release CI under
+   `next` and do not update the stable Cask; or
+6. for an eligible stable release, after the complete assets and signing
+   readiness gate, publish npm under `latest`, validate the generated Cask
+   change, and directly commit it to the tap.
 
 The desktop archives and Android package remain unchanged. A failed validation
 stops publication. A publication retry must first check the external registry;
-published npm bytes must never be silently replaced.
+published npm bytes must never be silently replaced. A tap retry must compare
+the current Cask version and checksums and no-op when already current.
 
 ## Relationship to Spec 016
 
@@ -292,9 +297,9 @@ separate explicit contract for paths, versions, asset pairing, and ownership.
 | Package files drift from verified archives | Generate only from final archives and inspect the exact `.tgz` |
 | Legal file is omitted | Preserve and validate the complete package legal closure |
 | Cask direct binary path does not survive Caskroom relinking | Test lifecycle; defer a wrapper until direct failure is demonstrated |
-| Third-party tap code is trusted too broadly | Use a fully qualified command and review the tap change |
+| Third-party tap code is trusted too broadly | Use a fully qualified command and restrict CI writes to the intended Cask change |
 | CI publishes a wrong or unintended npm version | Gate publication on an intentional final tag/release, publish the inspected `.tgz`, and check npm before retry |
-| CI can modify the tap too broadly | Store a fine-grained tap-only contents/pull-request credential and leave merge to a maintainer |
+| CI can modify the tap too broadly | Store a fine-grained tap-only credential with only `Contents: write`; write only the intended Cask change and no-op when current |
 | Plugin and standalone distribution ownership becomes coupled | Keep the one-sentence Spec 016 boundary |
 
 ## Focused validation matrix
@@ -327,6 +332,8 @@ separate explicit contract for paths, versions, asset pairing, and ownership.
 - verify only `herdr-world` is exposed and no installation step starts a
   process or mutates a workspace; and
 - block stable publication until the separate signing/readiness policy passes.
+- validate and directly commit only the generated stable Cask update to the tap;
+- verify prereleases leave the stable Cask unchanged.
 
 ### Unchanged behavior
 
@@ -346,7 +353,8 @@ separate explicit contract for paths, versions, asset pairing, and ownership.
    `latest` for stable releases. Bootstrap uses a temporary/granular token,
    then later releases use trusted publishing with GitHub OIDC.
 5. Use a direct-archive stable Cask in the public third-party tap
-   `IvoryHeart/homebrew-tap`, with a CI-prepared, maintainer-reviewed tap change.
+   `IvoryHeart/homebrew-tap`, with a CI-validated, directly committed Cask
+   change only for eligible stable releases.
 6. Keep staged publishing, platform npm splits, Cask wrappers, formulas, extra
    targets, and plugin package-manager reuse deferred.
 

--- a/docs/specs/017-herdr-world-npm-homebrew-distribution-spec.md
+++ b/docs/specs/017-herdr-world-npm-homebrew-distribution-spec.md
@@ -285,8 +285,10 @@ SHALL not be presented as reviewed, endorsed, or official Homebrew software.
 The cross-repository credential used to open the pull request SHALL be a
 fine-grained credential restricted to `IvoryHeart/homebrew-tap` with only the
 repository contents and pull-request permissions needed to create the branch
-and pull request. It SHALL be stored as a GitHub Actions secret, SHALL not
-permit tap merging, and SHALL not grant access to other repositories.
+and pull request. It SHALL be stored as a GitHub Actions secret and SHALL not
+grant access to other repositories. The workflow SHALL only create the branch
+and pull request; it SHALL never invoke a merge. A maintainer SHALL review and
+merge the tap pull request.
 
 ### 4.7 npm publication
 
@@ -309,17 +311,18 @@ The publish job SHALL have `contents: read`. Its release condition SHALL be
 bound to an intentional final tag or release event, and SHALL exclude ordinary
 branch and pull-request events.
 
-The first publication SHALL run in this CI job using a temporary or granular
-npm publish token stored as a GitHub Actions secret. It SHALL be the first real
-prerelease and SHALL use explicit public access:
+The first publication SHALL run in this CI job on a GitHub-hosted runner using
+a temporary or granular npm publish token stored as a GitHub Actions secret.
+The bootstrap job SHALL grant `contents: read` and `id-token: write`, and SHALL
+use the supported Node 22.14.0+ and npm 11.5.1+ toolchain. It SHALL be the
+first real prerelease and SHALL enable npm provenance with explicit public
+access:
 
 ```bash
-npm publish <tested-package.tgz> --access public --tag next
+npm publish <tested-package.tgz> --provenance --access public --tag next
 ```
 
-Where the selected npm CLI supports provenance, the bootstrap publication
-SHALL enable npm provenance from the GitHub-hosted workflow. The token SHALL
-be removed from GitHub and revoked after bootstrap.
+The token SHALL be removed from GitHub and revoked after bootstrap.
 
 After the package exists, npm trusted publishing SHALL be configured for the
 exact repository `IvoryHeart/herdr-world` and the exact release workflow
@@ -404,8 +407,9 @@ Implementation SHALL provide the following focused evidence:
 - the exact CI-published `.tgz` is the one install-tested and hashed;
 - npm publication runs only for an intentional final tag or release, never an
   ordinary branch or pull request;
-- bootstrap uses a temporary/granular secret token with public access, then
-  removes and revokes that token;
+- bootstrap uses a temporary/granular secret token with `--provenance`,
+  `--access public`, `contents: read`, and `id-token: write`, then removes and
+  revokes that token;
 - later publication uses GitHub OIDC with `id-token: write`, `contents: read`,
   exact trusted-publisher configuration, and automatic provenance;
 - `next` and `latest` are used only for their intended release classes;

--- a/docs/specs/017-herdr-world-npm-homebrew-distribution-spec.md
+++ b/docs/specs/017-herdr-world-npm-homebrew-distribution-spec.md
@@ -1,4 +1,4 @@
-# Herdr World npm and Homebrew distribution
+# Herdr World distribution release contract
 
 - **Spec ID:** `017-herdr-world-npm-homebrew-distribution`
 - **Status:** Draft
@@ -8,463 +8,158 @@
 - **Approved by:** —
 - **Approved at:** —
 
-This specification is a standalone distribution contract related to, but
-independent from, [Spec 016](016-herdr-world-plugin-release-spec.md). Its
-primary research input is the
-[npm and Homebrew distribution analysis](../analysis/npm-homebrew-distribution-analysis-2026-08-28.md).
-It does not extend the Herdr plugin lifecycle contract.
+This specification defines the npm and Homebrew distribution contract for
+Herdr World. It is related to, but independent from, [Spec 016](016-herdr-world-plugin-release-spec.md).
+It describes the release outcome and boundaries; implementation details belong
+in the packaging and release documentation.
 
-## 1. Purpose and outcome
+## 1. Goal
 
-Herdr World already produces verified desktop archives containing the native
-bridge, web application, launcher, documentation, and legal assets. This
-specification defines the smallest package-manager distribution that reuses
-those release outputs.
+For every final release tag, one release pipeline SHALL build or consume the
+verified release outputs and publish that release to the supported distribution
+channels. The normal path SHALL be the same for `vX.Y.Z`, prereleases, and
+future releases; the current `v0.1.0-rc.1` is only a test fixture, not a
+permanent version or special-case workflow.
 
-The outcome is:
+The initial channels are:
 
-- one public npm package, `@ivoryheart/herdr-world`, containing the Node
-  entrypoint, shared application payload, and all three supported native
-  bridges; and
-- one binary-first Homebrew Cask in the separate public third-party tap
-  `IvoryHeart/homebrew-tap`.
+- the public universal npm package `@ivoryheart/herdr-world`; and
+- the stable third-party Homebrew Cask in `IvoryHeart/homebrew-tap`.
 
-Both distributions SHALL remain separate from Herdr itself. Installation SHALL
-install files only: it SHALL not install Herdr, start Herdr or the bridge,
-create a workspace, or change plugin state.
+The release design SHALL make additional channels an adapter to the same
+release version and verified release record. Where a channel can reuse the
+verified outputs, it SHALL do so rather than creating another native build or
+release procedure.
 
-## 2. Scope and support matrix
+## 2. Scope and boundaries
 
-The supported package-manager targets are:
+The existing verified desktop archives are the native source of truth. The npm
+package SHALL contain the shared application payload, documentation, legal
+material, and all three supported desktop bridges. The Cask SHALL reference the
+immutable desktop archives and their checksums.
 
-| Operating system | CPU | Existing release archive |
-| --- | --- | --- |
-| Linux | x86-64 with glibc 2.34 or newer | `linux-x86_64` |
-| macOS | ARM64 | `macos-arm64` |
-| macOS | x86-64 | `macos-x86_64` |
+Neither channel SHALL build a second native bridge, download release assets at
+install time, start Herdr, create a workspace, or change plugin state. Desktop
+archives and Android packaging remain independent outputs.
 
-Linux ARM64, musl Linux, Windows, Android, and other combinations are outside
-this support promise. The npm entrypoint and Cask SHALL fail clearly for
-unsupported operating systems, architectures, or libc implementations.
+The supported operating systems, architectures, libc baseline, launcher
+behavior, legal closure, and security defaults remain those established by
+[packaging documentation](../packaging.md) and [release documentation](../release.md).
+This specification does not duplicate platform implementation details.
 
-This specification does not implement package generation, npm publication,
-Cask or release-workflow changes, or launcher changes. Those are follow-up
-implementation work.
+Spec 016 remains the owner of plugin installation, plugin-managed lifecycle,
+and source-build behavior. The npm package and Cask SHALL not be discovered or
+used implicitly by the plugin. A future plugin mode that consumes an external
+distribution requires an explicit change to the plugin contract.
 
-## 3. Non-goals
+## 3. Release contract
 
-The following are explicitly deferred:
+The final release tag SHALL be the version source for every channel. A release
+pipeline SHALL:
 
-- optional npm platform packages or a multi-package publication graph;
-- a second native build pipeline or an install-time release downloader;
-- npm publication states, staged publishing, or a publication database;
-- a Cask wrapper, new public path environment contract, or service supervisor;
-- source-building or binary Homebrew formulas;
-- official Homebrew repository submission;
-- a prerelease Homebrew Cask channel;
-- Linux ARM64, musl Linux, Windows, or additional targets;
-- plugin discovery or reuse of npm/Homebrew installations; and
-- changes to desktop tarball layout, Android packaging, or Spec 016.
+1. build the native archives from the final release;
+2. verify archive contents, legal closure, native formats, checksums, and the
+   existing live smoke;
+3. make the verified outputs available to the channel adapters;
+4. publish the npm package and, for an eligible stable release, update the
+   Homebrew Cask from those same outputs; and
+5. invoke any additional enabled distribution adapters using the same release
+   version and verified release record, subject to that channel's owning
+   contract.
 
-A later package split MAY be proposed only after measured packed-size evidence or
-an actual npm distribution limit demonstrates that the universal package is
-impractical.
+The pipeline SHALL run publication only for an intentional release tag or
+release event. Ordinary branches and pull requests SHALL not publish.
 
-## 4. Settled requirements
+Each adapter SHALL report success or failure against the release version. A
+retry SHALL be safe: if the exact version and contents already exist, the
+adapter MAY no-op; an existing version with different contents SHALL not be
+replaced and SHALL require a new release version.
 
-### 4.1 Verified release reuse
+Adding a distribution channel SHALL require only its packaging metadata,
+publication credentials, validation, and adapter in the release pipeline. It
+MUST NOT require changes to native archive production or to existing channels.
 
-The existing GitHub desktop release archives SHALL remain the native source of
-truth. The release process SHALL build all three archives from the final tag
-and verify their contents, legal closure, native format, and SHA-256 checksums
-before creating either package-manager artifact.
+## 4. npm distribution
 
-The npm package SHALL copy each native bridge from its matching verified archive.
-The Cask SHALL use those same immutable release archives. Neither distribution
-MAY compile a second native bridge or download a bridge during installation.
+The npm channel SHALL publish one public package, `@ivoryheart/herdr-world`.
+It SHALL:
 
-The existing desktop tarballs and Android packaging SHALL remain unchanged.
-
-### 4.2 Universal npm package
-
-The package SHALL be named `@ivoryheart/herdr-world`. Ownership of the
-`@ivoryheart` npm scope is an external publication prerequisite. npm package
-names SHALL be checked before the first real publication; placeholder packages
-SHALL not be published merely to reserve names.
-
-The package SHALL:
-
-- be public, with `publishConfig.access: "public"`;
-- derive its version from `release.json` by removing only the leading `v`;
-- declare `engines.node: ">=22.14.0"`;
-- use repository metadata resolving exactly to
-  `https://github.com/IvoryHeart/herdr-world`;
-- use an explicit `files` allowlist;
+- use the release-tag version;
+- contain all three native bridges plus the shared launcher, web assets,
+  documentation, and complete legal material;
 - expose only the `herdr-world` command;
-- contain the Node entrypoint, shared launcher behavior, bundled web assets,
-  documentation, and complete legal material; and
-- contain all three bridges at these fixed package-relative paths:
+- select the fixed bridge for the running supported target; and
+- contain no install-time downloader or second native build.
 
-```text
-native/linux-x64/herdr-world-bridge
-native/darwin-arm64/herdr-world-bridge
-native/darwin-x64/herdr-world-bridge
-```
+Prereleases SHALL use the prerelease channel and SHALL not update the stable
+Homebrew Cask. Stable releases SHALL use the stable npm channel and continue
+through the same release pipeline.
 
-The package SHALL not declare optional platform dependencies or platform
-selectors. The root and `web/package.json` files SHALL remain private
-development manifests and SHALL not be published as the runtime package.
+The npm package SHALL be generated, packed, inspected, install-tested, and
+hashed before publication. The published package SHALL be the exact package
+that passed those checks. The npm scope and publication credentials are release
+setup prerequisites, not per-release manual work.
 
-The allowlist SHALL include the package manifest and README, launcher support
-files, `share/herdr-world/web/**`, all three native paths, `LICENSE`,
-`THIRD_PARTY_NOTICES.md`, `UPSTREAM.md`, `docs/world-assets.md`,
-`third_party/**`, and
-`vendor/herdr-compat/VENDOR-MANIFEST.toml`. It SHALL include every file
-referenced by the bundled legal manifest and SHALL not include source-only
-dependencies, tests, CI files, Android outputs, or an arbitrary
-`node_modules` tree.
+Platform-specific npm packages, staged publication, and a separate npm
+publication state machine are not part of the initial design.
 
-The package SHALL not use `preinstall` or `postinstall` to fetch release
-assets, execute Herdr, or create a second native payload.
+## 5. Homebrew distribution
 
-#### Scenario: The npm package is inspected
-
-- **GIVEN** a package is generated from `v0.1.0-rc.1`
-- **WHEN** its manifest and packed file list are inspected
-- **THEN** the version is `0.1.0-rc.1`, the repository is exact, access is
-  public, only `herdr-world` is exposed, all three fixed bridge paths exist,
-  and the package contains complete applicable legal material
-
-### 4.3 npm entrypoint and runtime selection
-
-The Node entrypoint SHALL select exactly one fixed bridge path using
-`process.platform`, `process.arch`, and Linux libc information:
-
-| Platform | Architecture | Runtime result | Bridge path |
-| --- | --- | --- | --- |
-| `linux` | `x64` | glibc 2.34+ | `native/linux-x64/herdr-world-bridge` |
-| `darwin` | `arm64` | any supported macOS libc | `native/darwin-arm64/herdr-world-bridge` |
-| `darwin` | `x64` | any supported macOS libc | `native/darwin-x64/herdr-world-bridge` |
-
-It SHALL reject Linux ARM64, musl or unknown libc, Windows, and every other
-unsupported combination before executing a bridge. Missing or damaged
-package-local bridge files SHALL produce an actionable nonzero error.
-
-The entrypoint SHALL resolve all package files from its own installed package
-location. It SHALL not use the current working directory, a guessed npm
-prefix, an ambient global executable, or a user-provided path override.
-
-The entrypoint SHALL invoke the shared launcher behavior with the selected
-package-local bridge and the package-local static web directory. This
-selection is an internal package implementation detail; this specification
-defines no new public environment-variable path contract.
-
-The entrypoint SHALL preserve arguments, standard input, standard output,
-standard error, relevant child signals, and child exit status. It SHALL not
-start Herdr onboarding, select a workspace, or start a bridge for
-`herdr-world --help`. Help SHALL succeed without a running Herdr session.
-
-#### Scenario: npm target selection succeeds
-
-- **GIVEN** the package is installed on macOS ARM64
-- **WHEN** `herdr-world --help` or a normal invocation runs
-- **THEN** the entrypoint selects only
-  `native/darwin-arm64/herdr-world-bridge` and does not inspect a global
-  installation or the caller's working directory
-
-#### Scenario: npm target is unsupported
-
-- **GIVEN** the package is run on Linux ARM64, musl Linux, Windows, or another
-  unsupported target
-- **WHEN** the entrypoint starts
-- **THEN** it exits before bridge execution with a diagnostic naming the
-  detected operating system, architecture, or libc and the supported matrix
-
-#### Scenario: npm help is requested
-
-- **GIVEN** no Herdr session is running
-- **WHEN** `herdr-world --help` runs
-- **THEN** usage is printed, the command exits successfully, and no Herdr or
-  bridge process starts
-
-### 4.4 Linux glibc baseline
-
-The published `v0.1.0-rc.1` Linux bridge currently requires symbols through
-`GLIBC_2.34`. glibc 2.34 is the initial minimum Linux runtime contract.
-
-Release validation SHALL extract the maximum required GLIBC symbol version from
-the exact Linux bridge copied from the verified archive and SHALL fail if it
-exceeds 2.34. The extracted value and binary digest SHALL be retained as
-release evidence.
-
-The npm entrypoint SHALL detect the host glibc version before executing the
-Linux bridge. It SHALL report both the fixed required version, 2.34, and the
-detected version when the host is below the floor. npm's libc metadata is not
-used because this universal package has no platform selector and npm cannot
-express a glibc version constraint.
-
-Validation SHALL include a positive test at glibc 2.34 and negative tests below
-2.34, on musl, and on Linux ARM64.
-
-#### Scenario: Linux glibc is too old
-
-- **GIVEN** the Linux host reports glibc 2.33
-- **WHEN** `herdr-world` is invoked
-- **THEN** it exits before bridge execution and reports required 2.34 and
-  detected 2.33
-
-### 4.5 Homebrew Cask
-
-The initial Homebrew distribution SHALL be one stable-only Cask in the
-separate public third-party repository `IvoryHeart/homebrew-tap`. The
-user-facing command SHALL be:
+The Homebrew channel SHALL be one stable-only binary Cask in the public
+third-party tap `IvoryHeart/homebrew-tap`, installed with:
 
 ```bash
 brew install --cask IvoryHeart/tap/herdr-world
 ```
 
-The Cask SHALL select the immutable versioned GitHub release archive and
-matching SHA-256 by OS and architecture:
+For an eligible stable release, CI SHALL generate and validate the Cask update
+from the release version, immutable archive URLs, and checksums, then write that
+update to the tap as part of the same release. There SHALL be no separate
+Homebrew binary upload. The Cask SHALL expose only `herdr-world` and SHALL not
+start a process or mutate a workspace during installation.
 
-| Target | Archive |
-| --- | --- |
-| macOS ARM64 | `herdr-world-vX.Y.Z-macos-arm64.tar.gz` |
-| macOS x86-64 | `herdr-world-vX.Y.Z-macos-x86_64.tar.gz` |
-| Linux x86-64 | `herdr-world-vX.Y.Z-linux-x86_64.tar.gz` |
+The ordinary Cask SHALL remain stable-only. A prerelease Cask, if ever needed,
+requires a separately named channel. Source-building and binary formulas are
+deferred.
 
-It SHALL support only those three targets, explicitly reject unsupported
-combinations, never use a moving `latest` URL, and expose only the existing
-`herdr-world` archive launcher through the normal Cask `binary` mechanism.
-The bridge SHALL not become a second command.
+## 6. Validation and acceptance
 
-The initial Cask design SHALL not add a command wrapper, path environment
-contract, downloader, daemon, or service-supervisor behavior. Cask validation
-MUST prove that the direct `binary` mapping resolves the archive launcher and
-continues to work after install, upgrade, reinstall, and removal of an older
-version. If direct mapping demonstrably fails because of Caskroom path
-resolution, implementation SHALL use the smallest validated path adaptation
-and update this specification only if the public contract changes. It SHALL
-not silently add a workaround to this contract.
+The implementation SHALL demonstrate:
 
-Cask installation SHALL preserve the archive's bridge, web assets,
-documentation, and legal material. It SHALL not start Herdr or the bridge,
-create or modify a workspace, or weaken the existing loopback, host, origin, or
-security behavior.
+- a release tag produces matching versions across all published channels;
+- npm and Homebrew consume the verified desktop outputs without rebuilding a
+  bridge;
+- the universal npm package contains the intended bridges, shared payload, and
+  legal closure;
+- npm and Cask install, upgrade, reinstall, invoke, and uninstall correctly on
+  every supported target;
+- unsupported targets fail clearly and installation has no Herdr, bridge,
+  workspace, or daemon side effects;
+- prereleases do not update the stable Cask;
+- a retry does not replace an existing published version or silently mutate
+  release contents; and
+- adding a future adapter does not change existing archive or channel output.
 
-The ordinary Cask SHALL remain stable-only. A prerelease Cask, if later needed,
-MUST have a separate name and documented channel. Stable Cask publication is
-also gated by the project's separate macOS signing, notarization, and
-applicable Gatekeeper checks. That gate is release readiness policy; it does
-not determine the package architecture.
+The release checks SHALL use versioned test fixtures. No acceptance requirement
+SHALL depend on `v0.1.0-rc.1` being the release version.
 
-#### Scenario: The Cask is installed
+## 7. Deferred work
 
-- **GIVEN** a supported target and a complete signed stable release
-- **WHEN** `brew install --cask IvoryHeart/tap/herdr-world` runs
-- **THEN** Homebrew verifies the selected immutable archive and checksum,
-  installs only `herdr-world`, starts no process, and makes no workspace
-  mutation
-
-### 4.6 Homebrew tap update
-
-For an eligible stable release, after the complete GitHub release asset set is
-available and the signing gate passes, CI SHALL generate, validate, and
-directly commit the Cask update to `IvoryHeart/homebrew-tap` as part of the
-same release. The commit SHALL update only the Cask version, the three archive
-URLs, and their three SHA-256 values.
-
-There SHALL be no separate Homebrew binary upload. CI SHALL read the final
-version, archive URLs, and checksums from the complete immutable GitHub release
-asset set when generating the Cask change.
-
-CI SHALL run Cask audit/style and available installation checks on each
-supported target before writing the change. The tap SHALL be described as
-third-party and SHALL not be presented as reviewed, endorsed, or official
-Homebrew software.
-
-The cross-repository credential SHALL be a fine-grained credential restricted
-to `IvoryHeart/homebrew-tap` with only the `Contents: write` repository
-permission. It SHALL be stored as a GitHub Actions secret and SHALL not grant
-access to other repositories. No pull-request permission SHALL be required.
-
-If the stable tap update is retried, CI SHALL compare the tap's current Cask
-version and three SHA-256 values with the intended release and SHALL no-op when
-they are already current.
-
-### 4.7 npm publication
-
-The normal npm publication SHALL run in the release workflow only for an
-intentional final version tag or published release. It SHALL not publish from
-an ordinary branch or pull request. The CI job SHALL:
-
-1. consume the final verified desktop release outputs;
-2. generate the one universal npm package;
-3. run `npm pack`;
-4. inspect, hash, and install-test the exact resulting `.tgz` on Linux x64,
-   macOS ARM64, and macOS x64; and
-5. publish that same file with:
-
-   ```bash
-   npm publish <tested-package.tgz> --tag <next-or-latest>
-   ```
-
-The publish job SHALL have `contents: read`. Its release condition SHALL be
-bound to an intentional final tag or release event, and SHALL exclude ordinary
-branch and pull-request events.
-
-The first publication SHALL run in this CI job on a GitHub-hosted runner using
-a temporary or granular npm publish token stored as a GitHub Actions secret.
-The bootstrap job SHALL grant `contents: read` and `id-token: write`, and SHALL
-use the supported Node 22.14.0+ and npm 11.5.1+ toolchain. It SHALL be the
-first real prerelease and SHALL enable npm provenance with explicit public
-access:
-
-```bash
-npm publish <tested-package.tgz> --provenance --access public --tag next
-```
-
-The token SHALL be removed from GitHub and revoked after bootstrap.
-
-After the package exists, npm trusted publishing SHALL be configured for the
-exact repository `IvoryHeart/herdr-world` and the exact release workflow
-filename `release.yml`, with direct `npm publish` allowed. This is a one-time
-bootstrap step, not a second publication architecture.
-
-Subsequent publications SHALL use npm trusted publishing from a GitHub-hosted
-runner with Node 22.14.0 or newer and npm 11.5.1 or newer. The publish job
-SHALL grant `id-token: write` and `contents: read`, SHALL use no long-lived npm
-publishing token, and SHALL rely on npm's automatic provenance for trusted
-GitHub publishing. It SHALL publish the already inspected `.tgz` directly
-under `next` for prereleases or `latest` for stable releases. A protected
-environment approval is not required by this specification. Staged publishing
-is not part of the release flow.
-
-Prerelease application versions SHALL use the `next` dist-tag and SHALL not
-update the stable Cask. Stable versions SHALL use `latest` and SHALL update the
-Cask only through the gated CI release path. A prerelease SHALL not move
-`latest`. OIDC and CI publication are the normal post-bootstrap path; staged
-publishing remains deferred.
-
-npm package versions are immutable. If incorrect bytes are published, that
-version SHALL not be reused; a later release SHALL use a new application
-version. Before retrying a failed publication, CI SHALL check npm; if the
-version is already live, it SHALL not attempt to replace it.
-
-### 4.8 Spec 016 independence
-
-Spec 016 SHALL remain source-build-only. Installing or running the npm package
-or Homebrew Cask SHALL not alter plugin ownership, plugin-managed service
-lifecycle, or plugin state. Any future plugin mode that uses an external
-distribution requires a separate explicit specification.
-
-## 5. Release sequence
-
-For a release intended for either package-manager distribution:
-
-1. Build all three native archives from the final tag.
-2. Verify archive contents, legal closure, native formats, checksums, and the
-   existing stock-Herdr live smoke for all three targets.
-3. Generate the single universal npm package from those verified outputs.
-4. Pack, inspect, install-test, and hash the exact npm `.tgz`.
-5. For a prerelease, publish the exact `.tgz` from the tag/release CI job under
-   `next` and do not update the stable Cask.
-6. For an eligible stable release, after the complete immutable release assets
-   and signing gate are available, publish the exact `.tgz` under `latest`,
-   generate and validate the Cask update, and directly commit that update to
-   `IvoryHeart/homebrew-tap` in the same CI release.
-
-A failed validation SHALL stop the sequence before publication. A failed or
-uncertain npm publication SHALL be checked against the npm registry before a
-retry; if the version is already live, it SHALL not be republished or mutated.
-A tap update retry SHALL compare the current Cask version and three checksums
-before writing and SHALL no-op when they already match the intended release.
-
-## 6. Security properties
-
-- npm and Homebrew installation SHALL not execute Herdr, a bridge, or a release
-  downloader.
-- The package-manager launchers SHALL preserve the existing loopback defaults
-  and explicit host/origin behavior. These checks are not authentication.
-- The npm package SHALL contain no publish credential, install-time network
-  downloader, or executable exposed other than `herdr-world`.
-- The third-party tap contains executable package definitions and SHALL be
-  installed only with a fully qualified tap/item command.
-- Release archives, the npm `.tgz`, and Cask checksums SHALL be retained as
-  immutable release evidence.
-
-## 7. Validation and acceptance
-
-Implementation SHALL provide the following focused evidence:
-
-- `npm pack` contains exactly the allowlisted universal package payload,
-  including all three bridge paths and legal files;
-- the package version, public metadata, repository, Node floor, and sole
-  `herdr-world` command are correct;
-- npm installs and selects the correct bridge on all three supported targets;
-- unsupported OS, CPU, libc, missing bridge, and glibc-below-floor failures are
-  actionable;
-- `herdr-world --help` succeeds without Herdr, a workspace, or a bridge;
-- arguments, stdio, signals, and child exit status are forwarded;
-- the existing live bridge smoke passes against stock Herdr;
-- the exact CI-published `.tgz` is the one install-tested and hashed;
-- npm publication runs only for an intentional final tag or release, never an
-  ordinary branch or pull request;
-- bootstrap uses a temporary/granular secret token with `--provenance`,
-  `--access public`, `contents: read`, and `id-token: write`, then removes and
-  revokes that token;
-- later publication uses GitHub OIDC with `id-token: write`, `contents: read`,
-  exact trusted-publisher configuration, and automatic provenance;
-- `next` and `latest` are used only for their intended release classes;
-- Cask audit/style checks pass;
-- Cask installation, upgrade, reinstall, direct launcher invocation, and
-  uninstall pass on every available supported target;
-- stable CI validates and directly commits only the generated Cask update after
-  the signing/readiness gate, while prereleases do not update the stable Cask;
-- Cask installation starts no process and changes no Herdr workspace;
-- Cask URLs are immutable and checksums match;
-- stable Cask publication is blocked until signing/notarization/Gatekeeper
-  checks pass; and
-- desktop tarball, Android, and Spec 016 behavior remain unchanged.
-
-## 8. Rollout and deferred work
-
-Before implementation, resolve ownership of the `@ivoryheart` scope and create
-the public `IvoryHeart/homebrew-tap` repository. Implement and validate the CI
-npm package and direct Cask against release-candidate fixtures without changing
-desktop or Android outputs.
-
-Publish the first npm package from CI under `next` only after the exact tarball
-has been installed and tested on the support matrix. Configure trusted
-publishing and revoke the bootstrap token after that first publication. Publish
-the stable Cask only after its separate signing/readiness gate passes; CI
-validates and directly commits the generated Cask update to the tap as part of
-the stable release.
-
-The following remain deferred until evidence justifies them:
-
-- splitting npm native payloads into platform packages;
-- staged npm publication;
-- Cask path adaptation if direct `binary` mapping fails;
-- a separately named prerelease Cask;
-- Homebrew formulas or official Homebrew submission;
-- additional platform/libc support; and
+- npm platform-package splitting;
+- staged npm publication or a publication database;
+- install-time downloaders, Cask wrappers, service supervisors, and formulas;
+- additional operating systems, architectures, or libc implementations;
+- a prerelease Homebrew channel; and
 - plugin reuse of an external package-manager installation.
 
-## 9. References
+## 8. References
 
 - [Distribution analysis](../analysis/npm-homebrew-distribution-analysis-2026-08-28.md)
 - [Spec 016](016-herdr-world-plugin-release-spec.md)
 - [Packaging documentation](../packaging.md)
 - [Release documentation](../release.md)
-- [npm package.json fields](https://docs.npmjs.com/cli/v11/configuring-npm/package-json)
+- [npm package.json](https://docs.npmjs.com/cli/v11/configuring-npm/package-json)
 - [npm publish](https://docs.npmjs.com/cli/v11/commands/npm-publish/)
-- [npm scoped public packages](https://docs.npmjs.com/creating-and-publishing-scoped-public-packages/)
-- [npm distribution tags](https://docs.npmjs.com/cli/v11/commands/npm-dist-tag/)
 - [npm trusted publishers](https://docs.npmjs.com/trusted-publishers/)
-- [GitHub Actions OIDC](https://docs.github.com/en/actions/reference/security/oidc)
-- [GitHub Actions workflow syntax](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax)
-- [GitHub fine-grained token permissions](https://docs.github.com/en/rest/authentication/permissions-required-for-fine-grained-personal-access-tokens)
 - [Homebrew Cask Cookbook](https://docs.brew.sh/Cask-Cookbook)
 - [Homebrew taps](https://docs.brew.sh/Taps)
-- [Homebrew acceptable Casks](https://docs.brew.sh/Acceptable-Casks)
-- [Homebrew Tap Trust](https://docs.brew.sh/Tap-Trust)

--- a/docs/specs/017-herdr-world-npm-homebrew-distribution-spec.md
+++ b/docs/specs/017-herdr-world-npm-homebrew-distribution-spec.md
@@ -268,27 +268,28 @@ not determine the package architecture.
 ### 4.6 Homebrew tap update
 
 For an eligible stable release, after the complete GitHub release asset set is
-available and the signing gate passes, CI SHALL prepare and open a pull request
-in `IvoryHeart/homebrew-tap`. The pull request SHALL update only the Cask
-version, the three archive URLs, their three SHA-256 values, and reviewed Cask
-metadata if required.
+available and the signing gate passes, CI SHALL generate, validate, and
+directly commit the Cask update to `IvoryHeart/homebrew-tap` as part of the
+same release. The commit SHALL update only the Cask version, the three archive
+URLs, and their three SHA-256 values.
 
 There SHALL be no separate Homebrew binary upload. CI SHALL read the final
 version, archive URLs, and checksums from the complete immutable GitHub release
 asset set when generating the Cask change.
 
 CI SHALL run Cask audit/style and available installation checks on each
-supported target. Human review SHALL be required before merge, and CI SHALL
-not merge the pull request. The tap SHALL be described as third-party and
-SHALL not be presented as reviewed, endorsed, or official Homebrew software.
+supported target before writing the change. The tap SHALL be described as
+third-party and SHALL not be presented as reviewed, endorsed, or official
+Homebrew software.
 
-The cross-repository credential used to open the pull request SHALL be a
-fine-grained credential restricted to `IvoryHeart/homebrew-tap` with only the
-repository contents and pull-request permissions needed to create the branch
-and pull request. It SHALL be stored as a GitHub Actions secret and SHALL not
-grant access to other repositories. The workflow SHALL only create the branch
-and pull request; it SHALL never invoke a merge. A maintainer SHALL review and
-merge the tap pull request.
+The cross-repository credential SHALL be a fine-grained credential restricted
+to `IvoryHeart/homebrew-tap` with only the `Contents: write` repository
+permission. It SHALL be stored as a GitHub Actions secret and SHALL not grant
+access to other repositories. No pull-request permission SHALL be required.
+
+If the stable tap update is retried, CI SHALL compare the tap's current Cask
+version and three SHA-256 values with the intended release and SHALL no-op when
+they are already current.
 
 ### 4.7 npm publication
 
@@ -338,10 +339,11 @@ under `next` for prereleases or `latest` for stable releases. A protected
 environment approval is not required by this specification. Staged publishing
 is not part of the release flow.
 
-Prerelease application versions SHALL use the `next` dist-tag. Stable
-versions SHALL use `latest`. A prerelease SHALL not move `latest`. OIDC and
-CI publication are the normal post-bootstrap path; staged publishing remains
-deferred.
+Prerelease application versions SHALL use the `next` dist-tag and SHALL not
+update the stable Cask. Stable versions SHALL use `latest` and SHALL update the
+Cask only through the gated CI release path. A prerelease SHALL not move
+`latest`. OIDC and CI publication are the normal post-bootstrap path; staged
+publishing remains deferred.
 
 npm package versions are immutable. If incorrect bytes are published, that
 version SHALL not be reused; a later release SHALL use a new application
@@ -364,17 +366,18 @@ For a release intended for either package-manager distribution:
    existing stock-Herdr live smoke for all three targets.
 3. Generate the single universal npm package from those verified outputs.
 4. Pack, inspect, install-test, and hash the exact npm `.tgz`.
-5. Publish the exact `.tgz` from the tag/release CI job under `next` or
-   `latest`, as appropriate.
+5. For a prerelease, publish the exact `.tgz` from the tag/release CI job under
+   `next` and do not update the stable Cask.
 6. For an eligible stable release, after the complete immutable release assets
-   and signing gate are available, have CI prepare and open the Homebrew tap
-   pull request.
-7. Run Cask audit/style and install-test checks; leave tap review and merge to
-   a maintainer.
+   and signing gate are available, publish the exact `.tgz` under `latest`,
+   generate and validate the Cask update, and directly commit that update to
+   `IvoryHeart/homebrew-tap` in the same CI release.
 
 A failed validation SHALL stop the sequence before publication. A failed or
 uncertain npm publication SHALL be checked against the npm registry before a
 retry; if the version is already live, it SHALL not be republished or mutated.
+A tap update retry SHALL compare the current Cask version and three checksums
+before writing and SHALL no-op when they already match the intended release.
 
 ## 6. Security properties
 
@@ -385,8 +388,7 @@ retry; if the version is already live, it SHALL not be republished or mutated.
 - The npm package SHALL contain no publish credential, install-time network
   downloader, or executable exposed other than `herdr-world`.
 - The third-party tap contains executable package definitions and SHALL be
-  installed only with a fully qualified tap/item command after appropriate
-  review.
+  installed only with a fully qualified tap/item command.
 - Release archives, the npm `.tgz`, and Cask checksums SHALL be retained as
   immutable release evidence.
 
@@ -416,6 +418,8 @@ Implementation SHALL provide the following focused evidence:
 - Cask audit/style checks pass;
 - Cask installation, upgrade, reinstall, direct launcher invocation, and
   uninstall pass on every available supported target;
+- stable CI validates and directly commits only the generated Cask update after
+  the signing/readiness gate, while prereleases do not update the stable Cask;
 - Cask installation starts no process and changes no Herdr workspace;
 - Cask URLs are immutable and checksums match;
 - stable Cask publication is blocked until signing/notarization/Gatekeeper
@@ -432,8 +436,9 @@ desktop or Android outputs.
 Publish the first npm package from CI under `next` only after the exact tarball
 has been installed and tested on the support matrix. Configure trusted
 publishing and revoke the bootstrap token after that first publication. Publish
-the stable Cask only after its separate signing/readiness gate passes; CI opens
-the tap PR but a maintainer reviews and merges it.
+the stable Cask only after its separate signing/readiness gate passes; CI
+validates and directly commits the generated Cask update to the tap as part of
+the stable release.
 
 The following remain deferred until evidence justifies them:
 

--- a/docs/specs/017-herdr-world-npm-homebrew-distribution-spec.md
+++ b/docs/specs/017-herdr-world-npm-homebrew-distribution-spec.md
@@ -61,9 +61,12 @@ pipeline SHALL:
 2. verify archive contents, legal closure, native formats, checksums, and the
    existing live smoke;
 3. make the verified outputs available to the channel adapters;
-4. publish the npm package and, for an eligible stable release, update the
-   Homebrew Cask from those same outputs; and
-5. invoke any additional enabled distribution adapters using the same release
+4. generate, inspect, install-test, and hash the npm package;
+5. for a prerelease, publish npm under its prerelease channel without updating
+   the stable Cask; for an eligible stable release, generate and complete Cask
+   validation, then publish npm under the stable channel and write the already
+   validated Cask update to the tap; and
+6. invoke any additional enabled distribution adapters using the same release
    version and verified release record, subject to that channel's owning
    contract.
 
@@ -114,9 +117,13 @@ brew install --cask IvoryHeart/tap/herdr-world
 
 For an eligible stable release, CI SHALL generate and validate the Cask update
 from the release version, immutable archive URLs, and checksums, then write that
-update to the tap as part of the same release. There SHALL be no separate
-Homebrew binary upload. The Cask SHALL expose only `herdr-world` and SHALL not
-start a process or mutate a workspace during installation.
+update to the tap as part of the same release, after the stable npm publication.
+There SHALL be no separate Homebrew binary upload. The Cask SHALL expose only
+`herdr-world` and SHALL not start a process or mutate a workspace during
+installation.
+
+If the stable update is retried, CI SHALL regenerate the intended complete Cask
+and SHALL no-op when it already matches the tap.
 
 The ordinary Cask SHALL remain stable-only. A prerelease Cask, if ever needed,
 requires a separately named channel. Source-building and binary formulas are

--- a/docs/specs/017-herdr-world-npm-homebrew-distribution-spec.md
+++ b/docs/specs/017-herdr-world-npm-homebrew-distribution-spec.md
@@ -57,8 +57,7 @@ The following are explicitly deferred:
 
 - optional npm platform packages or a multi-package publication graph;
 - a second native build pipeline or an install-time release downloader;
-- npm publication states, staged publishing, OIDC/CI publication automation,
-  or a publication database;
+- npm publication states, staged publishing, or a publication database;
 - a Cask wrapper, new public path environment contract, or service supervisor;
 - source-building or binary Homebrew formulas;
 - official Homebrew repository submission;
@@ -268,37 +267,83 @@ not determine the package architecture.
 
 ### 4.6 Homebrew tap update
 
-After the complete GitHub release asset set is available and the signing gate
-passes, a maintainer SHALL prepare a pull request in
-`IvoryHeart/homebrew-tap`. The pull request SHALL update only the Cask version,
-the three archive URLs, their three SHA-256 values, and reviewed Cask metadata
-if required.
+For an eligible stable release, after the complete GitHub release asset set is
+available and the signing gate passes, CI SHALL prepare and open a pull request
+in `IvoryHeart/homebrew-tap`. The pull request SHALL update only the Cask
+version, the three archive URLs, their three SHA-256 values, and reviewed Cask
+metadata if required.
 
-The maintainer SHALL run Cask audit/style and installation checks on each
-available supported target. Human review SHALL be required before merge. The
-tap SHALL be described as third-party and SHALL not be presented as reviewed,
-endorsed, or official Homebrew software.
+There SHALL be no separate Homebrew binary upload. CI SHALL read the final
+version, archive URLs, and checksums from the complete immutable GitHub release
+asset set when generating the Cask change.
+
+CI SHALL run Cask audit/style and available installation checks on each
+supported target. Human review SHALL be required before merge, and CI SHALL
+not merge the pull request. The tap SHALL be described as third-party and
+SHALL not be presented as reviewed, endorsed, or official Homebrew software.
+
+The cross-repository credential used to open the pull request SHALL be a
+fine-grained credential restricted to `IvoryHeart/homebrew-tap` with only the
+repository contents and pull-request permissions needed to create the branch
+and pull request. It SHALL be stored as a GitHub Actions secret, SHALL not
+permit tap merging, and SHALL not grant access to other repositories.
 
 ### 4.7 npm publication
 
-The npm package SHALL be generated from the final verified release outputs.
-Before publication, the maintainer SHALL:
+The normal npm publication SHALL run in the release workflow only for an
+intentional final version tag or published release. It SHALL not publish from
+an ordinary branch or pull request. The CI job SHALL:
 
-1. create the package staging directory;
-2. run `npm pack` and inspect the exact resulting `.tgz` file list and
-   manifest;
-3. install-test that exact `.tgz` on Linux x64, macOS ARM64, and macOS x64;
-4. record its SHA-256; and
-5. publish that same `.tgz` manually with standard npm authentication.
+1. consume the final verified desktop release outputs;
+2. generate the one universal npm package;
+3. run `npm pack`;
+4. inspect, hash, and install-test the exact resulting `.tgz` on Linux x64,
+   macOS ARM64, and macOS x64; and
+5. publish that same file with:
+
+   ```bash
+   npm publish <tested-package.tgz> --tag <next-or-latest>
+   ```
+
+The publish job SHALL have `contents: read`. Its release condition SHALL be
+bound to an intentional final tag or release event, and SHALL exclude ordinary
+branch and pull-request events.
+
+The first publication SHALL run in this CI job using a temporary or granular
+npm publish token stored as a GitHub Actions secret. It SHALL be the first real
+prerelease and SHALL use explicit public access:
+
+```bash
+npm publish <tested-package.tgz> --access public --tag next
+```
+
+Where the selected npm CLI supports provenance, the bootstrap publication
+SHALL enable npm provenance from the GitHub-hosted workflow. The token SHALL
+be removed from GitHub and revoked after bootstrap.
+
+After the package exists, npm trusted publishing SHALL be configured for the
+exact repository `IvoryHeart/herdr-world` and the exact release workflow
+filename `release.yml`, with direct `npm publish` allowed. This is a one-time
+bootstrap step, not a second publication architecture.
+
+Subsequent publications SHALL use npm trusted publishing from a GitHub-hosted
+runner with Node 22.14.0 or newer and npm 11.5.1 or newer. The publish job
+SHALL grant `id-token: write` and `contents: read`, SHALL use no long-lived npm
+publishing token, and SHALL rely on npm's automatic provenance for trusted
+GitHub publishing. It SHALL publish the already inspected `.tgz` directly
+under `next` for prereleases or `latest` for stable releases. A protected
+environment approval is not required by this specification. Staged publishing
+is not part of the release flow.
 
 Prerelease application versions SHALL use the `next` dist-tag. Stable
 versions SHALL use `latest`. A prerelease SHALL not move `latest`. OIDC and
-CI publication automation, including staged publishing, are deferred until
-the manual path has worked in practice.
+CI publication are the normal post-bootstrap path; staged publishing remains
+deferred.
 
 npm package versions are immutable. If incorrect bytes are published, that
 version SHALL not be reused; a later release SHALL use a new application
-version.
+version. Before retrying a failed publication, CI SHALL check npm; if the
+version is already live, it SHALL not attempt to replace it.
 
 ### 4.8 Spec 016 independence
 
@@ -316,15 +361,17 @@ For a release intended for either package-manager distribution:
    existing stock-Herdr live smoke for all three targets.
 3. Generate the single universal npm package from those verified outputs.
 4. Pack, inspect, install-test, and hash the exact npm `.tgz`.
-5. Manually publish the exact `.tgz` under `next` or `latest`, as
-   appropriate.
-6. After the complete immutable release assets and signing gate are available,
-   prepare and review the manual Homebrew tap pull request.
-7. Run Cask audit/style and install-test checks before merging the tap change.
+5. Publish the exact `.tgz` from the tag/release CI job under `next` or
+   `latest`, as appropriate.
+6. For an eligible stable release, after the complete immutable release assets
+   and signing gate are available, have CI prepare and open the Homebrew tap
+   pull request.
+7. Run Cask audit/style and install-test checks; leave tap review and merge to
+   a maintainer.
 
 A failed validation SHALL stop the sequence before publication. A failed or
 uncertain npm publication SHALL be checked against the npm registry before a
-manual retry; published bytes SHALL never be replaced or silently mutated.
+retry; if the version is already live, it SHALL not be republished or mutated.
 
 ## 6. Security properties
 
@@ -354,7 +401,13 @@ Implementation SHALL provide the following focused evidence:
 - `herdr-world --help` succeeds without Herdr, a workspace, or a bridge;
 - arguments, stdio, signals, and child exit status are forwarded;
 - the existing live bridge smoke passes against stock Herdr;
-- the exact manually published `.tgz` is the one install-tested and hashed;
+- the exact CI-published `.tgz` is the one install-tested and hashed;
+- npm publication runs only for an intentional final tag or release, never an
+  ordinary branch or pull request;
+- bootstrap uses a temporary/granular secret token with public access, then
+  removes and revokes that token;
+- later publication uses GitHub OIDC with `id-token: write`, `contents: read`,
+  exact trusted-publisher configuration, and automatic provenance;
 - `next` and `latest` are used only for their intended release classes;
 - Cask audit/style checks pass;
 - Cask installation, upgrade, reinstall, direct launcher invocation, and
@@ -368,18 +421,20 @@ Implementation SHALL provide the following focused evidence:
 ## 8. Rollout and deferred work
 
 Before implementation, resolve ownership of the `@ivoryheart` scope and create
-the public `IvoryHeart/homebrew-tap` repository. Implement and validate the
-manual npm package and direct Cask against release-candidate fixtures without
-changing desktop or Android outputs.
+the public `IvoryHeart/homebrew-tap` repository. Implement and validate the CI
+npm package and direct Cask against release-candidate fixtures without changing
+desktop or Android outputs.
 
-Publish the first npm package manually under `next` only after the exact
-tarball has been installed and tested on the support matrix. Publish the stable
-Cask only after its separate signing/readiness gate passes.
+Publish the first npm package from CI under `next` only after the exact tarball
+has been installed and tested on the support matrix. Configure trusted
+publishing and revoke the bootstrap token after that first publication. Publish
+the stable Cask only after its separate signing/readiness gate passes; CI opens
+the tap PR but a maintainer reviews and merges it.
 
 The following remain deferred until evidence justifies them:
 
 - splitting npm native payloads into platform packages;
-- OIDC, CI, or staged npm publication;
+- staged npm publication;
 - Cask path adaptation if direct `binary` mapping fails;
 - a separately named prerelease Cask;
 - Homebrew formulas or official Homebrew submission;
@@ -397,6 +452,9 @@ The following remain deferred until evidence justifies them:
 - [npm scoped public packages](https://docs.npmjs.com/creating-and-publishing-scoped-public-packages/)
 - [npm distribution tags](https://docs.npmjs.com/cli/v11/commands/npm-dist-tag/)
 - [npm trusted publishers](https://docs.npmjs.com/trusted-publishers/)
+- [GitHub Actions OIDC](https://docs.github.com/en/actions/reference/security/oidc)
+- [GitHub Actions workflow syntax](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax)
+- [GitHub fine-grained token permissions](https://docs.github.com/en/rest/authentication/permissions-required-for-fine-grained-personal-access-tokens)
 - [Homebrew Cask Cookbook](https://docs.brew.sh/Cask-Cookbook)
 - [Homebrew taps](https://docs.brew.sh/Taps)
 - [Homebrew acceptable Casks](https://docs.brew.sh/Acceptable-Casks)


### PR DESCRIPTION
## Summary

Simplify the existing Spec 017 and its analysis into a durable release contract: one final release pipeline produces one verified release record, then publishes npm, updates Homebrew, and can invoke future distribution adapters without repeating release-specific work.

- The release tag, not `v0.1.0-rc.1`, supplies the version for every future release.
- npm and Homebrew reuse verified desktop outputs; no second native build or install-time downloader is introduced.
- The universal npm package and stable third-party direct-archive Cask remain the initial channels.
- Prereleases leave the stable Cask unchanged; stable releases update npm and the Cask through the same pipeline.
- Spec 016 keeps ownership of plugin lifecycle and source-build behavior while sharing the release boundary.
- Future channels are small adapters to the same release version/record.
- `AGENTS.md` adds the requested guidance to prefer complete, economical solutions and material review findings.
- No implementation files changed.

## Scope

Only these repository guidance/documentation files changed:

- `AGENTS.md`
- `docs/specs/017-herdr-world-npm-homebrew-distribution-spec.md`
- `docs/analysis/npm-homebrew-distribution-analysis-2026-08-28.md`

## Validation

- `npm run check` passed (162 Rust tests)
- local Markdown link-target check
- `git diff --check`
- no workflow, packaging script, launcher, Cask, desktop archive, Android, or plugin implementation files changed