### PR TITLE
Fix release validation reliability

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -718,11 +718,19 @@ jobs:
             exit 1
           }
           formula_name="$(basename "$formula_file" .rb)"
-          brew audit --strict --online "$formula_file"
-          brew install --formula "$formula_file"
-          brew test "$formula_name"
-          brew reinstall --formula "$formula_name"
-          brew uninstall --force "$formula_name"
+          tap_owner="${HOMEBREW_TAP_REPOSITORY%%/*}"
+          tap_repository="${HOMEBREW_TAP_REPOSITORY#*/}"
+          tap_name="$tap_owner/${tap_repository#homebrew-}"
+          brew tap "$tap_name"
+          tap_root="$(brew --repository "$tap_name")"
+          mkdir -p "$tap_root/Formula"
+          cp "$formula_file" "$tap_root/Formula/${formula_name}.rb"
+          qualified_formula="$tap_name/$formula_name"
+          brew audit --strict --online "$qualified_formula"
+          brew install --formula "$qualified_formula"
+          brew test "$qualified_formula"
+          brew reinstall --formula "$qualified_formula"
+          brew uninstall --force "$qualified_formula"
 
   npm_publish:
     name: Publish npm channel

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Fixed
 
 - Updated Homebrew release validation for current name-based audit and trusted-tap requirements.
+  [Herdr World PR #31](https://github.com/IvoryHeart/herdr-world/pull/31)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- Updated Homebrew release validation for current name-based audit and trusted-tap requirements.
+
 ### Removed
 
 ## [0.1.0-rc.2] - 2026-08-29

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@capacitor/cli": "^8.4.0",
         "@playwright/test": "^1.55.0",
         "generate-license-file": "4.2.3",
+        "ghostty-web": "0.4.0",
         "typescript": "^5.9.3",
         "ws": "^8.18.3"
       }
@@ -1389,6 +1390,13 @@
       "engines": {
         "node": ">=20"
       }
+    },
+    "node_modules/ghostty-web": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/ghostty-web/-/ghostty-web-0.4.0.tgz",
+      "integrity": "sha512-0puDBik2qapbD/QQBW9o5ZHfXnZBqZWx/ctBiVtKZ6ZLds4NYb+wZuw1cRLXZk9zYovIQ908z3rvFhexAvc5Hg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/glob": {
       "version": "13.0.6",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "notices:generate": "node scripts/dependency-notices.mjs --generate",
     "notices:check": "node scripts/dependency-notices.mjs --check",
     "test:dev": "node --test scripts/dev.test.mjs",
-    "test:release": "node --test scripts/release-target.test.mjs scripts/release-version.test.mjs scripts/release-notes.test.mjs scripts/release-publication.test.mjs scripts/npm-launcher.test.mjs scripts/npm-registry-query.test.mjs scripts/homebrew-formula.test.mjs scripts/herdr-world-installer.test.mjs scripts/herdr-world-launcher.test.mjs",
+    "test:release": "node --test scripts/release-target.test.mjs scripts/release-version.test.mjs scripts/release-notes.test.mjs scripts/release-publication.test.mjs scripts/npm-launcher.test.mjs scripts/npm-registry-query.test.mjs scripts/homebrew-formula.test.mjs scripts/herdr-world-installer.test.mjs scripts/herdr-world-launcher.test.mjs scripts/terminal-screen.test.mjs",
     "test:pages": "node --test scripts/pages.test.mjs",
     "test:web": "npm run test --prefix web",
     "test:observability": "npm run test --prefix web -- observability.test.ts && cargo test --manifest-path bridge/Cargo.toml --bin herdr-web-bridge observability",
@@ -41,6 +41,7 @@
     "@capacitor/cli": "^8.4.0",
     "@playwright/test": "^1.55.0",
     "generate-license-file": "4.2.3",
+    "ghostty-web": "0.4.0",
     "typescript": "^5.9.3",
     "ws": "^8.18.3"
   },

--- a/scripts/live-bridge-smoke.mjs
+++ b/scripts/live-bridge-smoke.mjs
@@ -2,6 +2,7 @@
 
 import assert from "node:assert/strict";
 import WebSocket from "ws";
+import { createTerminalScreen } from "./terminal-screen.mjs";
 
 const bridgeA = process.env.HERDR_WEB_LIVE_BRIDGE_A;
 const bridgeB = process.env.HERDR_WEB_LIVE_BRIDGE_B;
@@ -132,25 +133,37 @@ function waitForTerminalSizeCommand(rows, cols, evidence) {
     `target="$(printf '%s' ${targetParts})"; i=0; ` +
     'while [ "$i" -lt 100 ]; do current="$(stty size | tr -d \'[:space:]\')"; ' +
     '[ "$current" = "$target" ] && break; i=$((i+1)); sleep 0.05; done; ' +
-    `printf '\\033[32m${evidence}_UNICODE_λ\\033[0m\\n'; printf '%s\\n' "$current"\n`
+    `printf '\\033[32m${evidence}_UNICODE_λ\\033[0m\\n'; ` +
+    `printf '${evidence}_SIZE_%s\\n' "$current"\n`
   );
 }
 
+let attachSequence = 0;
+const terminalConnections = new Map();
+
+function connectionKey(origin, terminalId) {
+  return `${origin}\u0000${terminalId}`;
+}
+
+function resizeTerminalScreens(key, cols, rows) {
+  for (const connection of terminalConnections.get(key) ?? []) {
+    connection.screen.resize(cols, rows);
+  }
+}
+
 async function attach(origin, terminalId, cols, rows) {
+  const screen = await createTerminalScreen(cols, rows);
   const socket = new WebSocket(socketUrl(origin, terminalId, cols, rows));
-  let output = "";
+  const key = connectionKey(origin, terminalId);
   const waiters = new Set();
-  const terminalText = () =>
-    output
-      .replace(/\u001b\][^\u0007]*(?:\u0007|\u001b\\)/gu, "")
-      .replace(/\u001b\[[0-?]*[ -/]*[@-~]/gu, "")
-      .replace(/\u001b[()][0-2A-Z]/gu, "");
+  let closed = false;
+  const terminalText = () => screen.text();
   socket.on("message", (data, isBinary) => {
-    if (!isBinary) {
+    if (closed || !isBinary) {
       return;
     }
     const bytes = Buffer.from(data);
-    output += bytes.toString("utf8");
+    screen.write(bytes);
     const textOutput = terminalText();
     for (const waiter of waiters) {
       if (textOutput.includes(waiter.marker)) {
@@ -160,16 +173,48 @@ async function attach(origin, terminalId, cols, rows) {
       }
     }
   });
-  await new Promise((resolve, reject) => {
-    socket.once("open", resolve);
-    socket.once("error", reject);
-  });
-  return {
+  try {
+    await new Promise((resolve, reject) => {
+      const finish = (callback, value) => {
+        clearTimeout(timer);
+        socket.off("open", onOpen);
+        socket.off("error", onError);
+        socket.off("close", onClose);
+        callback(value);
+      };
+      const onOpen = () => finish(resolve);
+      const onError = (error) => finish(reject, error);
+      const onClose = () =>
+        finish(
+          reject,
+          new Error(`terminal socket closed before opening for ${origin}`),
+        );
+      const timer = setTimeout(
+        () =>
+          finish(
+            reject,
+            new Error(`terminal socket did not open for ${origin}`),
+          ),
+        10_000,
+      );
+      socket.once("open", onOpen);
+      socket.once("error", onError);
+      socket.once("close", onClose);
+    });
+  } catch (error) {
+    screen.close();
+    socket.on("error", () => {});
+    socket.terminate();
+    throw error;
+  }
+  const connection = {
     socket,
+    screen,
     send(data) {
       socket.send(JSON.stringify({ type: "input", data }));
     },
     resize(colsValue, rowsValue) {
+      resizeTerminalScreens(key, colsValue, rowsValue);
       socket.send(
         JSON.stringify({ type: "resize", cols: colsValue, rows: rowsValue }),
       );
@@ -200,9 +245,23 @@ async function attach(origin, terminalId, cols, rows) {
       });
     },
     close() {
+      if (closed) {
+        return;
+      }
+      closed = true;
+      terminalConnections.get(key)?.delete(connection);
+      screen.close();
       socket.close();
     },
   };
+  const connections = terminalConnections.get(key) ?? new Set();
+  connections.add(connection);
+  terminalConnections.set(key, connections);
+  resizeTerminalScreens(key, cols, rows);
+  const readyMarker = `SPEC010_ATTACH_${++attachSequence}`;
+  connection.send(waitForTerminalSizeCommand(rows, cols, readyMarker));
+  await connection.waitFor(`${readyMarker}_SIZE_${rows}${cols}`);
+  return connection;
 }
 
 const stateA = await bridgeState(bridgeA);
@@ -238,20 +297,16 @@ try {
   const markerA = `SPEC010_A_${Date.now()}`;
   secondA.send(waitForTerminalSizeCommand(28, 91, markerA));
   await Promise.all([
-    firstA.waitFor(`${markerA}_UNICODE_λ`),
-    secondA.waitFor(`${markerA}_UNICODE_λ`),
-    firstA.waitFor("2891"),
-    secondA.waitFor("2891"),
+    firstA.waitFor(`${markerA}_SIZE_2891`),
+    secondA.waitFor(`${markerA}_SIZE_2891`),
   ]);
 
   firstA.resize(101, 31);
   const refitMarker = `${markerA}_REFIT`;
   firstA.send(waitForTerminalSizeCommand(31, 101, refitMarker));
   await Promise.all([
-    firstA.waitFor(refitMarker),
-    secondA.waitFor(refitMarker),
-    firstA.waitFor("31101"),
-    secondA.waitFor("31101"),
+    firstA.waitFor(`${refitMarker}_SIZE_31101`),
+    secondA.waitFor(`${refitMarker}_SIZE_31101`),
   ]);
 
   const interruptMarker = `${markerA}_INTERRUPTED`;

--- a/scripts/live-stock-v082.sh
+++ b/scripts/live-stock-v082.sh
@@ -84,13 +84,20 @@ HERDR_SOCKET_PATH="$LIVE_ROOT/herdr-b.sock" \
   "$ROOT/scripts/run-bridge.sh" --bridge-label live-b >"$LIVE_ROOT/bridge-b.log" 2>&1 &
 pid_bridge_b=$!
 
+bridges_ready=false
 for _ in $(seq 1 100); do
   if curl -fsS "http://127.0.0.1:$BRIDGE_A_PORT/api/capabilities" >/dev/null 2>&1 \
     && curl -fsS "http://127.0.0.1:$BRIDGE_B_PORT/api/capabilities" >/dev/null 2>&1; then
+    bridges_ready=true
     break
   fi
   sleep 0.2
 done
+if [[ "$bridges_ready" != true ]]; then
+  echo "Herdr World bridges did not become ready" >&2
+  cat "$LIVE_ROOT/bridge-a.log" "$LIVE_ROOT/bridge-b.log" >&2
+  exit 1
+fi
 
 HERDR_WEB_LIVE_BRIDGE_A="http://127.0.0.1:$BRIDGE_A_PORT" \
   HERDR_WEB_LIVE_BRIDGE_B="http://127.0.0.1:$BRIDGE_B_PORT" \

--- a/scripts/terminal-screen.mjs
+++ b/scripts/terminal-screen.mjs
@@ -1,0 +1,42 @@
+import { Ghostty } from "ghostty-web";
+
+let ghosttyPromise;
+
+async function loadGhostty() {
+  globalThis.self ??= globalThis;
+  ghosttyPromise ??= Ghostty.load();
+  return ghosttyPromise;
+}
+
+function lineText(cells) {
+  return cells
+    .map((cell) =>
+      cell.codepoint === 0 ? " " : String.fromCodePoint(cell.codepoint),
+    )
+    .join("")
+    .trimEnd();
+}
+
+export async function createTerminalScreen(cols, rows) {
+  const ghostty = await loadGhostty();
+  const terminal = ghostty.createTerminal(cols, rows);
+
+  return {
+    write(data) {
+      terminal.write(data);
+    },
+    resize(nextCols, nextRows) {
+      terminal.resize(nextCols, nextRows);
+    },
+    text() {
+      const lines = [];
+      for (let row = 0; row < terminal.rows; row += 1) {
+        lines.push(lineText(terminal.getLine(row) ?? []));
+      }
+      return lines.join("\n");
+    },
+    close() {
+      terminal.free();
+    },
+  };
+}

--- a/scripts/terminal-screen.test.mjs
+++ b/scripts/terminal-screen.test.mjs
@@ -1,0 +1,22 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { createTerminalScreen } from "./terminal-screen.mjs";
+
+test("renders stateful ANSI updates as the terminal screen", async () => {
+  const screen = await createTerminalScreen(20, 4);
+
+  try {
+    screen.write("old value");
+    screen.write("\r\u001b[2Cw");
+    assert.equal(screen.text().split("\n")[0], "olw value");
+
+    screen.write("\u001b[2;1HSIZE_31101");
+    assert.match(screen.text(), /SIZE_31101/);
+
+    screen.resize(30, 5);
+    screen.write("\u001b[3;1HRESIZED");
+    assert.match(screen.text(), /RESIZED/);
+  } finally {
+    screen.close();
+  }
+});

--- a/tests/e2e/world.spec.ts
+++ b/tests/e2e/world.spec.ts
@@ -566,7 +566,6 @@ test("deduplicates terminal windows and stops at the five-window Office cap", as
 test("moves and resizes the Office conversation bubble without losing its live anchors", async ({
   page,
 }) => {
-  test.setTimeout(45_000);
   await page.setViewportSize({ width: 1440, height: 900 });
   await page.goto("/world");
   await waitForOffice(page);


### PR DESCRIPTION
Updates release validation for current Homebrew, which no longer accepts formula paths for `brew audit`. The generated formula is staged in the configured tap checkout and audited/exercised by its fully qualified name.

Also fixes the two timing-related test-harness failures found during release validation:

- the Office drag/resize test now inherits the suite's 90-second CI budget instead of overriding it with 45 seconds;
- the live terminal smoke test renders stateful ANSI updates with the same Ghostty terminal core used by the web app, waits for attach readiness, and bounds socket/bridge startup waits.

Validation:

- `npm run check`
- Office drag/resize Playwright test: 20/20 repeated passes
- stock Herdr v0.8.2 live terminal smoke: 50/50 repeated passes on isolated ports