### PR TITLE
Automate multi-channel release distribution

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -399,10 +399,160 @@ jobs:
           if-no-files-found: error
           retention-days: 14
 
+  external_state:
+    name: Validate external release state
+    if: github.event_name == 'push' && github.ref_type == 'tag'
+    needs: [provenance, native, npm_package, formula]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+      - uses: actions/download-artifact@v8
+        with:
+          name: npm-package-${{ github.run_id }}
+          path: npm-output
+          run-id: ${{ github.run_id }}
+          github-token: ${{ github.token }}
+      - uses: actions/download-artifact@v8
+        with:
+          name: homebrew-formula-${{ github.run_id }}
+          path: formula-output
+          run-id: ${{ github.run_id }}
+          github-token: ${{ github.token }}
+      - name: Verify npm and Homebrew availability before publication
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ github.ref_name }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          package="$NPM_PACKAGE_NAME"
+          version="${VERSION#v}"
+          channel="latest"
+          [[ "$VERSION" == *-rc.* ]] && channel="next"
+          npm_state() {
+            node scripts/npm-registry-query.mjs state "$@"
+          }
+          npm_present() {
+            node --input-type=module - "$1" <<'NODE'
+          const state = JSON.parse(process.argv[2]);
+          console.log(state.present);
+          NODE
+          }
+          npm_value() {
+            node --input-type=module - "$1" <<'NODE'
+          const state = JSON.parse(process.argv[2]);
+          if (!state.present || !state.raw || state.raw === "null" || state.raw === "undefined") process.exit(0);
+          const value = JSON.parse(state.raw);
+          if (value !== null && value !== undefined) process.stdout.write(String(value));
+          NODE
+          }
+          package_state="$(npm_state view "$package" name --json)"
+          package_exists="$(npm_present "$package_state")"
+          exact_state="$(npm_state view "$package@$version" version --json)"
+          exact_exists="$(npm_present "$exact_state")"
+          metadata_integrity="$(node -e 'console.log(JSON.parse(require("fs").readFileSync(process.argv[1])).integrity)' npm-output/npm-package-metadata.json)"
+          exact_matches=false
+          if [[ "$exact_exists" == true ]]; then
+            exact_integrity="$(npm_value "$(npm_state view "$package@$version" dist.integrity --json)")"
+            [[ "$exact_integrity" == "$metadata_integrity" ]] || {
+              echo "npm version already exists with different content: $package@$version" >&2
+              exit 1
+            }
+            exact_matches=true
+          fi
+          if [[ "$package_exists" == false ]]; then
+            [[ "$VERSION" == *-rc.* ]] || {
+              echo "the first npm publication must be an RC; publish a unique release candidate before $VERSION" >&2
+              exit 1
+            }
+          else
+            pointer="$(npm_value "$(npm_state view "$package" "dist-tags.$channel" --json)")"
+            if [[ -n "$pointer" ]]; then
+              comparison="$(node --input-type=module - "$VERSION" "v$pointer" <<'NODE'
+          import { compareReleaseTags } from './scripts/release-version.mjs';
+          const [candidate, pointer] = process.argv.slice(2);
+          console.log(compareReleaseTags(candidate, pointer));
+          NODE
+              )"
+              if [[ "$comparison" != "0" || "$exact_matches" != true ]]; then
+              node --input-type=module - "$VERSION" "v$pointer" <<'NODE'
+          import { compareReleaseTags } from './scripts/release-version.mjs';
+          const [candidate, pointer] = process.argv.slice(2);
+          if (compareReleaseTags(candidate, pointer) <= 0) {
+            console.error(`npm channel already reaches ${pointer}; candidate ${candidate} must be higher`);
+            process.exit(1);
+          }
+          NODE
+              fi
+            fi
+          fi
+
+          gh repo view "$HOMEBREW_TAP_REPOSITORY" --json nameWithOwner --jq .nameWithOwner >/dev/null
+          formula="herdr-world.rb"
+          [[ "$VERSION" == *-rc.* ]] && formula="herdr-world-rc.rb"
+          formula_file="formula-output/$formula"
+          [[ -f "$formula_file" ]] || { echo "generated Homebrew Formula is missing: $formula_file" >&2; exit 1; }
+          endpoint="repos/$HOMEBREW_TAP_REPOSITORY/contents/Formula/$formula"
+          formula_error="${RUNNER_TEMP}/homebrew-formula-api-error"
+          formula_json=""
+          if formula_json="$(gh api "$endpoint" 2>"$formula_error")"; then
+            formula_version="$(node --input-type=module - "$formula_json" <<'NODE'
+          const response = JSON.parse(process.argv[2]);
+          const contents = Buffer.from(response.content, 'base64').toString('utf8');
+          const version = contents.match(/^\s*version\s+"([^"]+)"/m)?.[1];
+          if (!version) process.exit(1);
+          console.log(version);
+          NODE
+            )"
+            comparison="$(node --input-type=module - "$VERSION" "v$formula_version" <<'NODE'
+          import { compareReleaseTags } from './scripts/release-version.mjs';
+          const [candidate, current] = process.argv.slice(2);
+          console.log(compareReleaseTags(candidate, current));
+          NODE
+            )"
+            if [[ "$comparison" == "-1" ]]; then
+              echo "Homebrew Formula already reaches v$formula_version; candidate $VERSION must be higher" >&2
+              exit 1
+            fi
+            if [[ "$comparison" == "0" ]]; then
+              existing_formula="${RUNNER_TEMP}/existing-formula.rb"
+              node --input-type=module - "$formula_json" > "$existing_formula" <<'NODE'
+          const response = JSON.parse(process.argv[2]);
+          process.stdout.write(Buffer.from(response.content, 'base64'));
+          NODE
+              cmp -s "$formula_file" "$existing_formula" || {
+                echo "Homebrew Formula already exists with different content: $formula" >&2
+                exit 1
+              }
+            fi
+          else
+            formula_error_text="$(<"$formula_error")"
+            formula_status="$(node --input-type=module - "$formula_json" <<'NODE'
+          try {
+            const status = JSON.parse(process.argv[2]).status;
+            if (status !== undefined) console.log(status);
+          } catch {}
+          NODE
+            )"
+            if [[ "$formula_status" != "404" && "$formula_error_text" != *"HTTP 404"* ]]; then
+              echo "could not check Homebrew Formula $formula: ${formula_error_text:-$formula_json}" >&2
+              exit 1
+            fi
+          fi
+
   github_release:
     name: Assemble and publish GitHub release
     if: github.event_name == 'push' && github.ref_type == 'tag'
-    needs: [provenance, native]
+    needs: [provenance, native, external_state]
+    outputs:
+      publication_result: ${{ steps.publish.outputs.result }}
+      publication_url: ${{ steps.publish.outputs.url }}
     runs-on: ubuntu-24.04
     timeout-minutes: 20
     permissions:
@@ -430,6 +580,7 @@ jobs:
           done
           node scripts/release-notes.mjs "$VERSION" CHANGELOG.md "${RUNNER_TEMP}/release-notes.md"
       - name: Create or validate the draft release
+        id: release_state
         env:
           GH_TOKEN: ${{ github.token }}
           VERSION: ${{ github.ref_name }}
@@ -441,7 +592,31 @@ jobs:
             if [[ "$VERSION" == *-rc.* ]]; then args+=(--prerelease); fi
             gh "${args[@]}"
           fi
-          [[ "$(gh release view "$VERSION" --repo "$RELEASE_REPOSITORY" --json tagName --jq .tagName)" == "$VERSION" ]]
+          release_json="$(gh release view "$VERSION" --repo "$RELEASE_REPOSITORY" --json tagName,name,body,isDraft,isPrerelease)"
+          node --input-type=module - "$release_json" "$VERSION" "${RUNNER_TEMP}/release-notes.md" <<'NODE' >> "$GITHUB_OUTPUT"
+          import { readFileSync } from 'node:fs';
+          const [raw, version, notesPath] = process.argv.slice(2);
+          const release = JSON.parse(raw);
+          const expectedBody = readFileSync(notesPath, 'utf8').trim();
+          const expected = {
+            tagName: version,
+            name: `Herdr World ${version}`,
+            body: expectedBody,
+            isPrerelease: version.includes('-rc.'),
+          };
+          for (const [field, value] of Object.entries(expected)) {
+            const actual = field === 'body' ? release[field].trim() : release[field];
+            if (actual !== value) {
+              console.error(`existing GitHub release ${field} does not match the tagged release`);
+              process.exit(1);
+            }
+          }
+          if (typeof release.isDraft !== 'boolean') {
+            console.error('existing GitHub release has an invalid draft state');
+            process.exit(1);
+          }
+          console.log(`is_draft=${release.isDraft}`);
+          NODE
       - name: Upload absent assets and verify existing assets byte-for-byte
         env:
           GH_TOKEN: ${{ github.token }}
@@ -478,15 +653,23 @@ jobs:
             exit 1
           }
       - name: Publish the complete GitHub release
+        id: publish
         env:
           GH_TOKEN: ${{ github.token }}
           VERSION: ${{ github.ref_name }}
         shell: bash
         run: |
-          args=(release edit "$VERSION" --repo "$RELEASE_REPOSITORY" --draft=false)
-          if [[ "$VERSION" == *-rc.* ]]; then args+=(--prerelease); fi
-          gh "${args[@]}"
-          echo "GitHub: published — https://github.com/${RELEASE_REPOSITORY}/releases/tag/${VERSION}" >> "$GITHUB_STEP_SUMMARY"
+          url="https://github.com/${RELEASE_REPOSITORY}/releases/tag/${VERSION}"
+          result="already complete"
+          if [[ "${{ steps.release_state.outputs.is_draft }}" == true ]]; then
+            args=(release edit "$VERSION" --repo "$RELEASE_REPOSITORY" --draft=false)
+            if [[ "$VERSION" == *-rc.* ]]; then args+=(--prerelease); else args+=(--prerelease=false); fi
+            gh "${args[@]}"
+            result="published"
+          fi
+          echo "result=$result" >> "$GITHUB_OUTPUT"
+          echo "url=$url" >> "$GITHUB_OUTPUT"
+          echo "GitHub: $result — $url" >> "$GITHUB_STEP_SUMMARY"
 
   homebrew_test:
     name: Homebrew Formula test (${{ matrix.platform }})
@@ -545,7 +728,8 @@ jobs:
     if: github.event_name == 'push' && github.ref_type == 'tag'
     needs: [provenance, github_release, npm_package, npm_install_test]
     outputs:
-      publication_result: ${{ steps.complete.outputs.result || steps.state.outputs.result }}
+      publication_result: ${{ steps.publish.outputs.result || steps.state.outputs.result }}
+      publication_url: ${{ steps.publish.outputs.url || steps.state.outputs.url }}
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     permissions:
@@ -623,6 +807,7 @@ jobs:
               echo "Artifact: https://github.com/${RELEASE_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
             } >> "$GITHUB_STEP_SUMMARY"
             echo "result=action-required" >> "$GITHUB_OUTPUT"
+            echo "url=https://github.com/${RELEASE_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           digest_matches=false
@@ -644,6 +829,7 @@ jobs:
           action="$(node -e 'console.log(JSON.parse(process.argv[1]).action)' "$decision")"
           [[ "$action" != "fail" ]] || { node -e 'console.error(JSON.parse(process.argv[1]).reason)' "$decision"; exit 1; }
       - name: Publish or repair npm channel
+        id: publish
         if: steps.state.outputs.result != 'action-required'
         env:
           VERSION: ${{ github.ref_name }}
@@ -672,16 +858,18 @@ jobs:
           metadata_integrity="$(node -e 'console.log(JSON.parse(require("fs").readFileSync(process.argv[1])).integrity)' npm-output/npm-package-metadata.json)"
           [[ "$registry_integrity" == "$metadata_integrity" ]]
           [[ "$registry_pointer" == "${VERSION#v}" ]]
-          echo "npm: $result — https://www.npmjs.com/package/${NPM_PACKAGE_NAME}/v/${VERSION#v}" >> "$GITHUB_STEP_SUMMARY"
-      - name: Mark npm publication complete
-        id: complete
-        if: steps.state.outputs.result != 'action-required'
-        run: echo "result=complete" >> "$GITHUB_OUTPUT"
+          url="https://www.npmjs.com/package/${NPM_PACKAGE_NAME}/v/${VERSION#v}"
+          echo "result=$result" >> "$GITHUB_OUTPUT"
+          echo "url=$url" >> "$GITHUB_OUTPUT"
+          echo "npm: $result — $url" >> "$GITHUB_STEP_SUMMARY"
 
   homebrew_publish:
     name: Publish Homebrew channel
     if: github.event_name == 'push' && github.ref_type == 'tag'
     needs: [provenance, github_release, formula, homebrew_test]
+    outputs:
+      publication_result: ${{ steps.publish.outputs.result }}
+      publication_url: ${{ steps.publish.outputs.url }}
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     steps:
@@ -693,18 +881,22 @@ jobs:
           run-id: ${{ github.run_id }}
           github-token: ${{ github.token }}
       - name: Commit the validated Formula directly to the tap
+        id: publish
         env:
           HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
           VERSION: ${{ github.ref_name }}
         run: |
           formula_file="$(find formula -maxdepth 1 -type f \( -name 'herdr-world.rb' -o -name 'herdr-world-rc.rb' \) -print -quit)"
           [[ -n "$formula_file" ]] || { echo "no channel-specific Formula was downloaded" >&2; exit 1; }
-          scripts/update-homebrew-tap.sh "$VERSION" "$formula_file"
-      - name: Report Homebrew channel
-        env:
-          VERSION: ${{ github.ref_name }}
-        run: |
-          echo "Homebrew: published or already complete — https://github.com/${HOMEBREW_TAP_REPOSITORY}" >> "$GITHUB_STEP_SUMMARY"
+          publication="$(scripts/update-homebrew-tap.sh "$VERSION" "$formula_file")"
+          printf '%s\n' "$publication"
+          result="published"
+          [[ "$publication" == *"already complete"* ]] && result="already complete"
+          formula_name="$(basename "$formula_file" .rb)"
+          url="https://github.com/${HOMEBREW_TAP_REPOSITORY}/blob/main/Formula/${formula_name}.rb"
+          echo "result=$result" >> "$GITHUB_OUTPUT"
+          echo "url=$url" >> "$GITHUB_OUTPUT"
+          echo "Homebrew: $result — $url" >> "$GITHUB_STEP_SUMMARY"
 
   publication_summary:
     name: Release publication summary
@@ -719,12 +911,12 @@ jobs:
           {
             echo "## Herdr World $VERSION distribution"
             echo
-            echo "| Channel | Result |"
-            echo "| --- | --- |"
-            echo "| GitHub | ${{ needs.github_release.result }} |"
-            echo "| npm (${NPM_PACKAGE_NAME}) | ${{ needs.npm_publish.outputs.publication_result || needs.npm_publish.result }} |"
-            echo "| Homebrew (${HOMEBREW_TAP_REPOSITORY}) | ${{ needs.homebrew_publish.result }} |"
-            echo "| Herdr plugin | not enabled; Spec 016 remains a separate release tranche |"
+            echo "| Channel | Version | Result | URL |"
+            echo "| --- | --- | --- | --- |"
+            echo "| GitHub | ${VERSION#v} | ${{ needs.github_release.outputs.publication_result || needs.github_release.result }} | ${{ needs.github_release.outputs.publication_url || '—' }} |"
+            echo "| npm (${NPM_PACKAGE_NAME}) | ${VERSION#v} | ${{ needs.npm_publish.outputs.publication_result || needs.npm_publish.result }} | ${{ needs.npm_publish.outputs.publication_url || '—' }} |"
+            echo "| Homebrew (${HOMEBREW_TAP_REPOSITORY}) | ${VERSION#v} | ${{ needs.homebrew_publish.outputs.publication_result || needs.homebrew_publish.result }} | ${{ needs.homebrew_publish.outputs.publication_url || '—' }} |"
+            echo "| Herdr plugin | — | not enabled; Spec 016 remains a separate release tranche | — |"
             echo
             echo "Source commit: $GITHUB_SHA"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ on:
       - "scripts/npm-launcher.mjs"
       - "scripts/npm-package-inspect.mjs"
       - "scripts/npm-package.mjs"
+      - "scripts/npm-registry-query.mjs"
       - "scripts/package-tarball.sh"
       - "scripts/release-notes.mjs"
       - "scripts/release-publication.mjs"
@@ -283,7 +284,7 @@ jobs:
   npm_install_test:
     name: npm install test (${{ matrix.platform }})
     needs: npm_package
-    if: needs.npm_package.result == 'success'
+    if: always() && needs.npm_package.result == 'success'
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 15
     strategy:
@@ -342,7 +343,17 @@ jobs:
       - uses: actions/setup-node@v7
         with:
           node-version: 22
+      - name: Restore exact Homebrew Formula from an earlier attempt
+        id: restore
+        continue-on-error: true
+        uses: actions/download-artifact@v8
+        with:
+          name: homebrew-formula-${{ github.run_id }}
+          path: formula-output
+          run-id: ${{ github.run_id }}
+          github-token: ${{ github.token }}
       - uses: actions/download-artifact@v8
+        if: steps.restore.outcome == 'failure'
         with:
           pattern: desktop-*-${{ github.run_id }}
           path: dist-packages
@@ -350,26 +361,41 @@ jobs:
           run-id: ${{ github.run_id }}
           github-token: ${{ github.token }}
       - name: Verify native checksums and generate Formula
+        if: steps.restore.outcome == 'failure'
         env:
           VERSION: ${{ steps.version.outputs.version }}
         run: |
+          mkdir -p formula-output
           for platform in linux-x86_64 macos-arm64 macos-x86_64; do
             scripts/verify-desktop-package.sh "$VERSION" "$platform"
           done
-          node scripts/homebrew-checksums.mjs "$VERSION" homebrew-checksums.json
+          node scripts/homebrew-checksums.mjs "$VERSION" formula-output/homebrew-checksums.json
           formula_name="$(node --input-type=module - "$VERSION" <<'NODE'
           import { homebrewFormulaName } from './scripts/homebrew-formula.mjs';
           console.log(homebrewFormulaName(process.argv[2]));
           NODE
           )"
-          node scripts/homebrew-formula.mjs "$VERSION" homebrew-checksums.json "${formula_name}.rb"
-          ruby -c "${formula_name}.rb"
+          node scripts/homebrew-formula.mjs "$VERSION" formula-output/homebrew-checksums.json "formula-output/${formula_name}.rb"
+      - name: Verify restored or newly generated Formula
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          formula_name="$(node --input-type=module - "$VERSION" <<'NODE'
+          import { homebrewFormulaName } from './scripts/homebrew-formula.mjs';
+          console.log(homebrewFormulaName(process.argv[2]));
+          NODE
+          )"
+          formula_file="formula-output/${formula_name}.rb"
+          [[ -f "$formula_file" ]] || { echo "expected Homebrew Formula is missing: $formula_file" >&2; exit 1; }
+          [[ -f formula-output/homebrew-checksums.json ]] || { echo "Homebrew checksum record is missing" >&2; exit 1; }
+          ruby -c "$formula_file"
       - uses: actions/upload-artifact@v7
+        if: steps.restore.outcome == 'failure'
         with:
           name: homebrew-formula-${{ github.run_id }}
           path: |
-            herdr-world*.rb
-            homebrew-checksums.json
+            formula-output/herdr-world*.rb
+            formula-output/homebrew-checksums.json
           if-no-files-found: error
           retention-days: 14
 
@@ -553,15 +579,35 @@ jobs:
           [[ "$VERSION" == *-rc.* ]] && channel="next"
           metadata="npm-output/npm-package-metadata.json"
           integrity="$(node -e 'console.log(JSON.parse(require("fs").readFileSync(process.argv[1])).integrity)' "$metadata")"
-          package_exists=false
-          npm view "$package" name --json >/dev/null 2>&1 && package_exists=true
-          exact_exists=false
+          npm_state() {
+            node scripts/npm-registry-query.mjs state "$@"
+          }
+          npm_present() {
+            node --input-type=module - "$1" <<'NODE'
+          const state = JSON.parse(process.argv[2]);
+          console.log(state.present);
+          NODE
+          }
+          npm_value() {
+            node --input-type=module - "$1" <<'NODE'
+          const state = JSON.parse(process.argv[2]);
+          if (!state.present || !state.raw || state.raw === "null" || state.raw === "undefined") process.exit(0);
+          const value = JSON.parse(state.raw);
+          if (value !== null && value !== undefined) process.stdout.write(String(value));
+          NODE
+          }
+          package_state="$(npm_state view "$package" name --json)"
+          package_exists="$(npm_present "$package_state")"
+          exact_state="$(npm_state view "$package@$version" version --json)"
+          exact_exists="$(npm_present "$exact_state")"
           exact_integrity=""
-          if npm view "$package@$version" version --json >/dev/null 2>&1; then
-            exact_exists=true
-            exact_integrity="$(npm view "$package@$version" dist.integrity --json 2>/dev/null | tr -d '"')"
+          if [[ "$exact_exists" == true ]]; then
+            exact_integrity="$(npm_value "$(npm_state view "$package@$version" dist.integrity --json)")"
           fi
-          pointer="$(npm view "$package" "dist-tags.$channel" --json 2>/dev/null | tr -d '"' || true)"
+          pointer=""
+          if [[ "$package_exists" == true ]]; then
+            pointer="$(npm_value "$(npm_state view "$package" "dist-tags.$channel" --json)")"
+          fi
           if [[ "$package_exists" == false ]]; then
             if [[ "$VERSION" != *-rc.* ]]; then
               echo "The npm package does not exist; only an RC may perform the one-time bootstrap." >&2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -357,13 +357,18 @@ jobs:
             scripts/verify-desktop-package.sh "$VERSION" "$platform"
           done
           node scripts/homebrew-checksums.mjs "$VERSION" homebrew-checksums.json
-          node scripts/homebrew-formula.mjs "$VERSION" homebrew-checksums.json formula.rb
-          ruby -c formula.rb
+          formula_name="$(node --input-type=module - "$VERSION" <<'NODE'
+          import { homebrewFormulaName } from './scripts/homebrew-formula.mjs';
+          console.log(homebrewFormulaName(process.argv[2]));
+          NODE
+          )"
+          node scripts/homebrew-formula.mjs "$VERSION" homebrew-checksums.json "${formula_name}.rb"
+          ruby -c "${formula_name}.rb"
       - uses: actions/upload-artifact@v7
         with:
           name: homebrew-formula-${{ github.run_id }}
           path: |
-            formula.rb
+            herdr-world*.rb
             homebrew-checksums.json
           if-no-files-found: error
           retention-days: 14
@@ -485,20 +490,29 @@ jobs:
           github-token: ${{ github.token }}
       - name: Validate Formula syntax on validation runs
         if: github.event_name != 'push'
-        run: ruby -c formula/formula.rb
+        run: |
+          formula_file="$(find formula -maxdepth 1 -type f \( -name 'herdr-world.rb' -o -name 'herdr-world-rc.rb' \) -print -quit)"
+          [[ -n "$formula_file" ]] || { echo "no channel-specific Formula was downloaded" >&2; exit 1; }
+          ruby -c "$formula_file"
       - name: Install, exercise, reinstall, and uninstall Formula
         if: github.event_name == 'push'
         shell: bash
         run: |
+          formula_file="$(find formula -maxdepth 1 -type f \( -name 'herdr-world.rb' -o -name 'herdr-world-rc.rb' \) -print -quit)"
+          [[ -n "$formula_file" ]] || { echo "no channel-specific Formula was downloaded" >&2; exit 1; }
+          if [[ "$(uname -s)" == "Linux" && -x "/home/linuxbrew/.linuxbrew/bin/brew" ]]; then
+            eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+          fi
           command -v brew >/dev/null || {
             echo "Homebrew is required on the ${{ matrix.platform }} runner for Formula lifecycle validation" >&2
             exit 1
           }
-          brew audit --strict --online formula/formula.rb
-          brew install --formula formula/formula.rb
-          brew test "$(basename formula/formula.rb .rb)"
-          brew reinstall --formula "$(basename formula/formula.rb .rb)"
-          brew uninstall --force "$(basename formula/formula.rb .rb)"
+          formula_name="$(basename "$formula_file" .rb)"
+          brew audit --strict --online "$formula_file"
+          brew install --formula "$formula_file"
+          brew test "$formula_name"
+          brew reinstall --formula "$formula_name"
+          brew uninstall --force "$formula_name"
 
   npm_publish:
     name: Publish npm channel
@@ -630,7 +644,10 @@ jobs:
         env:
           HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
           VERSION: ${{ github.ref_name }}
-        run: scripts/update-homebrew-tap.sh "$VERSION" formula/formula.rb
+        run: |
+          formula_file="$(find formula -maxdepth 1 -type f \( -name 'herdr-world.rb' -o -name 'herdr-world-rc.rb' \) -print -quit)"
+          [[ -n "$formula_file" ]] || { echo "no channel-specific Formula was downloaded" >&2; exit 1; }
+          scripts/update-homebrew-tap.sh "$VERSION" "$formula_file"
       - name: Report Homebrew channel
         env:
           VERSION: ${{ github.ref_name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -544,6 +544,8 @@ jobs:
     name: Publish npm channel
     if: github.event_name == 'push' && github.ref_type == 'tag'
     needs: [provenance, github_release, npm_package, npm_install_test]
+    outputs:
+      publication_result: ${{ steps.complete.outputs.result || steps.state.outputs.result }}
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     permissions:
@@ -620,7 +622,7 @@ jobs:
               echo "After registry verification, configure this workflow as the npm trusted publisher before the next release."
               echo "Artifact: https://github.com/${RELEASE_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
             } >> "$GITHUB_STEP_SUMMARY"
-            echo "result=bootstrap-required" >> "$GITHUB_OUTPUT"
+            echo "result=action-required" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           digest_matches=false
@@ -642,7 +644,7 @@ jobs:
           action="$(node -e 'console.log(JSON.parse(process.argv[1]).action)' "$decision")"
           [[ "$action" != "fail" ]] || { node -e 'console.error(JSON.parse(process.argv[1]).reason)' "$decision"; exit 1; }
       - name: Publish or repair npm channel
-        if: steps.state.outputs.result != 'bootstrap-required'
+        if: steps.state.outputs.result != 'action-required'
         env:
           VERSION: ${{ github.ref_name }}
         shell: bash
@@ -671,6 +673,10 @@ jobs:
           [[ "$registry_integrity" == "$metadata_integrity" ]]
           [[ "$registry_pointer" == "${VERSION#v}" ]]
           echo "npm: $result — https://www.npmjs.com/package/${NPM_PACKAGE_NAME}/v/${VERSION#v}" >> "$GITHUB_STEP_SUMMARY"
+      - name: Mark npm publication complete
+        id: complete
+        if: steps.state.outputs.result != 'action-required'
+        run: echo "result=complete" >> "$GITHUB_OUTPUT"
 
   homebrew_publish:
     name: Publish Homebrew channel
@@ -716,7 +722,7 @@ jobs:
             echo "| Channel | Result |"
             echo "| --- | --- |"
             echo "| GitHub | ${{ needs.github_release.result }} |"
-            echo "| npm (${NPM_PACKAGE_NAME}) | ${{ needs.npm_publish.result }} (bootstrap may be action-required; see job summary) |"
+            echo "| npm (${NPM_PACKAGE_NAME}) | ${{ needs.npm_publish.outputs.publication_result || needs.npm_publish.result }} |"
             echo "| Homebrew (${HOMEBREW_TAP_REPOSITORY}) | ${{ needs.homebrew_publish.result }} |"
             echo "| Herdr plugin | not enabled; Spec 016 remains a separate release tranche |"
             echo

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,13 +1,24 @@
-name: Desktop release
+name: Release distribution
 
 on:
   push:
     tags:
-      - "v[0-9]*"
+      - "v*"
   pull_request:
     paths:
       - ".github/workflows/release.yml"
+      - "scripts/desktop-artifact-metadata.mjs"
+      - "scripts/homebrew-checksums.mjs"
+      - "scripts/homebrew-formula.mjs"
+      - "scripts/npm-launcher.mjs"
+      - "scripts/npm-package-inspect.mjs"
+      - "scripts/npm-package.mjs"
       - "scripts/package-tarball.sh"
+      - "scripts/release-notes.mjs"
+      - "scripts/release-publication.mjs"
+      - "scripts/release-version.mjs"
+      - "scripts/update-homebrew-tap.sh"
+      - "scripts/validate-release.mjs"
       - "scripts/verify-desktop-package.sh"
       - "scripts/live-stock-v082.sh"
       - "scripts/live-bridge-smoke.mjs"
@@ -20,8 +31,7 @@ on:
       - "vendor/**"
       - "web/**"
       - "third_party/**"
-      - "docs/tarball-readme.md"
-      - "docs/world-assets.md"
+      - "docs/**"
       - "package.json"
       - "package-lock.json"
       - "LICENSE"
@@ -32,11 +42,40 @@ on:
 permissions:
   contents: read
 
+# Release tags share one FIFO queue. Validation runs use a separate group so
+# pull requests and manual checks never block or publish a real release.
 concurrency:
-  group: desktop-release-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.event_name == 'push' && 'herdr-world-release-queue' || format('herdr-world-validation-{0}', github.run_id) }}
+  queue: max
+  cancel-in-progress: false
+
+env:
+  RELEASE_REPOSITORY: IvoryHeart/herdr-world
+  NPM_PACKAGE_NAME: '@ivoryheart/herdr-world'
+  HOMEBREW_TAP_REPOSITORY: IvoryHeart/homebrew-tap
 
 jobs:
+  provenance:
+    name: Validate protected release provenance
+    if: github.event_name == 'push' && github.ref_type == 'tag'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - name: Fetch canonical protected main
+        shell: bash
+        run: |
+          git fetch --no-tags origin main:refs/remotes/origin/main
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+      - name: Validate tag, stamped commit, and public references
+        env:
+          GITHUB_SHA: ${{ github.sha }}
+        run: node scripts/validate-release.mjs "$GITHUB_REF_NAME"
+
   notices:
     name: Release notice gate
     runs-on: ubuntu-24.04
@@ -61,9 +100,12 @@ jobs:
       - name: Verify complete desktop dependency notices
         run: npm run notices:check
 
-  package:
+  native:
     name: ${{ matrix.platform }} package and live smoke
-    needs: notices
+    needs: [provenance, notices]
+    if: >-
+      always() && needs.notices.result == 'success' &&
+      (github.event_name != 'push' || needs.provenance.result == 'success')
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 35
     strategy:
@@ -91,13 +133,15 @@ jobs:
         shell: bash
         run: |
           if [[ "$GITHUB_EVENT_NAME" == "push" ]]; then
-            [[ "$GITHUB_REF_TYPE" == "tag" ]]
-            [[ "$(git tag --points-at HEAD --list "$GITHUB_REF_NAME")" == "$GITHUB_REF_NAME" ]]
             version="$GITHUB_REF_NAME"
           else
-            version="v0.0.0-ci.${GITHUB_RUN_ID}.${GITHUB_RUN_ATTEMPT}"
+            version="v0.0.0-rc.${GITHUB_RUN_ID}"
           fi
-          [[ "$version" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]
+          version="$(node --input-type=module - "$version" <<'NODE'
+          import { normalizeReleaseTag } from './scripts/release-version.mjs';
+          console.log(normalizeReleaseTag(process.argv[2]));
+          NODE
+          )"
           echo "version=$version" >> "$GITHUB_OUTPUT"
       - uses: actions/setup-node@v7
         with:
@@ -107,16 +151,32 @@ jobs:
             package-lock.json
             web/package-lock.json
       - uses: dtolnay/rust-toolchain@stable
-      - name: Install dependencies
+      - name: Restore verified native artifact from an earlier attempt
+        id: restore
+        continue-on-error: true
+        uses: actions/download-artifact@v8
+        with:
+          name: desktop-${{ matrix.platform }}-${{ github.run_id }}
+          path: dist-packages
+          run-id: ${{ github.run_id }}
+          github-token: ${{ github.token }}
+      - name: Install dependencies for a new native build
+        if: steps.restore.outcome == 'failure'
         run: |
           npm ci
           npm ci --prefix web
-      - name: Build and inspect native archive
+      - name: Build native archive
+        if: steps.restore.outcome == 'failure'
         env:
           CARGO_TARGET_DIR: ${{ runner.temp }}/herdr-world-cargo
+        run: scripts/package-tarball.sh "${{ steps.version.outputs.version }}" "${{ matrix.platform }}" --notices-verified
+      - name: Verify native archive and record its digests
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
-          scripts/package-tarball.sh "${{ steps.version.outputs.version }}" "${{ matrix.platform }}" --notices-verified
-          scripts/verify-desktop-package.sh "${{ steps.version.outputs.version }}" "${{ matrix.platform }}"
+          scripts/verify-desktop-package.sh "$VERSION" "${{ matrix.platform }}"
+          node scripts/desktop-artifact-metadata.mjs "$VERSION" "${{ matrix.platform }}" \
+            "dist-packages/herdr-world-${VERSION}-${{ matrix.platform }}.metadata.json"
       - name: Download verified stock Herdr v0.8.2
         env:
           HERDR_ASSET: ${{ matrix.herdr_asset }}
@@ -139,68 +199,463 @@ jobs:
           HERDR_WEB_BRIDGE_BIN: ${{ github.workspace }}/dist-packages/herdr-world-${{ steps.version.outputs.version }}-${{ matrix.platform }}/bin/herdr-world-bridge
           HERDR_WEB_STATIC_DIR: ${{ github.workspace }}/dist-packages/herdr-world-${{ steps.version.outputs.version }}-${{ matrix.platform }}/share/herdr-world/web
         run: scripts/live-stock-v082.sh
-      - name: Upload verified desktop archive
+      - name: Retain the verified native artifact
+        if: steps.restore.outcome == 'failure'
         uses: actions/upload-artifact@v7
         with:
-          name: desktop-${{ matrix.platform }}-${{ github.run_id }}-${{ github.run_attempt }}
+          name: desktop-${{ matrix.platform }}-${{ github.run_id }}
           path: |
             dist-packages/herdr-world-${{ steps.version.outputs.version }}-${{ matrix.platform }}.tar.gz
             dist-packages/herdr-world-${{ steps.version.outputs.version }}-${{ matrix.platform }}.tar.gz.sha256
+            dist-packages/herdr-world-${{ steps.version.outputs.version }}-${{ matrix.platform }}.metadata.json
           if-no-files-found: error
           retention-days: 14
 
-  publish:
-    name: Publish desktop assets
-    if: github.event_name == 'push' && github.ref_type == 'tag'
-    needs: package
+  npm_package:
+    name: Assemble exact npm package
+    needs: [provenance, native]
+    if: >-
+      always() && needs.native.result == 'success' &&
+      (github.event_name != 'push' || needs.provenance.result == 'success')
     runs-on: ubuntu-24.04
-    timeout-minutes: 10
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v7
+      - name: Resolve package version
+        id: version
+        shell: bash
+        run: |
+          if [[ "$GITHUB_EVENT_NAME" == "push" ]]; then version="$GITHUB_REF_NAME"; else version="v0.0.0-rc.${GITHUB_RUN_ID}"; fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+      - name: Restore exact npm package from an earlier attempt
+        id: restore
+        continue-on-error: true
+        uses: actions/download-artifact@v8
+        with:
+          name: npm-package-${{ github.run_id }}
+          path: npm-output
+          run-id: ${{ github.run_id }}
+          github-token: ${{ github.token }}
+      - name: Download verified native archives
+        if: steps.restore.outcome == 'failure'
+        uses: actions/download-artifact@v8
+        with:
+          pattern: desktop-*-${{ github.run_id }}
+          path: dist-packages
+          merge-multiple: true
+          run-id: ${{ github.run_id }}
+          github-token: ${{ github.token }}
+      - name: Stage and pack npm package
+        if: steps.restore.outcome == 'failure'
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        shell: bash
+        run: |
+          stage="${RUNNER_TEMP}/herdr-world-npm-stage"
+          mkdir -p npm-output
+          node scripts/npm-package.mjs "$VERSION" "$GITHUB_WORKSPACE/dist-packages" "$stage"
+          npm pack "$stage" --pack-destination npm-output >/dev/null
+          packed="$(find npm-output -maxdepth 1 -type f -name '*.tgz' -print -quit)"
+          [[ -n "$packed" ]]
+          mv "$packed" "npm-output/herdr-world-${VERSION}.tgz"
+          node scripts/npm-package-inspect.mjs \
+            "npm-output/herdr-world-${VERSION}.tgz" "$VERSION" \
+            "npm-output/npm-package-metadata.json"
+      - name: Verify restored or newly packed npm package
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          node scripts/npm-package-inspect.mjs \
+            "npm-output/herdr-world-${VERSION}.tgz" "$VERSION" \
+            "${RUNNER_TEMP}/npm-package-verification.json"
+      - name: Retain exact npm package and publication record
+        if: steps.restore.outcome == 'failure'
+        uses: actions/upload-artifact@v7
+        with:
+          name: npm-package-${{ github.run_id }}
+          path: npm-output
+          if-no-files-found: error
+          retention-days: 14
+
+  npm_install_test:
+    name: npm install test (${{ matrix.platform }})
+    needs: npm_package
+    if: needs.npm_package.result == 'success'
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux-x64
+            runner: ubuntu-24.04
+          - platform: macos-arm64
+            runner: macos-15
+          - platform: macos-x64
+            runner: macos-15-intel
+    steps:
+      - uses: actions/checkout@v7
+      - name: Resolve package version
+        id: version
+        shell: bash
+        run: |
+          if [[ "$GITHUB_EVENT_NAME" == "push" ]]; then version="$GITHUB_REF_NAME"; else version="v0.0.0-rc.${GITHUB_RUN_ID}"; fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22.14.0
+      - uses: actions/download-artifact@v8
+        with:
+          name: npm-package-${{ github.run_id }}
+          path: npm-output
+          run-id: ${{ github.run_id }}
+          github-token: ${{ github.token }}
+      - name: Install the exact package tarball without scripts
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        shell: bash
+        run: |
+          install_root="${RUNNER_TEMP}/herdr-world-npm-install"
+          npm install --ignore-scripts --prefix "$install_root" \
+            "$GITHUB_WORKSPACE/npm-output/herdr-world-${VERSION}.tgz"
+          "$install_root/node_modules/.bin/herdr-world" --help
+
+  formula:
+    name: Generate Homebrew Formula
+    needs: [provenance, native]
+    if: >-
+      always() && needs.native.result == 'success' &&
+      (github.event_name != 'push' || needs.provenance.result == 'success')
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v7
+      - name: Resolve formula version
+        id: version
+        shell: bash
+        run: |
+          if [[ "$GITHUB_EVENT_NAME" == "push" ]]; then version="$GITHUB_REF_NAME"; else version="v0.0.0-rc.${GITHUB_RUN_ID}"; fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+      - uses: actions/download-artifact@v8
+        with:
+          pattern: desktop-*-${{ github.run_id }}
+          path: dist-packages
+          merge-multiple: true
+          run-id: ${{ github.run_id }}
+          github-token: ${{ github.token }}
+      - name: Verify native checksums and generate Formula
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          for platform in linux-x86_64 macos-arm64 macos-x86_64; do
+            scripts/verify-desktop-package.sh "$VERSION" "$platform"
+          done
+          node scripts/homebrew-checksums.mjs "$VERSION" homebrew-checksums.json
+          node scripts/homebrew-formula.mjs "$VERSION" homebrew-checksums.json formula.rb
+          ruby -c formula.rb
+      - uses: actions/upload-artifact@v7
+        with:
+          name: homebrew-formula-${{ github.run_id }}
+          path: |
+            formula.rb
+            homebrew-checksums.json
+          if-no-files-found: error
+          retention-days: 14
+
+  github_release:
+    name: Assemble and publish GitHub release
+    if: github.event_name == 'push' && github.ref_type == 'tag'
+    needs: [provenance, native]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
     permissions:
       contents: write
     steps:
       - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
       - uses: actions/download-artifact@v8
         with:
-          pattern: desktop-*-${{ github.run_id }}-${{ github.run_attempt }}
-          path: release-assets
+          pattern: desktop-*-${{ github.run_id }}
+          path: dist-packages
           merge-multiple: true
-      - name: Verify the complete release set
+          run-id: ${{ github.run_id }}
+          github-token: ${{ github.token }}
+      - name: Verify the complete native release set
         env:
           VERSION: ${{ github.ref_name }}
         run: |
           for platform in linux-x86_64 macos-arm64 macos-x86_64; do
-            mkdir -p "dist-packages"
-            mv "release-assets/herdr-world-${VERSION}-${platform}.tar.gz" "dist-packages/"
-            mv "release-assets/herdr-world-${VERSION}-${platform}.tar.gz.sha256" "dist-packages/"
             scripts/verify-desktop-package.sh "$VERSION" "$platform"
           done
-          [[ "$(find release-assets -type f | wc -l)" -eq 0 ]]
-      - name: Wait for the GitHub release and upload immutable assets
+          node scripts/release-notes.mjs "$VERSION" CHANGELOG.md "${RUNNER_TEMP}/release-notes.md"
+      - name: Create or validate the draft release
         env:
           GH_TOKEN: ${{ github.token }}
           VERSION: ${{ github.ref_name }}
         shell: bash
         run: |
-          for attempt in $(seq 1 30); do
-            if gh release view "$VERSION" --repo IvoryHeart/herdr-world >/dev/null 2>&1; then
-              break
-            fi
-            if [[ "$attempt" -eq 30 ]]; then
-              echo "GitHub release $VERSION was not created within the upload window" >&2
-              exit 1
-            fi
-            sleep 5
-          done
-          if [[ "$(gh release view "$VERSION" --repo IvoryHeart/herdr-world --json tagName --jq .tagName)" != "$VERSION" ]]; then
-            echo "GitHub release does not point at $VERSION" >&2
-            exit 1
+          if ! gh release view "$VERSION" --repo "$RELEASE_REPOSITORY" >/dev/null 2>&1; then
+            args=(release create "$VERSION" --repo "$RELEASE_REPOSITORY" --verify-tag --draft \
+              --title "Herdr World $VERSION" --notes-file "${RUNNER_TEMP}/release-notes.md")
+            if [[ "$VERSION" == *-rc.* ]]; then args+=(--prerelease); fi
+            gh "${args[@]}"
           fi
-          for asset in dist-packages/*; do
-            name="$(basename "$asset")"
-            if gh release view "$VERSION" --repo IvoryHeart/herdr-world \
-              --json assets --jq '.assets[].name' | grep -Fxq "$name"; then
-              echo "refusing to replace existing release asset: $name" >&2
-              exit 1
+          [[ "$(gh release view "$VERSION" --repo "$RELEASE_REPOSITORY" --json tagName --jq .tagName)" == "$VERSION" ]]
+      - name: Upload absent assets and verify existing assets byte-for-byte
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ github.ref_name }}
+        shell: bash
+        run: |
+          expected=(
+            "herdr-world-${VERSION}-linux-x86_64.tar.gz"
+            "herdr-world-${VERSION}-linux-x86_64.tar.gz.sha256"
+            "herdr-world-${VERSION}-macos-arm64.tar.gz"
+            "herdr-world-${VERSION}-macos-arm64.tar.gz.sha256"
+            "herdr-world-${VERSION}-macos-x86_64.tar.gz"
+            "herdr-world-${VERSION}-macos-x86_64.tar.gz.sha256"
+          )
+          existing_dir="${RUNNER_TEMP}/release-existing"
+          mkdir -p "$existing_dir"
+          for name in "${expected[@]}"; do
+            local_file="dist-packages/$name"
+            if gh release view "$VERSION" --repo "$RELEASE_REPOSITORY" --json assets --jq '.assets[].name' | grep -Fxq "$name"; then
+              gh release download "$VERSION" --repo "$RELEASE_REPOSITORY" --pattern "$name" --dir "$existing_dir" --clobber
+              cmp -s "$local_file" "$existing_dir/$name" || {
+                echo "existing GitHub asset differs from the verified artifact: $name" >&2
+                exit 1
+              }
+            else
+              gh release upload "$VERSION" "$local_file" --repo "$RELEASE_REPOSITORY"
             fi
           done
-          gh release upload "$VERSION" dist-packages/* --repo IvoryHeart/herdr-world
+          actual="$(gh release view "$VERSION" --repo "$RELEASE_REPOSITORY" --json assets --jq '.assets[].name' | sort)"
+          expected_text="$(printf '%s\n' "${expected[@]}" | sort)"
+          [[ "$actual" == "$expected_text" ]] || {
+            echo "GitHub release asset set is not exact" >&2
+            diff -u <(printf '%s\n' "$expected_text") <(printf '%s\n' "$actual") >&2 || true
+            exit 1
+          }
+      - name: Publish the complete GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ github.ref_name }}
+        shell: bash
+        run: |
+          args=(release edit "$VERSION" --repo "$RELEASE_REPOSITORY" --draft=false)
+          if [[ "$VERSION" == *-rc.* ]]; then args+=(--prerelease); fi
+          gh "${args[@]}"
+          echo "GitHub: published — https://github.com/${RELEASE_REPOSITORY}/releases/tag/${VERSION}" >> "$GITHUB_STEP_SUMMARY"
+
+  homebrew_test:
+    name: Homebrew Formula test (${{ matrix.platform }})
+    needs: [formula, github_release]
+    if: >-
+      always() && needs.formula.result == 'success' &&
+      (github.event_name != 'push' || needs.github_release.result == 'success')
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux-x86_64
+            runner: ubuntu-24.04
+          - platform: macos-arm64
+            runner: macos-15
+          - platform: macos-x86_64
+            runner: macos-15-intel
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/download-artifact@v8
+        with:
+          name: homebrew-formula-${{ github.run_id }}
+          path: formula
+          run-id: ${{ github.run_id }}
+          github-token: ${{ github.token }}
+      - name: Validate Formula syntax on validation runs
+        if: github.event_name != 'push'
+        run: ruby -c formula/formula.rb
+      - name: Install, exercise, reinstall, and uninstall Formula
+        if: github.event_name == 'push'
+        shell: bash
+        run: |
+          command -v brew >/dev/null || {
+            echo "Homebrew is required on the ${{ matrix.platform }} runner for Formula lifecycle validation" >&2
+            exit 1
+          }
+          brew audit --strict --online formula/formula.rb
+          brew install --formula formula/formula.rb
+          brew test "$(basename formula/formula.rb .rb)"
+          brew reinstall --formula "$(basename formula/formula.rb .rb)"
+          brew uninstall --force "$(basename formula/formula.rb .rb)"
+
+  npm_publish:
+    name: Publish npm channel
+    if: github.event_name == 'push' && github.ref_type == 'tag'
+    needs: [provenance, github_release, npm_package, npm_install_test]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22.14.0
+          registry-url: https://registry.npmjs.org
+          package-manager-cache: false
+      - name: Use the required npm CLI
+        run: |
+          npm install --global npm@11.5.1
+          test "$(node --version | sed 's/^v//' | cut -d. -f1)" -ge 22
+          test "$(npm --version | cut -d. -f1)" -ge 11
+      - uses: actions/download-artifact@v8
+        with:
+          name: npm-package-${{ github.run_id }}
+          path: npm-output
+          run-id: ${{ github.run_id }}
+          github-token: ${{ github.token }}
+      - name: Recheck npm state inside the release mutex
+        id: state
+        env:
+          VERSION: ${{ github.ref_name }}
+        shell: bash
+        run: |
+          package="$NPM_PACKAGE_NAME"
+          version="${VERSION#v}"
+          channel="latest"
+          [[ "$VERSION" == *-rc.* ]] && channel="next"
+          metadata="npm-output/npm-package-metadata.json"
+          integrity="$(node -e 'console.log(JSON.parse(require("fs").readFileSync(process.argv[1])).integrity)' "$metadata")"
+          package_exists=false
+          npm view "$package" name --json >/dev/null 2>&1 && package_exists=true
+          exact_exists=false
+          exact_integrity=""
+          if npm view "$package@$version" version --json >/dev/null 2>&1; then
+            exact_exists=true
+            exact_integrity="$(npm view "$package@$version" dist.integrity --json 2>/dev/null | tr -d '"')"
+          fi
+          pointer="$(npm view "$package" "dist-tags.$channel" --json 2>/dev/null | tr -d '"' || true)"
+          if [[ "$package_exists" == false ]]; then
+            if [[ "$VERSION" != *-rc.* ]]; then
+              echo "The npm package does not exist; only an RC may perform the one-time bootstrap." >&2
+              exit 1
+            fi
+            {
+              echo "### npm"
+              echo "Action required — the first package publication is not automated."
+              echo "Download artifact npm-package-${GITHUB_RUN_ID}, verify SHA-256 and integrity from npm-package-metadata.json, then publish the exact .tgz unchanged with interactive 2FA using the next dist-tag."
+              echo "After registry verification, configure this workflow as the npm trusted publisher before the next release."
+              echo "Artifact: https://github.com/${RELEASE_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+            } >> "$GITHUB_STEP_SUMMARY"
+            echo "result=bootstrap-required" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          digest_matches=false
+          [[ "$exact_integrity" == "$integrity" ]] && digest_matches=true
+          decision="$(node --input-type=module - "$VERSION" "$pointer" "$exact_exists" "$digest_matches" <<'NODE'
+          import { assessPublication } from './scripts/release-publication.mjs';
+          const [candidate, pointer, exactExists, digestMatches] = process.argv.slice(2);
+          const result = assessPublication({
+            candidate,
+            currentVersion: pointer ? `v${pointer}` : null,
+            pointerVersion: pointer ? `v${pointer}` : null,
+            exactVersionExists: exactExists === 'true',
+            exactDigestMatches: digestMatches === 'true',
+          });
+          console.log(JSON.stringify(result));
+          NODE
+          )"
+          echo "decision=$decision" >> "$GITHUB_OUTPUT"
+          action="$(node -e 'console.log(JSON.parse(process.argv[1]).action)' "$decision")"
+          [[ "$action" != "fail" ]] || { node -e 'console.error(JSON.parse(process.argv[1]).reason)' "$decision"; exit 1; }
+      - name: Publish or repair npm channel
+        if: steps.state.outputs.result != 'bootstrap-required'
+        env:
+          VERSION: ${{ github.ref_name }}
+        shell: bash
+        run: |
+          decision='${{ steps.state.outputs.decision }}'
+          action="$(node -e 'console.log(JSON.parse(process.argv[1]).action)' "$decision")"
+          channel="latest"
+          [[ "$VERSION" == *-rc.* ]] && channel="next"
+          case "$action" in
+            complete)
+              result="already complete"
+              ;;
+            publish)
+              npm publish "npm-output/herdr-world-${VERSION}.tgz" --access public --tag "$channel" --provenance
+              result="published"
+              ;;
+            update-pointer)
+              npm dist-tag add "$NPM_PACKAGE_NAME@${VERSION#v}" "$channel"
+              result="pointer repaired"
+              ;;
+            *) echo "unknown npm publication action: $action" >&2; exit 1 ;;
+          esac
+          registry_integrity="$(npm view "$NPM_PACKAGE_NAME@${VERSION#v}" dist.integrity --json | tr -d '"')"
+          registry_pointer="$(npm view "$NPM_PACKAGE_NAME" "dist-tags.$channel" --json | tr -d '"')"
+          metadata_integrity="$(node -e 'console.log(JSON.parse(require("fs").readFileSync(process.argv[1])).integrity)' npm-output/npm-package-metadata.json)"
+          [[ "$registry_integrity" == "$metadata_integrity" ]]
+          [[ "$registry_pointer" == "${VERSION#v}" ]]
+          echo "npm: $result — https://www.npmjs.com/package/${NPM_PACKAGE_NAME}/v/${VERSION#v}" >> "$GITHUB_STEP_SUMMARY"
+
+  homebrew_publish:
+    name: Publish Homebrew channel
+    if: github.event_name == 'push' && github.ref_type == 'tag'
+    needs: [provenance, github_release, formula, homebrew_test]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/download-artifact@v8
+        with:
+          name: homebrew-formula-${{ github.run_id }}
+          path: formula
+          run-id: ${{ github.run_id }}
+          github-token: ${{ github.token }}
+      - name: Commit the validated Formula directly to the tap
+        env:
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          VERSION: ${{ github.ref_name }}
+        run: scripts/update-homebrew-tap.sh "$VERSION" formula/formula.rb
+      - name: Report Homebrew channel
+        env:
+          VERSION: ${{ github.ref_name }}
+        run: |
+          echo "Homebrew: published or already complete — https://github.com/${HOMEBREW_TAP_REPOSITORY}" >> "$GITHUB_STEP_SUMMARY"
+
+  publication_summary:
+    name: Release publication summary
+    if: always() && github.event_name == 'push' && github.ref_type == 'tag'
+    needs: [github_release, npm_publish, homebrew_publish]
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Summarize every channel
+        env:
+          VERSION: ${{ github.ref_name }}
+        run: |
+          {
+            echo "## Herdr World $VERSION distribution"
+            echo
+            echo "| Channel | Result |"
+            echo "| --- | --- |"
+            echo "| GitHub | ${{ needs.github_release.result }} |"
+            echo "| npm (${NPM_PACKAGE_NAME}) | ${{ needs.npm_publish.result }} (bootstrap may be action-required; see job summary) |"
+            echo "| Homebrew (${HOMEBREW_TAP_REPOSITORY}) | ${{ needs.homebrew_publish.result }} |"
+            echo "| Herdr plugin | not enabled; Spec 016 remains a separate release tranche |"
+            echo
+            echo "Source commit: $GITHUB_SHA"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Added
 
+- Added one protected release workflow that assembles exact native artifacts for GitHub, npm, and
+  Homebrew distribution, with platform-aware npm bridge selection and stable/RC Homebrew channels.
 - Added a desktop `install` / `herdr-world-installer` entrypoint that installs the complete
   versioned World bundle for the current user, exposes the `herdr-world` command, and then hands off
   to the consent-based Herdr dependency setup.

--- a/README.md
+++ b/README.md
@@ -527,10 +527,10 @@ that exact protocol rather than attempting to decode older or newer private wire
 
 See [docs/vendoring.md](docs/vendoring.md) for the refresh process.
 
-See [docs/packaging.md](docs/packaging.md) for desktop tarball and APK artifact packaging.
+See [docs/packaging.md](docs/packaging.md) for desktop tarball, npm, Homebrew, and APK artifact packaging.
 
 See [docs/release.md](docs/release.md) for release validation, browser smoke testing, tagging,
-GitHub release creation, and manual artifact upload.
+single-workflow distribution, and the one-time npm bootstrap.
 
 ## Contributing And Support
 

--- a/docs/npm-readme.md
+++ b/docs/npm-readme.md
@@ -1,0 +1,25 @@
+# Herdr World
+
+Herdr World is a browser and mobile client for monitoring and controlling Herdr agents.
+
+## Install
+
+```bash
+npm install --global @ivoryheart/herdr-world
+herdr-world
+```
+
+The package contains the tested Linux x64, macOS ARM64, and macOS x64 bridge binaries and the
+bundled web application. It requires Node.js 22.14.0 or newer and Linux glibc 2.34 or newer.
+Windows, Linux ARM64, musl Linux, and unknown libc environments are not supported.
+
+Package installation only installs files. It does not download or build native code, install Herdr,
+create a workspace, or start a process.
+
+Herdr World still requires a running Herdr 0.8.2 or newer session using terminal protocol 20. Start
+Herdr from the directory containing the work it should manage, then run `herdr-world`. Use
+`herdr-world --help` for bridge options. The bridge binds to loopback by default; Host, Origin, and
+Content Security Policy checks are request protections, not user authentication.
+
+The package includes the complete application legal notices and dependency inventories. The exact
+source release and package checksums are recorded in the corresponding GitHub release workflow.

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -1,10 +1,21 @@
 # Packaging
 
-`herdr-world` ships as separate desktop bridge/web tarballs and an Android APK.
+`herdr-world` ships as desktop bridge/web tarballs, one universal npm package, Homebrew Formulae,
+and an Android APK.
 
 The desktop tarball does not include Herdr itself. Users still need Herdr `v0.8.2` or newer with
 terminal protocol `20`; the packaged launcher can guide an interactive user through consent-based
 installation and startup of the default local session.
+
+The npm package is generated from the exact three verified desktop archives. It includes the web
+assets once and stores the Linux x64, macOS ARM64, and macOS x64 bridges at fixed paths; its launcher
+selects the supported bridge and rejects unsupported libc or architectures before native execution.
+Installation performs no build, download, Herdr setup, workspace mutation, or process start.
+
+Homebrew uses the prebuilt `herdr-world` Formula for stable releases and `herdr-world-rc` for release
+candidates in `IvoryHeart/homebrew-tap`. Each Formula installs the complete bundle privately and
+exposes only the `herdr-world` launcher. The two Formulae conflict so they cannot both provide the
+same command.
 
 ## Release Artifacts
 
@@ -231,11 +242,13 @@ WebSocket.
 
 ## Automated Desktop Publication
 
-`node scripts/release.mjs vX.Y.Z` updates the public version references, pushes the release tag,
-creates the GitHub release, and triggers `.github/workflows/release.yml`. The workflow builds,
-inspects, live-tests, and uploads all six Linux/macOS archive and checksum assets. Existing assets
-are never replaced. The release command also updates the website source, so the same release push
-deploys current links through the Pages workflow.
+`node scripts/release.mjs vX.Y.Z` updates the public version references, pushes the stamped release
+tag, and triggers `.github/workflows/release.yml`. The workflow builds, inspects, live-tests, and
+retains all six Linux/macOS archive and checksum assets, assembles the GitHub release draft, and
+publishes npm and the matching Homebrew channel from the exact tested outputs. Existing public
+content is never replaced. The release command also updates the website source, so the same release
+push deploys current links through the Pages workflow. See [docs/release.md](release.md) for the
+one-time npm bootstrap and required tap secret.
 
 Android remains a deliberate separate step until a signed public APK exists. Do not attach a debug
 APK to a public release as though it were a production artifact.

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,7 +1,9 @@
 # Release Process
 
-`herdr-world` is a public downstream application. Releases create Git tags and GitHub releases.
-They do not publish npm packages, and the package versions are not release versions.
+`herdr-world` is a public downstream application. One tagged release workflow assembles the
+GitHub, npm, and Homebrew distributions from the same verified native artifacts. Root and web
+development manifests remain private at version `0.0.0`; public package versions are derived from
+the release tag.
 
 ## Prerequisites
 
@@ -11,6 +13,11 @@ They do not publish npm packages, and the package versions are not release versi
 - `cargo-about` 0.9.2 (`cargo install cargo-about --version 0.9.2 --locked --features cli`).
 - JDK 21 and Android SDK when validating the Android shell.
 - GitHub CLI authenticated as a user that can create releases.
+- Active repository rulesets protecting `main` and `v*` release tags.
+- The public `IvoryHeart/homebrew-tap` repository and an Actions secret named
+  `HOMEBREW_TAP_TOKEN`, restricted to that repository's Formula contents.
+- After the one-time npm bootstrap: the exact `.github/workflows/release.yml` workflow configured
+  as the npm trusted publisher for `@ivoryheart/herdr-world`.
 - `origin` fetch and push URLs both resolve to `IvoryHeart/herdr-world`. The release helper rejects
   upstream, fork, local-path, and unsupported remote URLs before making any release mutation.
 - A local Herdr `v0.8.2` or newer session reporting terminal protocol `20` for browser and packaged
@@ -35,11 +42,8 @@ npm run check
 
 Do not cut a release without bridge test/build coverage.
 
-If an unannounced prerelease must be replaced under the same tag, first delete its GitHub release
-and local/remote tag, then run `node scripts/release.mjs vX.Y.Z-rc.N --reissue-prerelease`. This
-explicit recovery mode is limited to prereleases whose public version references already match;
-the normal clean-tree, canonical-remote, absent-tag, absent-release, test, commit, and publication
-checks still apply. Never use it to replace a stable release or immutable release assets.
+Corrections use a new release-candidate number. For example, a correction after
+`v1.2.3-rc.2` is `v1.2.3-rc.3`; the existing tag and public package content are never replaced.
 
 ## Package Artifacts
 
@@ -191,14 +195,12 @@ The script:
 - commits `Release vX.Y.Z`
 - tags `vX.Y.Z`
 - pushes `main` and the tag atomically
-- creates a GitHub release with notes extracted from `CHANGELOG.md`
-- passes `--repo IvoryHeart/herdr-world` and `--verify-tag` explicitly when creating the release
 - opens the next `## [Unreleased]` changelog section and pushes it
 
-The tag starts the desktop release workflow. It builds and verifies Linux x86-64, macOS ARM64, and
-macOS x86-64 archives, uploads their checksum files, and fails rather than replacing an asset that
-already exists. The release commit's site changes also trigger the Pages deployment. No separate
-desktop upload or documentation-edit step is required.
+The tag starts the release distribution workflow. It builds and verifies Linux x86-64, macOS ARM64,
+and macOS x86-64 archives, assembles a draft GitHub release, and publishes the enabled npm and
+Homebrew channels from the exact tested outputs. The release commit's site changes also trigger the
+Pages deployment. No separate desktop upload or documentation-edit step is required.
 
 ## Android Validation
 
@@ -207,11 +209,34 @@ Before distributing Android builds, follow [docs/android.md](android.md): run
 bridge started using `--allow-origin http://localhost`. Revisit the Android backup policy before
 adding any pairing token or other secret storage.
 
-## Automated Publication
+## One-time npm bootstrap and external setup
 
-After the tag is pushed, monitor both `Desktop release` and `Deploy GitHub Pages`. The desktop
-workflow attaches exactly three native archives and three checksum files. It does not publish npm,
-an Android debug APK, or any unsigned artifact represented as production-signed software.
+The first npm publication must be a release candidate. The protected workflow generates and
+install-tests the exact package tarball, then reports it as an action-required artifact because npm
+trusted publishing cannot be configured until the package exists.
+
+1. Download `npm-package-${RUN_ID}` from the tagged workflow.
+2. Verify its SHA-256 and npm integrity against `npm-package-metadata.json`.
+3. Publish that exact `.tgz` unchanged with interactive 2FA and the `next` dist-tag:
+
+```bash
+npm publish herdr-world-vX.Y.Z-rc.N.tgz --access public --tag next
+```
+
+4. In npm package settings, configure GitHub Actions trusted publishing for user `IvoryHeart`,
+   repository `herdr-world`, workflow `.github/workflows/release.yml`, allowing `npm publish`.
+5. Verify the registry version and integrity, then enable two-factor authentication for writes and
+   disallow traditional publishing tokens. Later tagged releases publish through OIDC and require
+   no `NPM_TOKEN`.
+
+Create the tap-scoped fine-grained GitHub token manually and save it as the repository Actions secret
+`HOMEBREW_TAP_TOKEN`. It needs only Contents read/write access to `IvoryHeart/homebrew-tap`; it must
+not be written to a Formula, artifact, cache, or log. The workflow validates and exercises the
+Formula on all three supported native runners before committing directly to the tap's default branch.
+
+After the tag is pushed, monitor `Release distribution` and `Deploy GitHub Pages`. The release
+workflow reports GitHub, npm, and Homebrew results separately. It does not publish Android debug
+builds or unsigned artifacts as production-signed software.
 
 ## After
 

--- a/docs/specs/017-herdr-world-automated-release-distribution-spec.md
+++ b/docs/specs/017-herdr-world-automated-release-distribution-spec.md
@@ -1,12 +1,12 @@
 # Herdr World automated release distribution
 
 - **Spec ID:** `017-herdr-world-automated-release-distribution`
-- **Status:** In review
+- **Status:** Approved
 - **Created:** 2026-08-28
 - **Owner:** IvoryHeart / Herdr World
 - **Reviewers:** IvoryHeart
-- **Approved by:** —
-- **Approved at:** —
+- **Approved by:** IvoryHeart
+- **Approved at:** 2026-08-28
 - **Supersedes:** all earlier drafts of Spec 017
 
 ## Purpose

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "notices:generate": "node scripts/dependency-notices.mjs --generate",
     "notices:check": "node scripts/dependency-notices.mjs --check",
     "test:dev": "node --test scripts/dev.test.mjs",
-    "test:release": "node --test scripts/release-target.test.mjs scripts/release-version.test.mjs scripts/herdr-world-installer.test.mjs scripts/herdr-world-launcher.test.mjs",
+    "test:release": "node --test scripts/release-target.test.mjs scripts/release-version.test.mjs scripts/release-publication.test.mjs scripts/npm-launcher.test.mjs scripts/homebrew-formula.test.mjs scripts/herdr-world-installer.test.mjs scripts/herdr-world-launcher.test.mjs",
     "test:pages": "node --test scripts/pages.test.mjs",
     "test:web": "npm run test --prefix web",
     "test:observability": "npm run test --prefix web -- observability.test.ts && cargo test --manifest-path bridge/Cargo.toml --bin herdr-web-bridge observability",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "notices:generate": "node scripts/dependency-notices.mjs --generate",
     "notices:check": "node scripts/dependency-notices.mjs --check",
     "test:dev": "node --test scripts/dev.test.mjs",
-    "test:release": "node --test scripts/release-target.test.mjs scripts/release-version.test.mjs scripts/release-publication.test.mjs scripts/npm-launcher.test.mjs scripts/homebrew-formula.test.mjs scripts/herdr-world-installer.test.mjs scripts/herdr-world-launcher.test.mjs",
+    "test:release": "node --test scripts/release-target.test.mjs scripts/release-version.test.mjs scripts/release-publication.test.mjs scripts/npm-launcher.test.mjs scripts/npm-registry-query.test.mjs scripts/homebrew-formula.test.mjs scripts/herdr-world-installer.test.mjs scripts/herdr-world-launcher.test.mjs",
     "test:pages": "node --test scripts/pages.test.mjs",
     "test:web": "npm run test --prefix web",
     "test:observability": "npm run test --prefix web -- observability.test.ts && cargo test --manifest-path bridge/Cargo.toml --bin herdr-web-bridge observability",

--- a/scripts/desktop-artifact-metadata.mjs
+++ b/scripts/desktop-artifact-metadata.mjs
@@ -1,14 +1,52 @@
 #!/usr/bin/env node
 import { createHash } from "node:crypto";
 import { execFileSync } from "node:child_process";
-import { readFileSync, writeFileSync } from "node:fs";
+import {
+  closeSync,
+  createReadStream,
+  mkdtempSync,
+  openSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 function digest(bytes) {
   return createHash("sha256").update(bytes).digest("hex");
 }
-export function recordDesktopArtifact({ root = process.cwd(), tag, platform, outputPath, sourceCommit = process.env.GITHUB_SHA ?? "unknown" }) {
+
+function digestFile(path) {
+  return new Promise((resolveDigest, reject) => {
+    const hash = createHash("sha256");
+    const stream = createReadStream(path);
+    stream.on("data", (chunk) => hash.update(chunk));
+    stream.on("error", reject);
+    stream.on("end", () => resolveDigest(hash.digest("hex")));
+  });
+}
+
+async function digestArchiveMember(archive, member) {
+  const extractionRoot = mkdtempSync(join(tmpdir(), "herdr-world-metadata-"));
+  const extractedPath = join(extractionRoot, "member");
+  let outputFd;
+  try {
+    outputFd = openSync(extractedPath, "w");
+    execFileSync("tar", ["-xOf", archive, member], {
+      stdio: ["ignore", outputFd, "pipe"],
+    });
+    closeSync(outputFd);
+    outputFd = undefined;
+    return await digestFile(extractedPath);
+  } finally {
+    if (outputFd !== undefined) closeSync(outputFd);
+    rmSync(extractionRoot, { recursive: true, force: true });
+  }
+}
+
+export async function recordDesktopArtifact({ root = process.cwd(), tag, platform, outputPath, sourceCommit = process.env.GITHUB_SHA ?? "unknown" }) {
   const name = `herdr-world-${tag}-${platform}`;
   const archive = join(root, "dist-packages", `${name}.tar.gz`);
   const checksumFile = `${archive}.sha256`;
@@ -17,9 +55,9 @@ export function recordDesktopArtifact({ root = process.cwd(), tag, platform, out
   if (archiveDigest !== expectedArchiveDigest) {
     throw new Error(`archive checksum does not match its checksum file: ${archive}`);
   }
-  const bridge = execFileSync(
-    "tar",
-    ["-xOf", archive, `${name}/bin/herdr-world-bridge`],
+  const bridgeDigest = await digestArchiveMember(
+    archive,
+    `${name}/bin/herdr-world-bridge`,
   );
   const metadata = {
     schema_version: 1,
@@ -28,7 +66,7 @@ export function recordDesktopArtifact({ root = process.cwd(), tag, platform, out
     platform,
     archive: `${name}.tar.gz`,
     archive_sha256: archiveDigest,
-    bridge_sha256: digest(bridge),
+    bridge_sha256: bridgeDigest,
   };
   writeFileSync(outputPath, `${JSON.stringify(metadata, null, 2)}\n`);
   return metadata;
@@ -41,7 +79,7 @@ if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.ur
     process.exit(2);
   }
   try {
-    console.log(JSON.stringify(recordDesktopArtifact({ tag, platform, outputPath })));
+    console.log(JSON.stringify(await recordDesktopArtifact({ tag, platform, outputPath })));
   } catch (error) {
     console.error(error.message);
     process.exit(1);

--- a/scripts/desktop-artifact-metadata.mjs
+++ b/scripts/desktop-artifact-metadata.mjs
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+import { createHash } from "node:crypto";
+import { execFileSync } from "node:child_process";
+import { readFileSync, writeFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+function digest(bytes) {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+export function recordDesktopArtifact({ root = process.cwd(), tag, platform, outputPath, sourceCommit = process.env.GITHUB_SHA ?? "unknown" }) {
+  const name = `herdr-world-${tag}-${platform}`;
+  const archive = join(root, "dist-packages", `${name}.tar.gz`);
+  const checksumFile = `${archive}.sha256`;
+  const expectedArchiveDigest = readFileSync(checksumFile, "utf8").trim().split(/\s+/)[0];
+  const archiveDigest = digest(readFileSync(archive));
+  if (archiveDigest !== expectedArchiveDigest) {
+    throw new Error(`archive checksum does not match its checksum file: ${archive}`);
+  }
+  const bridge = execFileSync(
+    "tar",
+    ["-xOf", archive, `${name}/bin/herdr-world-bridge`],
+  );
+  const metadata = {
+    schema_version: 1,
+    source_tag: tag,
+    source_commit: sourceCommit,
+    platform,
+    archive: `${name}.tar.gz`,
+    archive_sha256: archiveDigest,
+    bridge_sha256: digest(bridge),
+  };
+  writeFileSync(outputPath, `${JSON.stringify(metadata, null, 2)}\n`);
+  return metadata;
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  const [tag, platform, outputPath] = process.argv.slice(2);
+  if (!tag || !platform || !outputPath) {
+    console.error("Usage: node scripts/desktop-artifact-metadata.mjs TAG PLATFORM OUTPUT_JSON");
+    process.exit(2);
+  }
+  try {
+    console.log(JSON.stringify(recordDesktopArtifact({ tag, platform, outputPath })));
+  } catch (error) {
+    console.error(error.message);
+    process.exit(1);
+  }
+}

--- a/scripts/herdr-world-installer.test.mjs
+++ b/scripts/herdr-world-installer.test.mjs
@@ -93,10 +93,8 @@ test("the bundle installer creates versioned commands and the installed launcher
       env,
     });
     assert.equal(launch.status, 0, launch.stderr);
-    assert.equal(
-      launch.stdout,
-      `<--static-dir>\n<${join(installTarget, "share/herdr-world/web")}>\n<--help>\n`,
-    );
+    assert.match(launch.stdout, /Usage: herdr-world/);
+    assert.doesNotMatch(launch.stdout, /static-dir/);
 
     writeFileSync(join(bundle, "share/herdr-world/web/index.html"), "updated\n");
     const reinstall = spawnSync("/bin/bash", [join(bundle, "install"), "--install-only"], {
@@ -135,12 +133,7 @@ test("the installer can hand off directly to the installed application command",
 
     assert.equal(result.status, 0, result.stderr);
     assert.match(result.stderr, /Continuing with Herdr dependency setup/);
-    assert.equal(
-      result.stdout.endsWith(
-        `<--static-dir>\n<${join(installTarget, "share/herdr-world/web")}>\n<--help>\n`,
-      ),
-      true,
-    );
+    assert.match(result.stdout, /Usage: herdr-world/);
   } finally {
     rmSync(testRoot, { recursive: true, force: true });
   }

--- a/scripts/herdr-world-launcher.sh
+++ b/scripts/herdr-world-launcher.sh
@@ -21,8 +21,8 @@ herdr_world_resolve_script() {
 LAUNCHER_PATH="$(herdr_world_resolve_script "${BASH_SOURCE[0]}")"
 BIN_DIR="$(cd "$(dirname "$LAUNCHER_PATH")" && pwd)"
 BUNDLE_ROOT="$(cd "$BIN_DIR/.." && pwd)"
-BRIDGE_BIN="$BIN_DIR/herdr-world-bridge"
-STATIC_DIR="$BUNDLE_ROOT/share/herdr-world/web"
+BRIDGE_BIN="${HERDR_WORLD_BRIDGE_BIN:-$BIN_DIR/herdr-world-bridge}"
+STATIC_DIR="${HERDR_WORLD_STATIC_DIR:-$BUNDLE_ROOT/share/herdr-world/web}"
 
 HERDR_INSTALLER_URL="https://herdr.dev/install.sh"
 HERDR_INSTALL_DOCS_URL="https://herdr.dev/docs/install/"
@@ -169,6 +169,23 @@ Then start it from the directory containing the work you want Herdr to manage:
 
 Detach from Herdr with Ctrl+B, then Q, and run herdr-world again
 (or bin/herdr-world from a portable bundle).
+EOF
+}
+
+herdr_world_help() {
+  cat <<'EOF'
+Usage: herdr-world [OPTIONS]
+
+Starts the Herdr World browser bridge for the selected Herdr session.
+
+Options are forwarded to the bridge:
+  --host HOST                 Bind address (loopback by default)
+  --port PORT                 HTTP port (8787 by default)
+  --session NAME              Select a named Herdr session
+  --no-herdr-setup            Disable interactive Herdr setup
+  -h, --help                  Show this help without starting Herdr or a bridge
+
+The bridge requires Herdr 0.8.2 or newer with terminal protocol 20.
 EOF
 }
 
@@ -367,7 +384,7 @@ herdr_world_main() {
   for arg in "${bridge_args[@]+"${bridge_args[@]}"}"; do
     case "$arg" in
       -h | --help)
-        herdr_world_exec_bridge "${bridge_args[@]+"${bridge_args[@]}"}"
+        herdr_world_help
         return
         ;;
     esac

--- a/scripts/herdr-world-launcher.test.mjs
+++ b/scripts/herdr-world-launcher.test.mjs
@@ -52,7 +52,17 @@ herdr_world_main --port 8791
 });
 
 test("help and explicit connection targets never trigger guided setup", () => {
-  for (const args of ["--help", "--session work --port 8791"]) {
+  const help = runLauncher(`
+herdr_world_default_socket() { echo 'unexpected socket lookup' >&2; return 1; }
+herdr_world_exec_bridge() { echo 'unexpected bridge start' >&2; }
+herdr_world_main --help
+  `);
+  assert.equal(help.status, 0);
+  assert.match(help.stdout, /Usage: herdr-world/);
+  assert.doesNotMatch(help.stdout, /unexpected bridge start/);
+  assert.doesNotMatch(help.stderr, /unexpected socket lookup|unexpected bridge start/);
+
+  for (const args of ["--session work --port 8791"]) {
     const result = runLauncher(`
 herdr_world_default_socket() { echo 'unexpected socket lookup' >&2; return 1; }
 herdr_world_exec_bridge() { printf 'bridge'; printf ' <%s>' "$@"; printf '\\n'; }

--- a/scripts/homebrew-checksums.mjs
+++ b/scripts/homebrew-checksums.mjs
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+import { readFileSync, writeFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export const HOMEBREW_ARCHIVE_TARGETS = ["linux-x86_64", "macos-arm64", "macos-x86_64"];
+
+export function readDesktopChecksums({ root = process.cwd(), tag }) {
+  const result = {};
+  for (const platform of HOMEBREW_ARCHIVE_TARGETS) {
+    const checksumPath = join(root, "dist-packages", `herdr-world-${tag}-${platform}.tar.gz.sha256`);
+    const value = readFileSync(checksumPath, "utf8").trim().split(/\s+/)[0];
+    if (!/^[a-f0-9]{64}$/.test(value)) {
+      throw new Error(`invalid desktop archive checksum for ${platform}`);
+    }
+    result[platform] = value;
+  }
+  return result;
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  const [tag, outputPath] = process.argv.slice(2);
+  if (!tag || !outputPath) {
+    console.error("Usage: node scripts/homebrew-checksums.mjs TAG OUTPUT_JSON");
+    process.exit(2);
+  }
+  try {
+    const checksums = readDesktopChecksums({ tag });
+    writeFileSync(outputPath, `${JSON.stringify(checksums, null, 2)}\n`);
+    console.log(JSON.stringify(checksums));
+  } catch (error) {
+    console.error(error.message);
+    process.exit(1);
+  }
+}

--- a/scripts/homebrew-formula.mjs
+++ b/scripts/homebrew-formula.mjs
@@ -57,9 +57,9 @@ export function renderHomebrewFormula({ tag, checksums }) {
   conflicts_with "${otherFormula}", because: "both Formulae provide the herdr-world command"
 
   def install
-    bundle = Dir["herdr-world-v#{version}-*"]
-    odie "Herdr World archive root is missing" if bundle.empty?
-    libexec.install Dir["#{bundle.first}/*"]
+    libexec.install "VERSION", "bin", "share", "docs", "vendor",
+      "third_party", "LICENSE", "THIRD_PARTY_NOTICES.md", "UPSTREAM.md",
+      "README.md", "install"
     bin.install_symlink libexec/"bin/herdr-world"
   end
 

--- a/scripts/homebrew-formula.mjs
+++ b/scripts/homebrew-formula.mjs
@@ -1,0 +1,90 @@
+#!/usr/bin/env node
+import { readFileSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { normalizeReleaseTag, releaseVersion } from "./release-version.mjs";
+
+export function homebrewFormulaName(tag) {
+  return normalizeReleaseTag(tag).includes("-rc.") ? "herdr-world-rc" : "herdr-world";
+}
+
+function archiveUrl(tag, platform) {
+  const normalizedTag = normalizeReleaseTag(tag);
+  return `https://github.com/IvoryHeart/herdr-world/releases/download/${normalizedTag}/herdr-world-${normalizedTag}-${platform}.tar.gz`;
+}
+
+export function renderHomebrewFormula({ tag, checksums }) {
+  const normalizedTag = normalizeReleaseTag(tag);
+  const version = releaseVersion(normalizedTag);
+  const formulaName = homebrewFormulaName(normalizedTag);
+  const className = formulaName
+    .split("-")
+    .map((part) => part[0].toUpperCase() + part.slice(1))
+    .join("");
+  const otherFormula = formulaName === "herdr-world" ? "herdr-world-rc" : "herdr-world";
+  const checksum = (platform) => {
+    const value = checksums?.[platform];
+    if (!/^[a-f0-9]{64}$/.test(value ?? "")) {
+      throw new Error(`missing SHA-256 for Homebrew target ${platform}`);
+    }
+    return value;
+  };
+
+  return `class ${className} < Formula
+  desc "Browser and mobile client for monitoring and controlling Herdr agents"
+  homepage "https://ivoryheart.github.io/herdr-world/"
+  version "${version}"
+
+  on_macos do
+    on_arm do
+      url "${archiveUrl(normalizedTag, "macos-arm64")}"
+      sha256 "${checksum("macos-arm64")}"
+    end
+    on_intel do
+      url "${archiveUrl(normalizedTag, "macos-x86_64")}"
+      sha256 "${checksum("macos-x86_64")}"
+    end
+  end
+
+  on_linux do
+    on_intel do
+      url "${archiveUrl(normalizedTag, "linux-x86_64")}"
+      sha256 "${checksum("linux-x86_64")}"
+    end
+  end
+
+  conflicts_with "${otherFormula}", because: "both Formulae provide the herdr-world command"
+
+  def install
+    bundle = Dir["herdr-world-v#{version}-*"]
+    odie "Herdr World archive root is missing" if bundle.empty?
+    libexec.install Dir["#{bundle.first}/*"]
+    bin.install_symlink libexec/"bin/herdr-world"
+  end
+
+  test do
+    system bin/"herdr-world", "--help"
+  end
+end
+`;
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  const [tag, checksumsPath, outputPath] = process.argv.slice(2);
+  if (!tag || !checksumsPath || !outputPath) {
+    console.error("Usage: node scripts/homebrew-formula.mjs TAG CHECKSUMS_JSON OUTPUT_RB");
+    process.exit(2);
+  }
+  try {
+    const formula = renderHomebrewFormula({
+      tag,
+      checksums: JSON.parse(readFileSync(checksumsPath, "utf8")),
+    });
+    writeFileSync(outputPath, formula);
+    console.log(`Generated ${homebrewFormulaName(tag)} at ${outputPath}`);
+  } catch (error) {
+    console.error(error.message);
+    process.exit(1);
+  }
+}

--- a/scripts/homebrew-formula.test.mjs
+++ b/scripts/homebrew-formula.test.mjs
@@ -20,6 +20,7 @@ test("generates the stable Formula from exact release archives", () => {
   assert.match(formula, /herdr-world-v1\.2\.3-linux-x86_64\.tar\.gz/);
   assert.match(formula, /sha256 "111111/);
   assert.match(formula, /conflicts_with "herdr-world-rc"/);
+  assert.match(formula, /libexec\.install "VERSION", "bin", "share"/);
   assert.doesNotMatch(formula, /herdr-world-installer/);
 });
 test("generates the RC Formula without advancing stable", () => {

--- a/scripts/homebrew-formula.test.mjs
+++ b/scripts/homebrew-formula.test.mjs
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  homebrewFormulaName,
+  renderHomebrewFormula,
+} from "./homebrew-formula.mjs";
+
+const checksums = {
+  "linux-x86_64": "1".repeat(64),
+  "macos-arm64": "2".repeat(64),
+  "macos-x86_64": "3".repeat(64),
+};
+
+test("generates the stable Formula from exact release archives", () => {
+  const formula = renderHomebrewFormula({ tag: "v1.2.3", checksums });
+  assert.equal(homebrewFormulaName("v1.2.3"), "herdr-world");
+  assert.match(formula, /class HerdrWorld < Formula/);
+  assert.match(formula, /version "1\.2\.3"/);
+  assert.match(formula, /herdr-world-v1\.2\.3-linux-x86_64\.tar\.gz/);
+  assert.match(formula, /sha256 "111111/);
+  assert.match(formula, /conflicts_with "herdr-world-rc"/);
+  assert.doesNotMatch(formula, /herdr-world-installer/);
+});
+test("generates the RC Formula without advancing stable", () => {
+  const formula = renderHomebrewFormula({ tag: "v1.2.3-rc.2", checksums });
+  assert.equal(homebrewFormulaName("v1.2.3-rc.2"), "herdr-world-rc");
+  assert.match(formula, /class HerdrWorldRc < Formula/);
+  assert.match(formula, /version "1\.2\.3-rc\.2"/);
+  assert.match(formula, /conflicts_with "herdr-world"/);
+});
+
+test("requires every native archive checksum", () => {
+  assert.throws(
+    () => renderHomebrewFormula({ tag: "v1.2.3", checksums: {} }),
+    /missing SHA-256 for Homebrew target macos-arm64/,
+  );
+});

--- a/scripts/npm-launcher.mjs
+++ b/scripts/npm-launcher.mjs
@@ -91,8 +91,11 @@ export function runPackageLauncher(args = process.argv.slice(2), {
     stdio: "inherit",
   });
 
+  const signalHandlers = new Map();
   for (const signal of ["SIGINT", "SIGTERM", "SIGHUP"]) {
-    process.on(signal, () => child.kill(signal));
+    const handler = () => child.kill(signal);
+    signalHandlers.set(signal, handler);
+    process.on(signal, handler);
   }
   child.once("error", (error) => {
     console.error(`could not start Herdr World: ${error.message}`);
@@ -100,6 +103,9 @@ export function runPackageLauncher(args = process.argv.slice(2), {
   });
   child.once("exit", (code, signal) => {
     if (signal) {
+      for (const [forwardedSignal, handler] of signalHandlers) {
+        process.removeListener(forwardedSignal, handler);
+      }
       process.kill(process.pid, signal);
     } else {
       process.exitCode = code ?? 1;

--- a/scripts/npm-launcher.mjs
+++ b/scripts/npm-launcher.mjs
@@ -1,0 +1,122 @@
+#!/usr/bin/env node
+import { spawn } from "node:child_process";
+import { realpathSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join, resolve } from "node:path";
+
+export const SUPPORTED_PLATFORMS = {
+  "linux-x64": "linux-x64",
+  "darwin-arm64": "macos-arm64",
+  "darwin-x64": "macos-x64",
+};
+
+export function parseGlibcVersion(value) {
+  const match = typeof value === "string" ? value.match(/^(\d+)\.(\d+)$/) : null;
+  return match ? { major: Number(match[1]), minor: Number(match[2]) } : null;
+}
+
+function compareVersions(left, right) {
+  if (left.major !== right.major) return left.major - right.major;
+  return left.minor - right.minor;
+}
+
+export function selectBridge({
+  platform = process.platform,
+  arch = process.arch,
+  report = process.report,
+} = {}) {
+  const key = `${platform}-${arch}`;
+  const target = SUPPORTED_PLATFORMS[key];
+  if (!target) {
+    throw new Error(`Herdr World does not support this platform or architecture: ${key}`);
+  }
+
+  if (platform !== "linux") return target;
+
+  const glibcValue = report?.getReport?.().header?.glibcVersionRuntime;
+  if (typeof glibcValue !== "string") {
+    throw new Error("Herdr World requires a detectable glibc runtime on Linux; musl or unknown libc is unsupported");
+  }
+  const glibc = parseGlibcVersion(glibcValue);
+  if (!glibc) {
+    throw new Error(`Herdr World could not parse the Linux glibc version: ${glibcValue}`);
+  }
+  if (compareVersions(glibc, { major: 2, minor: 34 }) < 0) {
+    throw new Error(`Herdr World requires glibc 2.34 or newer; found ${glibcValue}`);
+  }
+  return target;
+}
+
+export function packageHelp() {
+  return `Usage: herdr-world [OPTIONS]
+
+Starts the Herdr World browser bridge for the selected Herdr session.
+
+Options are forwarded to the bridge:
+  --host HOST                 Bind address (loopback by default)
+  --port PORT                 HTTP port (8787 by default)
+  --session NAME              Select a named Herdr session
+  --no-herdr-setup            Disable interactive Herdr setup
+  -h, --help                  Show this help without starting Herdr or a bridge
+
+The bridge requires Herdr 0.8.2 or newer with terminal protocol 20.
+`;
+}
+
+export function isHelpRequest(args) {
+  return args.includes("-h") || args.includes("--help");
+}
+
+export function runPackageLauncher(args = process.argv.slice(2), {
+  platform = process.platform,
+  arch = process.arch,
+  report = process.report,
+  packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), ".."),
+} = {}) {
+  if (isHelpRequest(args)) {
+    process.stdout.write(packageHelp());
+    return null;
+  }
+
+  const target = selectBridge({ platform, arch, report });
+  const bridge = join(packageRoot, "lib", "bridges", target, "herdr-world-bridge");
+  const launcher = join(packageRoot, "lib", "herdr-world-launcher.sh");
+  const staticDir = join(packageRoot, "share", "herdr-world", "web");
+  const child = spawn("/bin/bash", [launcher, ...args], {
+    env: {
+      ...process.env,
+      HERDR_WORLD_BRIDGE_BIN: bridge,
+      HERDR_WORLD_STATIC_DIR: staticDir,
+    },
+    stdio: "inherit",
+  });
+
+  for (const signal of ["SIGINT", "SIGTERM", "SIGHUP"]) {
+    process.on(signal, () => child.kill(signal));
+  }
+  child.once("error", (error) => {
+    console.error(`could not start Herdr World: ${error.message}`);
+    process.exitCode = 1;
+  });
+  child.once("exit", (code, signal) => {
+    if (signal) {
+      process.kill(process.pid, signal);
+    } else {
+      process.exitCode = code ?? 1;
+    }
+  });
+  return child;
+}
+
+if (
+  process.argv[1] &&
+  realpathSync(resolve(process.argv[1])) === realpathSync(fileURLToPath(import.meta.url))
+) {
+  try {
+    const result = runPackageLauncher();
+    if (!result) process.exit(0);
+  } catch (error) {
+    console.error(error.message);
+    process.exit(1);
+  }
+}

--- a/scripts/npm-launcher.test.mjs
+++ b/scripts/npm-launcher.test.mjs
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import test from "node:test";
+
+import {
+  parseGlibcVersion,
+  selectBridge,
+} from "./npm-launcher.mjs";
+
+test("selects the supported bridge for each release target", () => {
+  assert.equal(
+    selectBridge({ platform: "linux", arch: "x64", report: { getReport: () => ({ header: { glibcVersionRuntime: "2.34" } }) } }),
+    "linux-x64",
+  );
+  assert.equal(selectBridge({ platform: "darwin", arch: "arm64" }), "macos-arm64");
+  assert.equal(selectBridge({ platform: "darwin", arch: "x64" }), "macos-x64");
+});
+
+test("rejects unsupported libc and host combinations before execution", () => {
+  assert.throws(
+    () => selectBridge({ platform: "linux", arch: "x64", report: { getReport: () => ({ header: {} }) } }),
+    /glibc runtime/,
+  );
+  assert.throws(
+    () => selectBridge({ platform: "linux", arch: "x64", report: { getReport: () => ({ header: { glibcVersionRuntime: "2.33" } }) } }),
+    /requires glibc 2\.34/,
+  );
+  assert.throws(
+    () => selectBridge({ platform: "linux", arch: "arm64" }),
+    /does not support this platform/,
+  );
+  assert.deepEqual(parseGlibcVersion("2.34"), { major: 2, minor: 34 });
+  assert.equal(parseGlibcVersion("musl"), null);
+});
+
+test("help succeeds without starting a bridge process", () => {
+  const output = execFileSync(process.execPath, ["scripts/npm-launcher.mjs", "--help"], {
+    encoding: "utf8",
+  });
+  assert.match(output, /Usage: herdr-world/);
+});

--- a/scripts/npm-package-inspect.mjs
+++ b/scripts/npm-package-inspect.mjs
@@ -1,0 +1,105 @@
+#!/usr/bin/env node
+import { createHash } from "node:crypto";
+import { execFileSync } from "node:child_process";
+import { readFileSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { normalizeReleaseTag, releaseVersion } from "./release-version.mjs";
+
+function tarEntries(tarball) {
+  return execFileSync("tar", ["-tzf", tarball], { encoding: "utf8" })
+    .trim()
+    .split("\n")
+    .filter(Boolean);
+}
+function tarFile(tarball, path) {
+  return execFileSync("tar", ["-xOf", tarball, path], { encoding: "utf8" });
+}
+
+export function inspectNpmPackage({ tarball, tag, sourceCommit = process.env.GITHUB_SHA ?? "unknown" }) {
+  const normalizedTag = normalizeReleaseTag(tag);
+  const entries = tarEntries(tarball);
+  for (const entry of entries) {
+    if (!entry.startsWith("package/") || entry.includes("../") || entry.startsWith("/")) {
+      throw new Error(`npm tarball contains an unsafe or unexpected entry: ${entry}`);
+    }
+  }
+
+  const packageJson = JSON.parse(tarFile(tarball, "package/package.json"));
+  if (packageJson.name !== "@ivoryheart/herdr-world") {
+    throw new Error(`unexpected npm package name: ${packageJson.name}`);
+  }
+  if (packageJson.version !== releaseVersion(normalizedTag)) {
+    throw new Error(`npm package version does not match ${normalizedTag}`);
+  }
+  if (packageJson.private === true || packageJson.publishConfig?.access !== "public") {
+    throw new Error("npm package must be public and publishable");
+  }
+  if (packageJson.engines?.node !== ">=22.14.0") {
+    throw new Error("npm package must require Node.js 22.14.0 or newer");
+  }
+  if (JSON.stringify(packageJson.bin) !== JSON.stringify({ "herdr-world": "bin/herdr-world" })) {
+    throw new Error("npm package must expose only the herdr-world command");
+  }
+
+  const relativeEntries = entries
+    .map((entry) => entry.slice("package/".length))
+    .filter((entry) => entry && !entry.endsWith("/"))
+    .sort();
+  const forbidden = relativeEntries.filter((entry) =>
+    ["install", "bin/herdr-world-installer", "package-lock.json", ".npmrc"].includes(entry),
+  );
+  if (forbidden.length > 0) {
+    throw new Error(`npm package contains forbidden files: ${forbidden.join(", ")}`);
+  }
+
+  for (const target of ["linux-x64", "macos-arm64", "macos-x64"]) {
+    if (!relativeEntries.includes(`lib/bridges/${target}/herdr-world-bridge`)) {
+      throw new Error(`npm package is missing the ${target} bridge`);
+    }
+  }
+  for (const required of [
+    "bin/herdr-world",
+    "lib/herdr-world-launcher.sh",
+    "share/herdr-world/web/index.html",
+    "share/herdr-world/web/legal/manifest.json",
+    "README.md",
+    "LICENSE",
+    "THIRD_PARTY_NOTICES.md",
+    "UPSTREAM.md",
+  ]) {
+    if (!relativeEntries.includes(required)) {
+      throw new Error(`npm package is missing ${required}`);
+    }
+  }
+
+  const bytes = readFileSync(tarball);
+  return {
+    schema_version: 1,
+    name: packageJson.name,
+    version: packageJson.version,
+    source_tag: normalizedTag,
+    source_commit: sourceCommit,
+    tarball: tarball,
+    files: relativeEntries,
+    sha256: createHash("sha256").update(bytes).digest("hex"),
+    integrity: `sha512-${createHash("sha512").update(bytes).digest("base64")}`,
+  };
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  const [tarball, tag, metadataPath] = process.argv.slice(2);
+  if (!tarball || !tag || !metadataPath) {
+    console.error("Usage: node scripts/npm-package-inspect.mjs TARBALL TAG METADATA_JSON");
+    process.exit(2);
+  }
+  try {
+    const metadata = inspectNpmPackage({ tarball, tag });
+    writeFileSync(metadataPath, `${JSON.stringify(metadata, null, 2)}\n`);
+    console.log(JSON.stringify(metadata));
+  } catch (error) {
+    console.error(error.message);
+    process.exit(1);
+  }
+}

--- a/scripts/npm-package.mjs
+++ b/scripts/npm-package.mjs
@@ -1,0 +1,172 @@
+#!/usr/bin/env node
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import {
+  chmodSync,
+  cpSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { normalizeReleaseTag, releaseVersion } from "./release-version.mjs";
+
+export const NPM_TARGETS = ["linux-x64", "macos-arm64", "macos-x64"];
+const ARCHIVE_TARGETS = {
+  "linux-x64": "linux-x86_64",
+  "macos-arm64": "macos-arm64",
+  "macos-x64": "macos-x86_64",
+};
+
+export function sha256File(path) {
+  return createHash("sha256").update(readFileSync(path)).digest("hex");
+}
+
+function copyRequired(sourceRoot, relativePath, destinationRoot) {
+  const source = join(sourceRoot, relativePath);
+  const destination = join(destinationRoot, relativePath);
+  mkdirSync(dirname(destination), { recursive: true });
+  cpSync(source, destination, { recursive: true });
+}
+
+function archiveBundleName(tag, platform) {
+  return `herdr-world-${tag}-${platform}`;
+}
+
+function extractArchive(archive, destination) {
+  execFileSync("tar", ["-xzf", archive, "-C", destination], { stdio: "ignore" });
+}
+
+function findBundle(extractionRoot, name) {
+  const bundle = join(extractionRoot, name);
+  try {
+    if (readFileSync(join(bundle, "VERSION"), "utf8").trim()) return bundle;
+  } catch {
+    throw new Error(`archive did not contain expected bundle ${name}`);
+  }
+  return bundle;
+}
+
+export function createNpmPackage({ root = resolve(dirname(fileURLToPath(import.meta.url)), ".."), tag, archivesDir, outputDir }) {
+  const normalizedTag = normalizeReleaseTag(tag);
+  const packageRoot = resolve(outputDir);
+  const archiveRoot = resolve(archivesDir);
+  rmSync(packageRoot, { recursive: true, force: true });
+  mkdirSync(packageRoot, { recursive: true });
+
+  const extractionRoot = join(packageRoot, ".archives");
+  mkdirSync(extractionRoot);
+  const bundles = {};
+  for (const [target, archivePlatform] of Object.entries(ARCHIVE_TARGETS)) {
+    const archive = join(
+      archiveRoot,
+      `${archiveBundleName(normalizedTag, archivePlatform)}.tar.gz`,
+    );
+    const checksum = `${archive}.sha256`;
+    const actualDigest = sha256File(archive);
+    const expectedDigest = readFileSync(checksum, "utf8").trim().split(/\s+/)[0];
+    if (actualDigest !== expectedDigest) {
+      throw new Error(`desktop archive checksum mismatch for ${archivePlatform}`);
+    }
+    const targetRoot = join(extractionRoot, target);
+    mkdirSync(targetRoot);
+    extractArchive(archive, targetRoot);
+    const bundle = findBundle(targetRoot, archiveBundleName(normalizedTag, archivePlatform));
+    if (readFileSync(join(bundle, "VERSION"), "utf8").trim() !== normalizedTag) {
+      throw new Error(`desktop archive VERSION does not match ${normalizedTag}: ${archive}`);
+    }
+    bundles[target] = { bundle, archive, archiveDigest: actualDigest };
+  }
+
+  const commonBundle = bundles["linux-x64"].bundle;
+  const commonPaths = [
+    "LICENSE",
+    "THIRD_PARTY_NOTICES.md",
+    "UPSTREAM.md",
+    "docs/world-assets.md",
+    "vendor/herdr-compat/VENDOR-MANIFEST.toml",
+    "third_party/licenses",
+    "third_party/dependencies",
+    "share/herdr-world/web",
+  ];
+  for (const relativePath of commonPaths) {
+    copyRequired(commonBundle, relativePath, packageRoot);
+  }
+
+  const launcherDirectory = join(packageRoot, "lib");
+  const bridgeDirectory = join(launcherDirectory, "bridges");
+  mkdirSync(join(packageRoot, "bin"), { recursive: true });
+  mkdirSync(bridgeDirectory, { recursive: true });
+  cpSync(join(root, "scripts/npm-launcher.mjs"), join(packageRoot, "bin", "herdr-world"));
+  cpSync(
+    join(root, "scripts/herdr-world-launcher.sh"),
+    join(launcherDirectory, "herdr-world-launcher.sh"),
+  );
+  chmodSync(join(packageRoot, "bin", "herdr-world"), 0o755);
+  chmodSync(join(launcherDirectory, "herdr-world-launcher.sh"), 0o755);
+
+  for (const [target, { bundle }] of Object.entries(bundles)) {
+    const destination = join(bridgeDirectory, target);
+    mkdirSync(destination, { recursive: true });
+    cpSync(join(bundle, "bin/herdr-world-bridge"), join(destination, "herdr-world-bridge"));
+    chmodSync(join(destination, "herdr-world-bridge"), 0o755);
+  }
+
+  const packageJson = {
+    name: "@ivoryheart/herdr-world",
+    version: releaseVersion(normalizedTag),
+    description: "Browser and mobile client for monitoring and controlling Herdr agents.",
+    type: "module",
+    bin: { "herdr-world": "bin/herdr-world" },
+    engines: { node: ">=22.14.0" },
+    license: "MIT",
+    repository: {
+      type: "git",
+      url: "git+https://github.com/IvoryHeart/herdr-world.git",
+    },
+    bugs: { url: "https://github.com/IvoryHeart/herdr-world/issues" },
+    homepage: "https://ivoryheart.github.io/herdr-world/",
+    files: [
+      "bin/herdr-world",
+      "lib/herdr-world-launcher.sh",
+      "lib/bridges",
+      "share/herdr-world/web",
+      "docs",
+      "vendor",
+      "third_party",
+      "LICENSE",
+      "THIRD_PARTY_NOTICES.md",
+      "UPSTREAM.md",
+    ],
+    publishConfig: { access: "public" },
+  };
+  writeFileSync(join(packageRoot, "package.json"), `${JSON.stringify(packageJson, null, 2)}\n`);
+  cpSync(join(root, "docs/npm-readme.md"), join(packageRoot, "README.md"));
+
+  rmSync(extractionRoot, { recursive: true, force: true });
+  return {
+    packageRoot,
+    version: packageJson.version,
+    archives: Object.fromEntries(
+      Object.entries(bundles).map(([target, value]) => [target, value.archiveDigest]),
+    ),
+  };
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  const [tag, archivesDir, outputDir] = process.argv.slice(2);
+  if (!tag || !archivesDir || !outputDir) {
+    console.error("Usage: node scripts/npm-package.mjs TAG ARCHIVES_DIR OUTPUT_DIR");
+    process.exit(2);
+  }
+  try {
+    const result = createNpmPackage({ tag, archivesDir, outputDir });
+    console.log(`Staged npm package ${result.version} at ${result.packageRoot}`);
+  } catch (error) {
+    console.error(error.message);
+    process.exit(1);
+  }
+}

--- a/scripts/npm-registry-query.mjs
+++ b/scripts/npm-registry-query.mjs
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { resolve } from "node:path";
+
+function parseNpmErrorCode(output) {
+  if (!output) return null;
+  try {
+    return JSON.parse(output)?.error?.code ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export function queryNpm(args, { command = "npm" } = {}) {
+  const result = spawnSync(command, args, { encoding: "utf8" });
+  if (result.error) throw result.error;
+
+  const stdout = (result.stdout ?? "").trim();
+  const stderr = (result.stderr ?? "").trim();
+  if (result.status === 0) return { present: true, raw: stdout };
+
+  const errorCode = parseNpmErrorCode(stdout) ?? parseNpmErrorCode(stderr);
+  if (errorCode === "E404") return { present: false, raw: "" };
+
+  const detail = stderr || stdout || `exit status ${result.status}`;
+  throw new Error(`npm ${args.join(" ")} failed${errorCode ? ` (${errorCode})` : ""}: ${detail}`);
+}
+
+function valueFromResult(result) {
+  if (
+    !result.present ||
+    !result.raw ||
+    result.raw === "null" ||
+    result.raw === "undefined"
+  ) return "";
+  const value = JSON.parse(result.raw);
+  return value === null || value === undefined ? "" : String(value);
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  const [mode, ...args] = process.argv.slice(2);
+  if (!mode || args.length === 0 || !["state", "value"].includes(mode)) {
+    console.error("Usage: node scripts/npm-registry-query.mjs <state|value> npm-args...");
+    process.exit(2);
+  }
+  try {
+    const result = queryNpm(args);
+    if (mode === "state") {
+      console.log(JSON.stringify(result));
+    } else {
+      process.stdout.write(`${valueFromResult(result)}\n`);
+    }
+  } catch (error) {
+    console.error(error.message);
+    process.exit(1);
+  }
+}

--- a/scripts/npm-registry-query.test.mjs
+++ b/scripts/npm-registry-query.test.mjs
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { queryNpm } from "./npm-registry-query.mjs";
+
+function fakeNpmOutput(payload, exitCode) {
+  return [
+    "-e",
+    `process.stdout.write(${JSON.stringify(JSON.stringify(payload))}); process.exit(${exitCode});`,
+  ];
+}
+
+test("treats an npm E404 response as an absent package", () => {
+  assert.deepEqual(
+    queryNpm(fakeNpmOutput({ error: { code: "E404" } }, 1), {
+      command: process.execPath,
+    }),
+    { present: false, raw: "" },
+  );
+});
+
+test("fails closed for other npm errors", () => {
+  assert.throws(
+    () =>
+      queryNpm(fakeNpmOutput({ error: { code: "EAI_AGAIN" } }, 1), {
+        command: process.execPath,
+      }),
+    /EAI_AGAIN/,
+  );
+});

--- a/scripts/release-notes.mjs
+++ b/scripts/release-notes.mjs
@@ -3,10 +3,10 @@ import { readFileSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { normalizeReleaseTag, releaseVersion } from "./release-version.mjs";
+import { escapeRegex, normalizeReleaseTag, releaseVersion } from "./release-version.mjs";
 
 export function extractReleaseNotes(changelog, tag) {
-  const version = releaseVersion(normalizeReleaseTag(tag)).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const version = escapeRegex(releaseVersion(normalizeReleaseTag(tag)));
   const match = changelog.match(
     new RegExp(`^## \\[${version}\\] - [^\\n]+\\n([\\s\\S]*?)(?=\\n## \\[|$)`, "m"),
   );

--- a/scripts/release-notes.mjs
+++ b/scripts/release-notes.mjs
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+import { readFileSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { normalizeReleaseTag, releaseVersion } from "./release-version.mjs";
+
+export function extractReleaseNotes(changelog, tag) {
+  const version = releaseVersion(normalizeReleaseTag(tag)).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const match = changelog.match(
+    new RegExp(`^## \\[${version}\\] - [^\\n]+\\n([\\s\\S]*?)(?=\\n## \\[|$)`, "m"),
+  );
+  if (!match || !match[1].trim()) {
+    throw new Error(`CHANGELOG.md has no release notes for ${tag}`);
+  }
+  return match[1].trim();
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  const [tag, changelogPath, outputPath] = process.argv.slice(2);
+  if (!tag || !changelogPath || !outputPath) {
+    console.error("Usage: node scripts/release-notes.mjs TAG CHANGELOG_PATH OUTPUT_MD");
+    process.exit(2);
+  }
+  try {
+    writeFileSync(outputPath, `${extractReleaseNotes(readFileSync(changelogPath, "utf8"), tag)}\n`);
+  } catch (error) {
+    console.error(error.message);
+    process.exit(1);
+  }
+}

--- a/scripts/release-publication.mjs
+++ b/scripts/release-publication.mjs
@@ -1,0 +1,67 @@
+import { compareReleaseTags, normalizeReleaseTag, releaseVersion } from "./release-version.mjs";
+
+export const NPM_PACKAGE_NAME = "@ivoryheart/herdr-world";
+export const HOMEBREW_TAP_REPOSITORY = "IvoryHeart/homebrew-tap";
+
+export function channelForRelease(tag) {
+  return normalizeReleaseTag(tag).includes("-rc.") ? "next" : "latest";
+}
+
+export function versionForRelease(tag) {
+  return releaseVersion(tag);
+}
+
+/**
+ * Decide what a publisher may do after reading its target channel while the
+ * release mutex is held. The caller supplies the exact-version record and the
+ * current moving pointer separately because registries expose those values
+ * through different APIs.
+ */
+export function assessPublication({
+  candidate,
+  currentVersion = null,
+  exactVersionExists = false,
+  exactDigestMatches = false,
+  pointerVersion = null,
+}) {
+  const normalizedCandidate = normalizeReleaseTag(candidate);
+  const normalizedCurrent = currentVersion ? normalizeReleaseTag(currentVersion) : null;
+  const normalizedPointer = pointerVersion ? normalizeReleaseTag(pointerVersion) : null;
+
+  if (normalizedCurrent && compareReleaseTags(normalizedCandidate, normalizedCurrent) < 0) {
+    return {
+      action: "fail",
+      reason: `candidate ${normalizedCandidate} is lower than target-channel version ${normalizedCurrent}`,
+    };
+  }
+
+  if (normalizedPointer && compareReleaseTags(normalizedCandidate, normalizedPointer) < 0) {
+    return {
+      action: "fail",
+      reason: `candidate ${normalizedCandidate} would regress target pointer ${normalizedPointer}`,
+    };
+  }
+
+  if (!exactVersionExists) {
+    if (normalizedCurrent && compareReleaseTags(normalizedCandidate, normalizedCurrent) <= 0) {
+      return {
+        action: "fail",
+        reason: `version ${normalizedCandidate} is unavailable for a new publication because the target channel already reached ${normalizedCurrent}`,
+      };
+    }
+    return { action: "publish", version: normalizedCandidate };
+  }
+
+  if (!exactDigestMatches) {
+    return {
+      action: "fail",
+      reason: `version ${normalizedCandidate} already exists with different content`,
+    };
+  }
+
+  if (normalizedPointer && compareReleaseTags(normalizedCandidate, normalizedPointer) === 0) {
+    return { action: "complete", version: normalizedCandidate };
+  }
+
+  return { action: "update-pointer", version: normalizedCandidate };
+}

--- a/scripts/release-publication.test.mjs
+++ b/scripts/release-publication.test.mjs
@@ -1,0 +1,64 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  assessPublication,
+  channelForRelease,
+  versionForRelease,
+} from "./release-publication.mjs";
+
+test("maps release identities to npm channels", () => {
+  assert.equal(channelForRelease("v1.2.3-rc.4"), "next");
+  assert.equal(channelForRelease("v1.2.3"), "latest");
+  assert.equal(versionForRelease("v1.2.3-rc.4"), "1.2.3-rc.4");
+});
+
+test("publishes an absent version", () => {
+  assert.deepEqual(
+    assessPublication({ candidate: "v1.2.3", currentVersion: "v1.2.2" }),
+    { action: "publish", version: "v1.2.3" },
+  );
+});
+test("rejects a lower candidate before mutation", () => {
+  assert.match(
+    assessPublication({ candidate: "v1.2.2", currentVersion: "v1.2.3" }).reason,
+    /lower than target-channel version/,
+  );
+});
+
+test("recognizes an exact-content retry as complete", () => {
+  assert.deepEqual(
+    assessPublication({
+      candidate: "v1.2.3-rc.2",
+      currentVersion: "v1.2.3-rc.2",
+      exactVersionExists: true,
+      exactDigestMatches: true,
+      pointerVersion: "v1.2.3-rc.2",
+    }),
+    { action: "complete", version: "v1.2.3-rc.2" },
+  );
+});
+
+test("rejects same-version content replacement", () => {
+  assert.match(
+    assessPublication({
+      candidate: "v1.2.3-rc.2",
+      exactVersionExists: true,
+      exactDigestMatches: false,
+    }).reason,
+    /different content/,
+  );
+});
+
+test("allows an exact-content retry to repair an older moving pointer", () => {
+  assert.deepEqual(
+    assessPublication({
+      candidate: "v1.2.3",
+      currentVersion: "v1.2.2",
+      exactVersionExists: true,
+      exactDigestMatches: true,
+      pointerVersion: "v1.2.2",
+    }),
+    { action: "update-pointer", version: "v1.2.3" },
+  );
+});

--- a/scripts/release-target.mjs
+++ b/scripts/release-target.mjs
@@ -40,11 +40,3 @@ export function assertReleaseRemoteUrls(remoteUrls, direction) {
 export function withReleaseRepository(args) {
   return [...args, "--repo", RELEASE_REPOSITORY];
 }
-
-export function releaseCreateArgs(tag, notesFile) {
-  const args = ["release", "create", tag, "--verify-tag", "--notes-file", notesFile];
-  if (tag.includes("-")) {
-    args.push("--prerelease");
-  }
-  return withReleaseRepository(args);
-}

--- a/scripts/release-target.test.mjs
+++ b/scripts/release-target.test.mjs
@@ -5,7 +5,6 @@ import {
   RELEASE_REPOSITORY,
   assertReleaseRemoteUrls,
   githubRepositoryFromRemoteUrl,
-  releaseCreateArgs,
   withReleaseRepository,
 } from "./release-target.mjs";
 
@@ -63,33 +62,6 @@ test("adds an explicit repository to GitHub CLI release commands", () => {
     "release",
     "view",
     "v1.2.3",
-    "--repo",
-    "IvoryHeart/herdr-world",
-  ]);
-});
-
-test("marks release-candidate GitHub releases as prereleases", () => {
-  assert.deepEqual(releaseCreateArgs("v0.1.0-rc.3", "notes.md"), [
-    "release",
-    "create",
-    "v0.1.0-rc.3",
-    "--verify-tag",
-    "--notes-file",
-    "notes.md",
-    "--prerelease",
-    "--repo",
-    "IvoryHeart/herdr-world",
-  ]);
-});
-
-test("leaves stable GitHub releases stable", () => {
-  assert.deepEqual(releaseCreateArgs("v0.1.0", "notes.md"), [
-    "release",
-    "create",
-    "v0.1.0",
-    "--verify-tag",
-    "--notes-file",
-    "notes.md",
     "--repo",
     "IvoryHeart/herdr-world",
   ]);

--- a/scripts/release-version.mjs
+++ b/scripts/release-version.mjs
@@ -1,4 +1,4 @@
-import { readFileSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
 export const RELEASE_REFERENCE_PATHS = [
@@ -7,8 +7,62 @@ export const RELEASE_REFERENCE_PATHS = [
   "site/site.js",
   "release.json",
 ];
+export const OPTIONAL_RELEASE_REFERENCE_PATHS = ["herdr-plugin.toml"];
 
-const VERSION_PATTERN = /^v\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/;
+const RELEASE_TAG_PATTERN =
+  /^v?(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-rc\.([1-9]\d*))?$/;
+
+export function parseReleaseTag(value) {
+  if (typeof value !== "string") {
+    throw new Error(`invalid release tag: ${value}`);
+  }
+
+  const match = value.match(RELEASE_TAG_PATTERN);
+  if (!match) {
+    throw new Error(
+      `invalid release tag: ${value}; expected vMAJOR.MINOR.PATCH or vMAJOR.MINOR.PATCH-rc.N`,
+    );
+  }
+
+  return {
+    major: Number(match[1]),
+    minor: Number(match[2]),
+    patch: Number(match[3]),
+    rc: match[4] === undefined ? null : Number(match[4]),
+    tag: `v${match[1]}.${match[2]}.${match[3]}${match[4] ? `-rc.${match[4]}` : ""}`,
+  };
+}
+
+export function normalizeReleaseTag(value) {
+  return parseReleaseTag(value).tag;
+}
+
+export function releaseVersion(value) {
+  return parseReleaseTag(value).tag.slice(1);
+}
+
+export function compareReleaseTags(left, right) {
+  const a = parseReleaseTag(left);
+  const b = parseReleaseTag(right);
+  for (const key of ["major", "minor", "patch"]) {
+    if (a[key] !== b[key]) {
+      return a[key] > b[key] ? 1 : -1;
+    }
+  }
+  if (a.rc === b.rc) return 0;
+  if (a.rc === null) return 1;
+  if (b.rc === null) return -1;
+  return a.rc > b.rc ? 1 : -1;
+}
+
+export function releaseReferencePaths(root = process.cwd()) {
+  return [
+    ...RELEASE_REFERENCE_PATHS,
+    ...OPTIONAL_RELEASE_REFERENCE_PATHS.filter((relativePath) =>
+      existsSync(join(root, relativePath)),
+    ),
+  ];
+}
 
 export function readCurrentReleaseTag(root = process.cwd()) {
   const metadataPath = join(root, "release.json");
@@ -19,15 +73,17 @@ export function readCurrentReleaseTag(root = process.cwd()) {
     throw new Error(`could not read release.json: ${error.message}`);
   }
 
-  if (typeof metadata.current !== "string" || !VERSION_PATTERN.test(metadata.current)) {
-    throw new Error("release.json current must be a v-prefixed SemVer release tag");
+  if (typeof metadata.current !== "string" || !metadata.current.startsWith("v")) {
+    throw new Error("release.json current must be a v-prefixed release tag");
   }
-  return metadata.current;
+  return parseReleaseTag(metadata.current).tag;
 }
 
 export function assertCurrentReleaseReferences(root = process.cwd()) {
   const current = readCurrentReleaseTag(root);
-  for (const relativePath of RELEASE_REFERENCE_PATHS.slice(0, -1)) {
+  for (const relativePath of releaseReferencePaths(root).filter(
+    (relativePath) => relativePath !== "release.json",
+  )) {
     const contents = readFileSync(join(root, relativePath), "utf8");
     if (!contents.includes(current)) {
       throw new Error(`${relativePath} does not reference the current release ${current}`);
@@ -39,21 +95,17 @@ export function assertCurrentReleaseReferences(root = process.cwd()) {
 export function stampCurrentRelease(
   newTag,
   root = process.cwd(),
-  { allowSameTag = false } = {},
 ) {
-  if (!VERSION_PATTERN.test(newTag)) {
-    throw new Error(`invalid release tag: ${newTag}`);
-  }
+  newTag = normalizeReleaseTag(newTag);
 
   const current = assertCurrentReleaseReferences(root);
   if (current === newTag) {
-    if (!allowSameTag) {
-      throw new Error(`release references already point to ${newTag}`);
-    }
-    return [];
+    throw new Error(`release references already point to ${newTag}`);
   }
 
-  const updates = RELEASE_REFERENCE_PATHS.slice(0, -1).map((relativePath) => {
+  const updates = releaseReferencePaths(root)
+    .filter((relativePath) => relativePath !== "release.json")
+    .map((relativePath) => {
     const path = join(root, relativePath);
     const contents = readFileSync(path, "utf8");
     const updated = contents.replaceAll(current, newTag);
@@ -61,7 +113,7 @@ export function stampCurrentRelease(
       throw new Error(`could not replace every ${current} reference in ${relativePath}`);
     }
     return { path, updated };
-  });
+    });
 
   for (const update of updates) {
     writeFileSync(update.path, update.updated);
@@ -72,5 +124,5 @@ export function stampCurrentRelease(
   );
 
   assertCurrentReleaseReferences(root);
-  return [...RELEASE_REFERENCE_PATHS];
+  return releaseReferencePaths(root);
 }

--- a/scripts/release-version.mjs
+++ b/scripts/release-version.mjs
@@ -37,6 +37,10 @@ export function normalizeReleaseTag(value) {
   return parseReleaseTag(value).tag;
 }
 
+export function escapeRegex(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
 export function releaseVersion(value) {
   return parseReleaseTag(value).tag.slice(1);
 }

--- a/scripts/release-version.test.mjs
+++ b/scripts/release-version.test.mjs
@@ -7,9 +7,46 @@ import test from "node:test";
 import {
   RELEASE_REFERENCE_PATHS,
   assertCurrentReleaseReferences,
+  compareReleaseTags,
+  normalizeReleaseTag,
+  parseReleaseTag,
+  releaseVersion,
   readCurrentReleaseTag,
   stampCurrentRelease,
 } from "./release-version.mjs";
+
+test("accepts only stable releases and numbered release candidates", () => {
+  assert.equal(normalizeReleaseTag("1.2.3"), "v1.2.3");
+  assert.equal(normalizeReleaseTag("v1.2.3-rc.4"), "v1.2.3-rc.4");
+  assert.equal(releaseVersion("v1.2.3-rc.4"), "1.2.3-rc.4");
+  assert.deepEqual(parseReleaseTag("v0.0.0"), {
+    major: 0,
+    minor: 0,
+    patch: 0,
+    rc: null,
+    tag: "v0.0.0",
+  });
+
+  for (const value of [
+    "v01.2.3",
+    "v1.02.3",
+    "v1.2.03",
+    "v1.2.3-rc.0",
+    "v1.2.3-beta.1",
+    "v1.2.3+build.1",
+    "v1.2.3-rc.1+build.1",
+    "v1.2.3-rc",
+  ]) {
+    assert.throws(() => normalizeReleaseTag(value), /invalid release tag/);
+  }
+});
+
+test("compares stable and release-candidate precedence", () => {
+  assert.equal(compareReleaseTags("v1.2.3-rc.1", "v1.2.3-rc.2"), -1);
+  assert.equal(compareReleaseTags("v1.2.3-rc.9", "v1.2.3"), -1);
+  assert.equal(compareReleaseTags("v1.2.4", "v1.2.3"), 1);
+  assert.equal(compareReleaseTags("v1.2.3", "1.2.3"), 0);
+});
 
 test("repository release references agree with release.json", () => {
   const root = resolve(import.meta.dirname, "..");
@@ -57,7 +94,7 @@ test("fails closed when a required public surface has drifted", () => {
   }
 });
 
-test("allows an explicit same-tag prerelease reissue without rewriting public files", () => {
+test("rejects reusing a release tag even when public references already match", () => {
   const root = mkdtempSync(join(tmpdir(), "herdr-world-release-version-"));
   try {
     mkdirSync(join(root, "site"));
@@ -71,18 +108,9 @@ test("allows an explicit same-tag prerelease reissue without rewriting public fi
       /release references already point to v1\.2\.3-rc\.1/,
     );
 
-    const before = RELEASE_REFERENCE_PATHS.map((relativePath) =>
-      readFileSync(join(root, relativePath), "utf8"),
-    );
-    assert.deepEqual(
-      stampCurrentRelease("v1.2.3-rc.1", root, { allowSameTag: true }),
-      [],
-    );
-    assert.deepEqual(
-      RELEASE_REFERENCE_PATHS.map((relativePath) =>
-        readFileSync(join(root, relativePath), "utf8"),
-      ),
-      before,
+    assert.throws(
+      () => stampCurrentRelease("v1.2.3-rc.1", root),
+      /release references already point to v1\.2\.3-rc\.1/,
     );
   } finally {
     rmSync(root, { recursive: true, force: true });

--- a/scripts/release-version.test.mjs
+++ b/scripts/release-version.test.mjs
@@ -8,6 +8,7 @@ import {
   RELEASE_REFERENCE_PATHS,
   assertCurrentReleaseReferences,
   compareReleaseTags,
+  escapeRegex,
   normalizeReleaseTag,
   parseReleaseTag,
   releaseVersion,
@@ -46,6 +47,12 @@ test("compares stable and release-candidate precedence", () => {
   assert.equal(compareReleaseTags("v1.2.3-rc.9", "v1.2.3"), -1);
   assert.equal(compareReleaseTags("v1.2.4", "v1.2.3"), 1);
   assert.equal(compareReleaseTags("v1.2.3", "1.2.3"), 0);
+});
+
+test("escapes release versions for literal changelog matching", () => {
+  const heading = new RegExp(`^## \\[${escapeRegex("1.2.3")}\\] - `, "m");
+  assert.match("## [1.2.3] - Release\n", heading);
+  assert.doesNotMatch("## [1x2x3] - Release\n", heading);
 });
 
 test("repository release references agree with release.json", () => {

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -2,6 +2,7 @@
 import { execFileSync } from "node:child_process";
 import { readFileSync, writeFileSync } from "node:fs";
 
+import { queryNpm } from "./npm-registry-query.mjs";
 import {
   HOMEBREW_TAP_REPOSITORY,
   NPM_PACKAGE_NAME,
@@ -59,28 +60,34 @@ function commandSucceeds(command, args) {
   }
 }
 
+function queryNpmOrFail(args, description) {
+  try {
+    return queryNpm(args);
+  } catch (error) {
+    fail(`could not ${description}: ${error.message}`);
+  }
+}
+
 function fail(message) {
   console.error(`Error: ${message}`);
   process.exit(1);
 }
 
 function readNpmChannelVersion(channel) {
-  let raw;
-  try {
-    raw = output("npm", [
-      "view",
-      NPM_PACKAGE_NAME,
-      `dist-tags.${channel}`,
-      "--json",
-    ]);
-  } catch (error) {
-    fail(`could not read npm ${channel} for ${NPM_PACKAGE_NAME}: ${error.message}`);
-  }
-  if (!raw || raw === "null" || raw === "undefined") return null;
+  const result = queryNpmOrFail(
+    ["view", NPM_PACKAGE_NAME, `dist-tags.${channel}`, "--json"],
+    `read npm ${channel} for ${NPM_PACKAGE_NAME}`,
+  );
+  if (
+    !result.present ||
+    !result.raw ||
+    result.raw === "null" ||
+    result.raw === "undefined"
+  ) return null;
 
   let value;
   try {
-    value = JSON.parse(raw);
+    value = JSON.parse(result.raw);
   } catch (error) {
     fail(`npm ${channel} returned invalid version data: ${error.message}`);
   }
@@ -93,23 +100,18 @@ function readNpmChannelVersion(channel) {
 }
 
 function checkExternalVersionAvailability() {
-  if (
-    commandSucceeds("npm", [
-      "view",
-      `${NPM_PACKAGE_NAME}@${version}`,
-      "version",
-      "--json",
-    ])
-  ) {
+  const exactVersion = queryNpmOrFail(
+    ["view", `${NPM_PACKAGE_NAME}@${version}`, "version", "--json"],
+    `check npm version ${NPM_PACKAGE_NAME}@${version}`,
+  );
+  if (exactVersion.present) {
     fail(`npm version already exists: ${NPM_PACKAGE_NAME}@${version}`);
   }
 
-  const npmPackageExists = commandSucceeds("npm", [
-    "view",
-    NPM_PACKAGE_NAME,
-    "name",
-    "--json",
-  ]);
+  const npmPackageExists = queryNpmOrFail(
+    ["view", NPM_PACKAGE_NAME, "name", "--json"],
+    `check whether npm package ${NPM_PACKAGE_NAME} exists`,
+  ).present;
   if (!npmPackageExists && !tag.includes("-rc.")) {
     fail(
       `the first npm publication must be an RC; publish a unique release candidate before ${tag}`,

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -68,6 +68,26 @@ function queryNpmOrFail(args, description) {
   }
 }
 
+function readGhApiOrMissing(args, description) {
+  try {
+    return JSON.parse(output("gh", args));
+  } catch (error) {
+    const stdout = String(error.stdout ?? "").trim();
+    const stderr = String(error.stderr ?? "").trim();
+    let response;
+    try {
+      response = JSON.parse(stdout);
+    } catch {
+      response = null;
+    }
+    if (response?.status === 404 || response?.status === "404" || /HTTP 404\b/.test(stderr)) {
+      return null;
+    }
+    const detail = stderr || stdout || error.message;
+    fail(`could not ${description}: ${detail}`);
+  }
+}
+
 function fail(message) {
   console.error(`Error: ${message}`);
   process.exit(1);
@@ -149,8 +169,11 @@ function checkExternalVersionAvailability() {
   const formula = tag.includes("-rc.") ? "herdr-world-rc.rb" : "herdr-world.rb";
   const formulaPath = `Formula/${formula}`;
   const endpoint = `repos/${HOMEBREW_TAP_REPOSITORY}/contents/${formulaPath}`;
-  if (commandSucceeds("gh", ["api", endpoint])) {
-    const response = JSON.parse(output("gh", ["api", endpoint]));
+  const response = readGhApiOrMissing(
+    ["api", endpoint],
+    `check Homebrew Formula ${formulaPath}`,
+  );
+  if (response) {
     const contents = Buffer.from(response.content, "base64").toString("utf8");
     const formulaVersion = contents.match(/^\s*version\s+"([^"]+)"/m)?.[1];
     if (!formulaVersion) {

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -1,38 +1,41 @@
 #!/usr/bin/env node
 import { execFileSync } from "node:child_process";
-import { readFileSync, rmSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import { readFileSync, writeFileSync } from "node:fs";
 
+import {
+  HOMEBREW_TAP_REPOSITORY,
+  NPM_PACKAGE_NAME,
+} from "./release-publication.mjs";
 import {
   RELEASE_REMOTE,
   RELEASE_REPOSITORY,
   assertReleaseRemoteUrls,
-  releaseCreateArgs,
   withReleaseRepository,
 } from "./release-target.mjs";
 import {
-  RELEASE_REFERENCE_PATHS,
-  readCurrentReleaseTag,
+  compareReleaseTags,
+  normalizeReleaseTag,
+  releaseReferencePaths,
   stampCurrentRelease,
 } from "./release-version.mjs";
 
 const RELEASE_BRANCH = "main";
 const RELEASE_ARG = process.argv[2];
-const REISSUE_PRERELEASE = process.argv[3] === "--reissue-prerelease";
-const VERSION_ARG = /^v?(\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?)$/;
 
-const match = RELEASE_ARG?.match(VERSION_ARG);
-if (!match || process.argv.length > (REISSUE_PRERELEASE ? 4 : 3)) {
-  console.error(
-    "Usage: node scripts/release.mjs <vX.Y.Z|X.Y.Z> [--reissue-prerelease]",
-  );
+if (!RELEASE_ARG || process.argv.length !== 3) {
+  console.error("Usage: node scripts/release.mjs <vX.Y.Z|X.Y.Z>");
   process.exit(1);
 }
 
-const version = match[1];
-const tag = `v${version}`;
+let tag;
+try {
+  tag = normalizeReleaseTag(RELEASE_ARG);
+} catch (error) {
+  console.error(`Error: ${error.message}`);
+  process.exit(1);
+}
+const version = tag.slice(1);
 const today = new Date().toISOString().slice(0, 10);
-const notesFile = join(process.cwd(), ".release-notes-tmp.md");
 const changelogSubsections = ["Breaking Changes", "Added", "Changed", "Fixed", "Removed"];
 
 function run(command, args, options = {}) {
@@ -58,6 +61,63 @@ function commandSucceeds(command, args) {
 function fail(message) {
   console.error(`Error: ${message}`);
   process.exit(1);
+}
+
+function checkExternalVersionAvailability() {
+  if (
+    commandSucceeds("npm", [
+      "view",
+      `${NPM_PACKAGE_NAME}@${version}`,
+      "version",
+      "--json",
+    ])
+  ) {
+    fail(`npm version already exists: ${NPM_PACKAGE_NAME}@${version}`);
+  }
+
+  const npmPackageExists = commandSucceeds("npm", [
+    "view",
+    NPM_PACKAGE_NAME,
+    "name",
+    "--json",
+  ]);
+  if (!npmPackageExists && !tag.includes("-rc.")) {
+    fail(
+      `the first npm publication must be an RC; publish a unique release candidate before ${tag}`,
+    );
+  }
+
+  if (
+    !commandSucceeds("gh", [
+      "repo",
+      "view",
+      HOMEBREW_TAP_REPOSITORY,
+      "--json",
+      "nameWithOwner",
+      "--jq",
+      ".nameWithOwner",
+    ])
+  ) {
+    fail(
+      `Homebrew tap ${HOMEBREW_TAP_REPOSITORY} is missing; create it before releasing ${tag}`,
+    );
+  }
+
+  const formula = tag.includes("-rc.") ? "herdr-world-rc.rb" : "herdr-world.rb";
+  const formulaPath = `Formula/${formula}`;
+  const endpoint = `repos/${HOMEBREW_TAP_REPOSITORY}/contents/${formulaPath}`;
+  if (commandSucceeds("gh", ["api", endpoint])) {
+    const response = JSON.parse(output("gh", ["api", endpoint]));
+    const contents = Buffer.from(response.content, "base64").toString("utf8");
+    const formulaVersion = contents.match(/^\s*version\s+"([^"]+)"/m)?.[1];
+    if (!formulaVersion) {
+      fail(`Homebrew Formula ${formulaPath} has no parseable version`);
+    }
+    const currentTag = normalizeReleaseTag(`v${formulaVersion}`);
+    if (compareReleaseTags(tag, currentTag) <= 0) {
+      fail(`Homebrew Formula ${formulaPath} already reaches ${currentTag}`);
+    }
+  }
 }
 
 function validatePreflight() {
@@ -101,7 +161,7 @@ function validatePreflight() {
     fail(`GitHub CLI resolved the release repository as ${accessibleRepository}`);
   }
 
-  run("git", ["fetch", RELEASE_REMOTE, RELEASE_BRANCH, "--tags"]);
+  run("git", ["fetch", RELEASE_REMOTE, RELEASE_BRANCH, "--no-tags"]);
   const local = output("git", ["rev-parse", RELEASE_BRANCH]);
   const remote = output("git", ["rev-parse", `${RELEASE_REMOTE}/${RELEASE_BRANCH}`]);
   if (local !== remote) {
@@ -114,13 +174,15 @@ function validatePreflight() {
     fail(`tag already exists locally: ${tag}`);
   }
   if (
-    commandSucceeds("git", ["ls-remote", "--exit-code", "--tags", RELEASE_REMOTE, tag])
+    commandSucceeds("git", ["ls-remote", "--exit-code", "--tags", RELEASE_REMOTE, `refs/tags/${tag}`])
   ) {
     fail(`tag already exists on ${RELEASE_REMOTE}: ${tag}`);
   }
   if (commandSucceeds("gh", withReleaseRepository(["release", "view", tag]))) {
     fail(`GitHub release already exists in ${RELEASE_REPOSITORY}: ${tag}`);
   }
+
+  checkExternalVersionAvailability();
 }
 
 function readChangelogForRelease() {
@@ -166,14 +228,6 @@ function removeEmptyChangelogSubsections(body) {
   return cleaned ? `\n${cleaned.trimStart()}\n` : "\n";
 }
 
-function extractReleaseNotes(changelog) {
-  const release = changelog.match(new RegExp(`## \\[${escapeRegex(version)}\\] - [^\\n]+\\n([\\s\\S]*?)(?=\\n## \\[|$)`));
-  if (!release || !release[1].trim()) {
-    fail(`could not extract release notes for ${tag}`);
-  }
-  return release[1].trim();
-}
-
 function openNextUnreleased(changelog) {
   const next = changelog.replace(
     "# Changelog\n\n",
@@ -189,41 +243,23 @@ function escapeRegex(value) {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
-try {
-  validatePreflight();
-  if (REISSUE_PRERELEASE) {
-    if (!tag.includes("-")) {
-      fail("--reissue-prerelease is only valid for a SemVer prerelease tag");
-    }
-    if (readCurrentReleaseTag() !== tag) {
-      fail("--reissue-prerelease requires public release references to match the requested tag");
-    }
-  }
-  const changelog = readChangelogForRelease();
+validatePreflight();
+const changelog = readChangelogForRelease();
 
-  run("npm", ["run", "check"]);
+run("npm", ["run", "check"]);
 
-  stampCurrentRelease(tag, process.cwd(), { allowSameTag: REISSUE_PRERELEASE });
-  const released = stampChangelog(changelog);
-  writeFileSync(notesFile, extractReleaseNotes(released));
+stampCurrentRelease(tag);
+const released = stampChangelog(changelog);
 
-  run("npm", ["run", "test:release"]);
-  run("npm", ["run", "test:pages"]);
+run("npm", ["run", "test:release"]);
+run("npm", ["run", "test:pages"]);
 
-  run("git", ["add", "CHANGELOG.md", ...RELEASE_REFERENCE_PATHS]);
-  run("git", ["commit", "-m", `Release ${tag}`]);
-  run("git", ["tag", tag]);
-  run("git", ["push", "--atomic", RELEASE_REMOTE, RELEASE_BRANCH, tag]);
+run("git", ["add", "CHANGELOG.md", ...releaseReferencePaths()]);
+run("git", ["commit", "-m", `Release ${tag}`]);
+run("git", ["tag", tag]);
+run("git", ["push", "--atomic", RELEASE_REMOTE, RELEASE_BRANCH, tag]);
 
-  run(
-    "gh",
-    releaseCreateArgs(tag, notesFile),
-  );
-
-  openNextUnreleased(released);
-  run("git", ["add", "CHANGELOG.md"]);
-  run("git", ["commit", "-m", "Prepare for next release"]);
-  run("git", ["push", RELEASE_REMOTE, RELEASE_BRANCH]);
-} finally {
-  rmSync(notesFile, { force: true });
-}
+openNextUnreleased(released);
+run("git", ["add", "CHANGELOG.md"]);
+run("git", ["commit", "-m", "Prepare for next release"]);
+run("git", ["push", RELEASE_REMOTE, RELEASE_BRANCH]);

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -14,6 +14,7 @@ import {
 } from "./release-target.mjs";
 import {
   compareReleaseTags,
+  escapeRegex,
   normalizeReleaseTag,
   releaseReferencePaths,
   stampCurrentRelease,
@@ -63,6 +64,34 @@ function fail(message) {
   process.exit(1);
 }
 
+function readNpmChannelVersion(channel) {
+  let raw;
+  try {
+    raw = output("npm", [
+      "view",
+      NPM_PACKAGE_NAME,
+      `dist-tags.${channel}`,
+      "--json",
+    ]);
+  } catch (error) {
+    fail(`could not read npm ${channel} for ${NPM_PACKAGE_NAME}: ${error.message}`);
+  }
+  if (!raw || raw === "null" || raw === "undefined") return null;
+
+  let value;
+  try {
+    value = JSON.parse(raw);
+  } catch (error) {
+    fail(`npm ${channel} returned invalid version data: ${error.message}`);
+  }
+  if (value === null || value === "") return null;
+  try {
+    return normalizeReleaseTag(value);
+  } catch (error) {
+    fail(`npm ${channel} returned an invalid release version: ${error.message}`);
+  }
+}
+
 function checkExternalVersionAvailability() {
   if (
     commandSucceeds("npm", [
@@ -85,6 +114,18 @@ function checkExternalVersionAvailability() {
     fail(
       `the first npm publication must be an RC; publish a unique release candidate before ${tag}`,
     );
+  }
+  if (npmPackageExists) {
+    const channel = tag.includes("-rc.") ? "next" : "latest";
+    const currentChannelVersion = readNpmChannelVersion(channel);
+    if (
+      currentChannelVersion &&
+      compareReleaseTags(tag, currentChannelVersion) <= 0
+    ) {
+      fail(
+        `npm ${channel} already reaches ${currentChannelVersion}; candidate ${tag} must be a higher release`,
+      );
+    }
   }
 
   if (
@@ -237,10 +278,6 @@ function openNextUnreleased(changelog) {
     fail("could not open next Unreleased changelog section");
   }
   writeFileSync("CHANGELOG.md", next);
-}
-
-function escapeRegex(value) {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
 validatePreflight();

--- a/scripts/update-homebrew-tap.sh
+++ b/scripts/update-homebrew-tap.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+if [[ $# -ne 2 ]]; then
+  echo "usage: scripts/update-homebrew-tap.sh TAG FORMULA" >&2
+  exit 2
+fi
+
+TAG="$1"
+FORMULA_SOURCE="$2"
+TAP_REPOSITORY="IvoryHeart/homebrew-tap"
+TAP_TOKEN="${HOMEBREW_TAP_TOKEN:-}"
+
+[[ -n "$TAP_TOKEN" ]] || {
+  echo "HOMEBREW_TAP_TOKEN is required; create a fine-grained token limited to $TAP_REPOSITORY contents" >&2
+  exit 1
+}
+FORMULA_SOURCE="$(cd "$(dirname "$FORMULA_SOURCE")" && pwd)/$(basename "$FORMULA_SOURCE")"
+[[ -f "$FORMULA_SOURCE" ]] || { echo "missing generated Formula: $FORMULA_SOURCE" >&2; exit 1; }
+[[ "$TAG" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-rc\.(0|[1-9][0-9]*))?$ ]] || {
+  echo "invalid release tag: $TAG" >&2
+  exit 1
+}
+
+formula_name="$(basename "$FORMULA_SOURCE" .rb)"
+case "$formula_name" in
+  herdr-world | herdr-world-rc) ;;
+  *) echo "unexpected Formula name: $formula_name" >&2; exit 1 ;;
+esac
+
+temp_root="$(mktemp -d "${RUNNER_TEMP:-${TMPDIR:-/tmp}}/herdr-world-tap.XXXXXX")"
+cleanup() { rm -rf -- "$temp_root"; }
+trap cleanup EXIT
+tap_root="$temp_root/homebrew-tap"
+auth="$(printf 'x-access-token:%s' "$TAP_TOKEN" | base64 | tr -d '\n')"
+
+git -c "http.extraheader=AUTHORIZATION: basic $auth" clone "https://github.com/$TAP_REPOSITORY.git" "$tap_root" >/dev/null
+cd "$tap_root"
+default_branch="$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null || true)"
+default_branch="${default_branch#origin/}"
+default_branch="${default_branch:-main}"
+git checkout "$default_branch" >/dev/null 2>&1
+git pull --ff-only origin "$default_branch" >/dev/null
+
+mkdir -p Formula
+target="Formula/$formula_name.rb"
+if [[ -f "$target" ]]; then
+  existing_version="$(sed -nE 's/^  version "([^"]+)"/\1/p' "$target" | head -n 1)"
+  [[ -n "$existing_version" ]] || { echo "$target has no parseable version" >&2; exit 1; }
+  node --input-type=module - "$TAG" "v$existing_version" "$ROOT/scripts/release-version.mjs" <<'NODE'
+import { pathToFileURL } from "node:url";
+const { compareReleaseTags, normalizeReleaseTag } = await import(pathToFileURL(process.argv[4]).href);
+const candidate = normalizeReleaseTag(process.argv[2]);
+const current = normalizeReleaseTag(process.argv[3]);
+if (compareReleaseTags(candidate, current) < 0) {
+  console.error(`candidate ${candidate} would regress Homebrew ${current}`);
+  process.exit(1);
+}
+if (compareReleaseTags(candidate, current) === 0) process.exit(0);
+NODE
+  if cmp -s "$FORMULA_SOURCE" "$target"; then
+    echo "Homebrew Formula $formula_name@$TAG is already complete"
+    exit 0
+  fi
+  if [[ "$existing_version" == "${TAG#v}" ]]; then
+    echo "Homebrew Formula $target has different content for ${TAG#v}; refusing replacement" >&2
+    exit 1
+  fi
+fi
+
+cp "$FORMULA_SOURCE" "$target"
+git add "$target"
+if git diff --cached --quiet; then
+  echo "Homebrew Formula $formula_name@$TAG is already complete"
+  exit 0
+fi
+git config user.name "Herdr World Release Bot"
+git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+git commit -m "Update $formula_name to ${TAG#v}" >/dev/null
+git -c "http.extraheader=AUTHORIZATION: basic $auth" push origin "$default_branch" >/dev/null
+echo "Published Homebrew Formula $formula_name@$TAG"

--- a/scripts/validate-release.mjs
+++ b/scripts/validate-release.mjs
@@ -5,6 +5,7 @@ import { join } from "node:path";
 
 import {
   assertCurrentReleaseReferences,
+  escapeRegex,
   normalizeReleaseTag,
   releaseVersion,
 } from "./release-version.mjs";
@@ -66,7 +67,7 @@ try {
 }
 
 const changelog = readFileSync(join(root, "CHANGELOG.md"), "utf8");
-const changelogHeading = new RegExp(`^## \\[${releaseVersion(tag).replace(/[.*+?^${}()|[\\]\\]/g, "\\$&")}\\] - `, "m");
+const changelogHeading = new RegExp(`^## \\[${escapeRegex(releaseVersion(tag))}\\] - `, "m");
 if (!changelogHeading.test(changelog)) {
   fail(`CHANGELOG.md has no released section for ${tag}`);
 }

--- a/scripts/validate-release.mjs
+++ b/scripts/validate-release.mjs
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import {
+  assertCurrentReleaseReferences,
+  normalizeReleaseTag,
+  releaseVersion,
+} from "./release-version.mjs";
+
+const root = process.cwd();
+const suppliedTag = process.argv[2] ?? process.env.GITHUB_REF_NAME;
+
+function fail(message) {
+  console.error(`Release validation failed: ${message}`);
+  process.exit(1);
+}
+
+function output(command, args) {
+  try {
+    return execFileSync(command, args, { cwd: root, encoding: "utf8" }).trim();
+  } catch (error) {
+    fail(`${command} ${args.join(" ")} failed: ${error.message}`);
+  }
+}
+
+if (!suppliedTag) fail("a release tag is required");
+let tag;
+try {
+  tag = normalizeReleaseTag(suppliedTag);
+} catch (error) {
+  fail(error.message);
+}
+if (suppliedTag !== tag) {
+  fail(`workflow release refs must use the canonical tag ${tag}`);
+}
+
+const tagSha = output("git", ["rev-list", "-n", "1", `refs/tags/${tag}`]);
+const expectedSha = process.env.GITHUB_SHA;
+if (expectedSha && tagSha !== expectedSha) {
+  fail(`tag ${tag} resolves to ${tagSha}, not GITHUB_SHA ${expectedSha}`);
+}
+if (output("git", ["tag", "--points-at", tagSha, "--list", tag]) !== tag) {
+  fail(`tag ${tag} does not point at the workflow commit`);
+}
+
+try {
+  execFileSync("git", ["merge-base", "--is-ancestor", tagSha, "origin/main"], {
+    cwd: root,
+    stdio: "ignore",
+  });
+} catch {
+  fail(`tagged commit ${tagSha} is not reachable from fetched protected origin/main`);
+}
+
+const subject = output("git", ["show", "-s", "--format=%s", tagSha]);
+if (subject !== `Release ${tag}`) {
+  fail(`tagged commit subject must be exactly Release ${tag}; found ${subject}`);
+}
+
+try {
+  assertCurrentReleaseReferences(root);
+} catch (error) {
+  fail(error.message);
+}
+
+const changelog = readFileSync(join(root, "CHANGELOG.md"), "utf8");
+const changelogHeading = new RegExp(`^## \\[${releaseVersion(tag).replace(/[.*+?^${}()|[\\]\\]/g, "\\$&")}\\] - `, "m");
+if (!changelogHeading.test(changelog)) {
+  fail(`CHANGELOG.md has no released section for ${tag}`);
+}
+
+for (const relativePath of ["package.json", "web/package.json"]) {
+  let manifest;
+  try {
+    manifest = JSON.parse(readFileSync(join(root, relativePath), "utf8"));
+  } catch (error) {
+    fail(`could not read ${relativePath}: ${error.message}`);
+  }
+  if (manifest.private !== true || manifest.version !== "0.0.0") {
+    fail(`${relativePath} must remain the private development manifest at version 0.0.0`);
+  }
+}
+
+const pluginPath = join(root, "herdr-plugin.toml");
+try {
+  const plugin = readFileSync(pluginPath, "utf8");
+  const pluginVersion = plugin.match(/^version\s*=\s*"([^"]+)"\s*$/m)?.[1];
+  if (pluginVersion !== releaseVersion(tag)) {
+    fail(`herdr-plugin.toml version must be ${releaseVersion(tag)}`);
+  }
+} catch (error) {
+  if (error.code !== "ENOENT") fail(`could not read herdr-plugin.toml: ${error.message}`);
+}
+
+console.log(`Validated protected release ${tag} at ${tagSha}`);

--- a/scripts/verify-desktop-package.sh
+++ b/scripts/verify-desktop-package.sh
@@ -91,6 +91,23 @@ case "$PLATFORM" in
       echo "unexpected Linux bridge architecture: $binary_description" >&2
       exit 1
     }
+    command -v objdump >/dev/null 2>&1 || {
+      echo "objdump is required to verify the Linux glibc floor" >&2
+      exit 1
+    }
+    required_glibc="$(objdump -T "$BUNDLE/bin/herdr-world-bridge" \
+      | sed -nE 's/.*GLIBC_([0-9]+\.[0-9]+).*/\1/p' \
+      | sort -V \
+      | tail -n 1)"
+    [[ -n "$required_glibc" ]] || {
+      echo "could not determine the Linux bridge glibc requirements" >&2
+      exit 1
+    }
+    highest_glibc="$(printf '%s\n' "2.34" "$required_glibc" | sort -V | tail -n 1)"
+    [[ "$highest_glibc" == "2.34" ]] || {
+      echo "Linux bridge requires glibc $required_glibc; the supported floor is 2.34" >&2
+      exit 1
+    }
     ;;
   macos-arm64)
     [[ "$binary_description" == *"Mach-O 64-bit"* \


### PR DESCRIPTION
## Summary
- Implement Spec 017 as one protected, queued release workflow for GitHub Releases, npm, and Homebrew.
- Build and verify the three native archives once, then reuse the exact outputs for downstream packaging and publication retries.
- Add strict stable/RC identity handling, provenance validation, monotonic publication checks, draft-first GitHub releases, universal npm packaging, and stable/RC Homebrew Formula generation.
- Remove same-tag reissue support; corrections use the next RC number or a new stable version.
- Keep Spec 016/plugin publication deferred as agreed.

## Validation
- npm run check passed.
- 36 release tests, 442 web tests, and 281 Rust/bridge tests passed.
- Linux glibc floor and native archive verification passed.
- npm package pack/install/help smoke test passed.
- Formula generation and Ruby syntax validation passed.

## External setup
- Created public tap repository: https://github.com/IvoryHeart/homebrew-tap
- Added an active v* tag locking ruleset to this repository.
- Remaining manual steps are documented in docs/release.md: create a tap-scoped fine-grained PAT and save it as HOMEBREW_TAP_TOKEN; bootstrap the first npm RC with interactive 2FA, then configure npm trusted publishing for this exact workflow.