### PR TITLE
Fix Homebrew Formula version inference

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -503,22 +503,21 @@ jobs:
           formula_error="${RUNNER_TEMP}/homebrew-formula-api-error"
           formula_json=""
           if formula_json="$(gh api "$endpoint" 2>"$formula_error")"; then
-            formula_version="$(node --input-type=module - "$formula_json" <<'NODE'
+            formula_tag="$(node --input-type=module - "$formula_json" <<'NODE'
+          import { homebrewFormulaReleaseTag } from './scripts/homebrew-formula.mjs';
           const response = JSON.parse(process.argv[2]);
           const contents = Buffer.from(response.content, 'base64').toString('utf8');
-          const version = contents.match(/^\s*version\s+"([^"]+)"/m)?.[1];
-          if (!version) process.exit(1);
-          console.log(version);
+          console.log(homebrewFormulaReleaseTag(contents));
           NODE
             )"
-            comparison="$(node --input-type=module - "$VERSION" "v$formula_version" <<'NODE'
+            comparison="$(node --input-type=module - "$VERSION" "$formula_tag" <<'NODE'
           import { compareReleaseTags } from './scripts/release-version.mjs';
           const [candidate, current] = process.argv.slice(2);
           console.log(compareReleaseTags(candidate, current));
           NODE
             )"
             if [[ "$comparison" == "-1" ]]; then
-              echo "Homebrew Formula already reaches v$formula_version; candidate $VERSION must be higher" >&2
+              echo "Homebrew Formula already reaches $formula_tag; candidate $VERSION must be higher" >&2
               exit 1
             fi
             if [[ "$comparison" == "0" ]]; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 ### Fixed
 
+- Let Homebrew derive the package version from immutable release URLs, avoiding a redundant
+  explicit version rejected by current Formula audit while preserving release-state safeguards.
+  [Herdr World PR #33](https://github.com/IvoryHeart/herdr-world/pull/33)
+
 ### Removed
 
 ## [0.1.0-rc.4] - 2026-08-29

--- a/scripts/homebrew-formula.mjs
+++ b/scripts/homebrew-formula.mjs
@@ -3,10 +3,31 @@ import { readFileSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { normalizeReleaseTag, releaseVersion } from "./release-version.mjs";
+import { normalizeReleaseTag } from "./release-version.mjs";
+
+const RELEASE_ARCHIVE_TAG_PATTERN =
+  /https:\/\/github\.com\/IvoryHeart\/herdr-world\/releases\/download\/(v[^/"\s]+)\//g;
 
 export function homebrewFormulaName(tag) {
   return normalizeReleaseTag(tag).includes("-rc.") ? "herdr-world-rc" : "herdr-world";
+}
+
+export function homebrewFormulaReleaseTag(formula) {
+  if (typeof formula !== "string") {
+    throw new Error("Homebrew Formula contents must be a string");
+  }
+  const tags = new Set(
+    [...formula.matchAll(RELEASE_ARCHIVE_TAG_PATTERN)].map((match) =>
+      normalizeReleaseTag(match[1]),
+    ),
+  );
+  if (tags.size === 0) {
+    throw new Error("Homebrew Formula has no parseable Herdr World release URL");
+  }
+  if (tags.size !== 1) {
+    throw new Error("Homebrew Formula release URLs do not use one version");
+  }
+  return [...tags][0];
 }
 
 function archiveUrl(tag, platform) {
@@ -16,7 +37,6 @@ function archiveUrl(tag, platform) {
 
 export function renderHomebrewFormula({ tag, checksums }) {
   const normalizedTag = normalizeReleaseTag(tag);
-  const version = releaseVersion(normalizedTag);
   const formulaName = homebrewFormulaName(normalizedTag);
   const className = formulaName
     .split("-")
@@ -34,7 +54,6 @@ export function renderHomebrewFormula({ tag, checksums }) {
   return `class ${className} < Formula
   desc "Browser and mobile client for monitoring and controlling Herdr agents"
   homepage "https://ivoryheart.github.io/herdr-world/"
-  version "${version}"
 
   on_macos do
     on_arm do

--- a/scripts/homebrew-formula.test.mjs
+++ b/scripts/homebrew-formula.test.mjs
@@ -3,6 +3,7 @@ import test from "node:test";
 
 import {
   homebrewFormulaName,
+  homebrewFormulaReleaseTag,
   renderHomebrewFormula,
 } from "./homebrew-formula.mjs";
 
@@ -16,7 +17,8 @@ test("generates the stable Formula from exact release archives", () => {
   const formula = renderHomebrewFormula({ tag: "v1.2.3", checksums });
   assert.equal(homebrewFormulaName("v1.2.3"), "herdr-world");
   assert.match(formula, /class HerdrWorld < Formula/);
-  assert.match(formula, /version "1\.2\.3"/);
+  assert.doesNotMatch(formula, /^\s*version\b/m);
+  assert.equal(homebrewFormulaReleaseTag(formula), "v1.2.3");
   assert.match(formula, /herdr-world-v1\.2\.3-linux-x86_64\.tar\.gz/);
   assert.match(formula, /sha256 "111111/);
   assert.match(formula, /conflicts_with "herdr-world-rc"/);
@@ -27,8 +29,27 @@ test("generates the RC Formula without advancing stable", () => {
   const formula = renderHomebrewFormula({ tag: "v1.2.3-rc.2", checksums });
   assert.equal(homebrewFormulaName("v1.2.3-rc.2"), "herdr-world-rc");
   assert.match(formula, /class HerdrWorldRc < Formula/);
-  assert.match(formula, /version "1\.2\.3-rc\.2"/);
+  assert.doesNotMatch(formula, /^\s*version\b/m);
+  assert.equal(homebrewFormulaReleaseTag(formula), "v1.2.3-rc.2");
   assert.match(formula, /conflicts_with "herdr-world"/);
+});
+
+test("requires every Formula archive URL to use one release tag", () => {
+  const formula = renderHomebrewFormula({ tag: "v1.2.3", checksums });
+  assert.throws(
+    () =>
+      homebrewFormulaReleaseTag(
+        formula.replace(
+          "releases/download/v1.2.3/herdr-world-v1.2.3-macos-arm64",
+          "releases/download/v1.2.4/herdr-world-v1.2.4-macos-arm64",
+        ),
+      ),
+    /do not use one version/,
+  );
+  assert.throws(
+    () => homebrewFormulaReleaseTag('url "https://example.com/archive.tar.gz"'),
+    /no parseable Herdr World release URL/,
+  );
 });
 
 test("requires every native archive checksum", () => {

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -3,6 +3,7 @@ import { execFileSync } from "node:child_process";
 import { readFileSync, writeFileSync } from "node:fs";
 
 import { queryNpm } from "./npm-registry-query.mjs";
+import { homebrewFormulaReleaseTag } from "./homebrew-formula.mjs";
 import {
   HOMEBREW_TAP_REPOSITORY,
   NPM_PACKAGE_NAME,
@@ -175,11 +176,12 @@ function checkExternalVersionAvailability() {
   );
   if (response) {
     const contents = Buffer.from(response.content, "base64").toString("utf8");
-    const formulaVersion = contents.match(/^\s*version\s+"([^"]+)"/m)?.[1];
-    if (!formulaVersion) {
-      fail(`Homebrew Formula ${formulaPath} has no parseable version`);
+    let currentTag;
+    try {
+      currentTag = homebrewFormulaReleaseTag(contents);
+    } catch (error) {
+      fail(`Homebrew Formula ${formulaPath} has no parseable version: ${error.message}`);
     }
-    const currentTag = normalizeReleaseTag(`v${formulaVersion}`);
     if (compareReleaseTags(tag, currentTag) <= 0) {
       fail(`Homebrew Formula ${formulaPath} already reaches ${currentTag}`);
     }

--- a/scripts/update-homebrew-tap.sh
+++ b/scripts/update-homebrew-tap.sh
@@ -47,9 +47,14 @@ git pull --ff-only origin "$default_branch" >/dev/null
 mkdir -p Formula
 target="Formula/$formula_name.rb"
 if [[ -f "$target" ]]; then
-  existing_version="$(sed -nE 's/^  version "([^"]+)"/\1/p' "$target" | head -n 1)"
-  [[ -n "$existing_version" ]] || { echo "$target has no parseable version" >&2; exit 1; }
-  node --input-type=module - "$TAG" "v$existing_version" "$ROOT/scripts/release-version.mjs" <<'NODE'
+  existing_tag="$(node --input-type=module - "$target" "$ROOT/scripts/homebrew-formula.mjs" <<'NODE'
+import { readFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+const { homebrewFormulaReleaseTag } = await import(pathToFileURL(process.argv[3]).href);
+console.log(homebrewFormulaReleaseTag(readFileSync(process.argv[2], "utf8")));
+NODE
+  )"
+  node --input-type=module - "$TAG" "$existing_tag" "$ROOT/scripts/release-version.mjs" <<'NODE'
 import { pathToFileURL } from "node:url";
 const { compareReleaseTags, normalizeReleaseTag } = await import(pathToFileURL(process.argv[4]).href);
 const candidate = normalizeReleaseTag(process.argv[2]);
@@ -64,8 +69,8 @@ NODE
     echo "Homebrew Formula $formula_name@$TAG is already complete"
     exit 0
   fi
-  if [[ "$existing_version" == "${TAG#v}" ]]; then
-    echo "Homebrew Formula $target has different content for ${TAG#v}; refusing replacement" >&2
+  if [[ "$existing_tag" == "$TAG" ]]; then
+    echo "Homebrew Formula $target has different content for $TAG; refusing replacement" >&2
     exit 1
   fi
 fi


### PR DESCRIPTION
## Summary
- remove the explicit Formula version that current Homebrew rejects as redundant
- derive release state from the immutable GitHub archive URLs instead
- keep monotonic and same-version replacement guards in release preflight, CI, and tap publication

## Evidence
- rc.4 Apple Silicon audit failure: https://github.com/IvoryHeart/herdr-world/actions/runs/33230367426/job/99042934704
- `npm run test:release` (43/43)
- `bash -n scripts/update-homebrew-tap.sh`
- workflow YAML parse and `git diff --check`

The failing audit was specific and reproducible: `version 0.1.0-rc.4 is redundant with version scanned from URL`. Linux and Intel accepted it, but the generated Formula must be valid on current Homebrew across all supported hosts.