### PR TITLE
Attribute automated release distribution changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - Added one protected release workflow that assembles exact native artifacts for GitHub, npm, and
   Homebrew distribution, with platform-aware npm bridge selection and stable/RC Homebrew channels.
+  [Herdr World PR #29](https://github.com/IvoryHeart/herdr-world/pull/29)
 - Added a desktop `install` / `herdr-world-installer` entrypoint that installs the complete
   versioned World bundle for the current user, exposes the `herdr-world` command, and then hands off
   to the consent-based Herdr dependency setup.


### PR DESCRIPTION
Adds the merged PR #29 link to its Unreleased changelog entry before the first automated distribution release.