### PR TITLE
Wait for npm publish-time scanning

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -776,7 +776,7 @@ jobs:
       publication_result: ${{ steps.publish.outputs.result || steps.state.outputs.result }}
       publication_url: ${{ steps.publish.outputs.url || steps.state.outputs.url }}
     runs-on: ubuntu-24.04
-    timeout-minutes: 15
+    timeout-minutes: 30
     permissions:
       contents: read
       id-token: write
@@ -898,9 +898,30 @@ jobs:
               ;;
             *) echo "unknown npm publication action: $action" >&2; exit 1 ;;
           esac
-          registry_integrity="$(npm view "$NPM_PACKAGE_NAME@${VERSION#v}" dist.integrity --json | tr -d '"')"
-          registry_pointer="$(npm view "$NPM_PACKAGE_NAME" "dist-tags.$channel" --json | tr -d '"')"
           metadata_integrity="$(node -e 'console.log(JSON.parse(require("fs").readFileSync(process.argv[1])).integrity)' npm-output/npm-package-metadata.json)"
+          npm_value() {
+            node --input-type=module - "$1" <<'NODE'
+          const state = JSON.parse(process.argv[2]);
+          if (!state.present || !state.raw || state.raw === "null" || state.raw === "undefined") process.exit(0);
+          const value = JSON.parse(state.raw);
+          if (value !== null && value !== undefined) process.stdout.write(String(value));
+          NODE
+          }
+          availability_attempts=1
+          [[ "$action" == "publish" ]] && availability_attempts=80
+          registry_integrity=""
+          registry_pointer=""
+          for ((attempt = 1; attempt <= availability_attempts; attempt++)); do
+            registry_integrity="$(npm_value "$(node scripts/npm-registry-query.mjs state view "$NPM_PACKAGE_NAME@${VERSION#v}" dist.integrity --json)")"
+            registry_pointer="$(npm_value "$(node scripts/npm-registry-query.mjs state view "$NPM_PACKAGE_NAME" "dist-tags.$channel" --json)")"
+            [[ -n "$registry_integrity" && -n "$registry_pointer" ]] && break
+            if (( attempt == availability_attempts )); then
+              echo "npm did not make $NPM_PACKAGE_NAME@${VERSION#v} available within the validation window" >&2
+              exit 1
+            fi
+            echo "npm publish-time scan is still pending; retrying public verification in 15 seconds"
+            sleep 15
+          done
           [[ "$registry_integrity" == "$metadata_integrity" ]]
           [[ "$registry_pointer" == "${VERSION#v}" ]]
           url="https://www.npmjs.com/package/${NPM_PACKAGE_NAME}/v/${VERSION#v}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 ### Fixed
 
+- Allowed npm release publication to wait for publish-time malware scanning before verifying the
+  immutable version, integrity, and channel pointer.
+  [Herdr World PR #34](https://github.com/IvoryHeart/herdr-world/pull/34)
+
 ### Removed
 
 ## [0.1.0-rc.5] - 2026-08-29

--- a/docs/release.md
+++ b/docs/release.md
@@ -229,6 +229,12 @@ npm publish herdr-world-vX.Y.Z-rc.N.tgz --access public --tag next
    disallow traditional publishing tokens. Later tagged releases publish through OIDC and require
    no `NPM_TOKEN`.
 
+npm scans newly published packages before making them publicly installable. Initial verification
+may return not found for several minutes even after `npm publish` succeeds; do not republish the
+immutable version. The protected workflow waits up to 20 minutes for public availability before
+verifying the exact integrity and channel pointer, and an idempotent rerun can finish validation if
+the scan takes longer.
+
 Create the tap-scoped fine-grained GitHub token manually and save it as the repository Actions secret
 `HOMEBREW_TAP_TOKEN`. It needs only Contents read/write access to `IvoryHeart/homebrew-tap`; it must
 not be written to a Formula, artifact, cache, or log. The workflow validates and exercises the


### PR DESCRIPTION
## Summary
- wait for a newly published npm version to become publicly visible before verifying it
- retain fail-closed registry queries and exact integrity/dist-tag checks
- document npm's publish-time scan and safe idempotent rerun behavior

## Evidence
- rc.5 was accepted by `npm publish`, then remained unavailable via public `npm view` during scanning while authenticated access reported it as public and owned
- after scanning, integrity matched `sha512-+kxFnV9/Y9vzrO45AA/69vrJXSWNq1SLt7DAkZx00OVyLwU/D1LVfQMI3rMBPxFMPv2CHsd62tf4EoliFUG2/Q==`, `next` pointed to rc.5, and a clean registry install passed
- official behavior: https://github.blog/changelog/2026-07-28-npm-publish-time-malware-scanning-and-dual-use-metadata/
- `npm run test:release` (43/43), workflow YAML parse, extracted shell syntax check, and `git diff --check`