### PR TITLE
feat: add Herdr World plugin release payload

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,48 +4,13 @@ on:
   push:
     tags:
       - "v*"
-  pull_request:
-    paths:
-      - ".github/workflows/release.yml"
-      - "scripts/desktop-artifact-metadata.mjs"
-      - "scripts/homebrew-checksums.mjs"
-      - "scripts/homebrew-formula.mjs"
-      - "scripts/npm-launcher.mjs"
-      - "scripts/npm-package-inspect.mjs"
-      - "scripts/npm-package.mjs"
-      - "scripts/npm-registry-query.mjs"
-      - "scripts/package-tarball.sh"
-      - "scripts/release-notes.mjs"
-      - "scripts/release-notes.test.mjs"
-      - "scripts/release-publication.mjs"
-      - "scripts/release-version.mjs"
-      - "scripts/update-homebrew-tap.sh"
-      - "scripts/validate-release.mjs"
-      - "scripts/verify-desktop-package.sh"
-      - "scripts/live-stock-v082.sh"
-      - "scripts/live-bridge-smoke.mjs"
-      - "scripts/herdr-world-launcher.sh"
-      - "scripts/herdr-world-installer.sh"
-      - "scripts/herdr-world-installer.test.mjs"
-      - "scripts/dependency-notices.mjs"
-      - "scripts/stage-web-legal-assets.mjs"
-      - "bridge/**"
-      - "vendor/**"
-      - "web/**"
-      - "third_party/**"
-      - "docs/**"
-      - "package.json"
-      - "package-lock.json"
-      - "LICENSE"
-      - "THIRD_PARTY_NOTICES.md"
-      - "UPSTREAM.md"
   workflow_dispatch:
 
 permissions:
   contents: read
 
-# Release tags share one FIFO queue. Validation runs use a separate group so
-# pull requests and manual checks never block or publish a real release.
+# Release tags share one FIFO queue. Explicit preflight runs use a separate
+# group so they never block or publish a real release.
 concurrency:
   group: ${{ github.event_name == 'push' && 'herdr-world-release-queue' || format('herdr-world-validation-{0}', github.run_id) }}
   queue: max
@@ -697,7 +662,7 @@ jobs:
           path: formula
           run-id: ${{ github.run_id }}
           github-token: ${{ github.token }}
-      - name: Download the local native archive for manual validation
+      - name: Download the local native archive for explicit preflight
         if: github.event_name == 'workflow_dispatch'
         uses: actions/download-artifact@v8
         with:
@@ -705,14 +670,7 @@ jobs:
           path: formula-native
           run-id: ${{ github.run_id }}
           github-token: ${{ github.token }}
-      - name: Validate Formula syntax on pull requests
-        if: github.event_name == 'pull_request'
-        run: |
-          formula_file="$(find formula -maxdepth 1 -type f \( -name 'herdr-world.rb' -o -name 'herdr-world-rc.rb' \) -print -quit)"
-          [[ -n "$formula_file" ]] || { echo "no channel-specific Formula was downloaded" >&2; exit 1; }
-          ruby -c "$formula_file"
       - name: Install, exercise, reinstall, and uninstall Formula
-        if: github.event_name != 'pull_request'
         shell: bash
         run: |
           formula_file="$(find formula -maxdepth 1 -type f \( -name 'herdr-world.rb' -o -name 'herdr-world-rc.rb' \) -print -quit)"
@@ -929,6 +887,61 @@ jobs:
           echo "url=$url" >> "$GITHUB_OUTPUT"
           echo "npm: $result — $url" >> "$GITHUB_STEP_SUMMARY"
 
+  plugin_smoke:
+    name: Herdr plugin smoke (${{ matrix.platform }})
+    if: >-
+      github.event_name == 'push' && github.ref_type == 'tag' &&
+      needs.npm_publish.result == 'success' &&
+      needs.npm_publish.outputs.publication_result != 'action-required'
+    needs: [npm_publish]
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 35
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux-x86_64
+            runner: ubuntu-24.04
+            herdr_asset: herdr-linux-x86_64
+            herdr_sha256: 976150a14d490c94b243ea2e1a7eb2dfb67f12e36b182db90936f6728e6aecf4
+          - platform: macos-arm64
+            runner: macos-15
+            herdr_asset: herdr-macos-aarch64
+            herdr_sha256: a5d4f4d504d8b309c91f811050559300faba31258425f53c50852fc96f6ae574
+          - platform: macos-x86_64
+            runner: macos-15-intel
+            herdr_asset: herdr-macos-x86_64
+            herdr_sha256: ab50262c8190cd7aa9056d249d255c08c328c3e8716de9cfa29db4f131b8e2c1
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22.14.0
+          package-manager-cache: false
+      - name: Download verified stock Herdr v0.8.2
+        env:
+          HERDR_ASSET: ${{ matrix.herdr_asset }}
+          HERDR_SHA256: ${{ matrix.herdr_sha256 }}
+        shell: bash
+        run: |
+          curl --proto '=https' --tlsv1.2 --fail --location --retry 3 \
+            "https://github.com/herdrdev/herdr/releases/download/v0.8.2/${HERDR_ASSET}" \
+            --output "${RUNNER_TEMP}/herdr"
+          if command -v sha256sum >/dev/null 2>&1; then
+            actual="$(sha256sum "${RUNNER_TEMP}/herdr" | awk '{print $1}')"
+          else
+            actual="$(shasum -a 256 "${RUNNER_TEMP}/herdr" | awk '{print $1}')"
+          fi
+          [[ "$actual" == "$HERDR_SHA256" ]]
+          chmod +x "${RUNNER_TEMP}/herdr"
+      - name: Install and exercise the tagged Herdr plugin
+        env:
+          HERDR_BIN: ${{ runner.temp }}/herdr
+          VERSION: ${{ github.ref_name }}
+        run: scripts/live-plugin-smoke.sh
+
   homebrew_publish:
     name: Publish Homebrew channel
     if: github.event_name == 'push' && github.ref_type == 'tag'
@@ -967,7 +980,7 @@ jobs:
   publication_summary:
     name: Release publication summary
     if: always() && github.event_name == 'push' && github.ref_type == 'tag'
-    needs: [github_release, npm_publish, homebrew_publish]
+    needs: [github_release, npm_publish, homebrew_publish, plugin_smoke]
     runs-on: ubuntu-24.04
     steps:
       - name: Summarize every channel
@@ -982,7 +995,7 @@ jobs:
             echo "| GitHub | ${VERSION#v} | ${{ needs.github_release.outputs.publication_result || needs.github_release.result }} | ${{ needs.github_release.outputs.publication_url || '—' }} |"
             echo "| npm (${NPM_PACKAGE_NAME}) | ${VERSION#v} | ${{ needs.npm_publish.outputs.publication_result || needs.npm_publish.result }} | ${{ needs.npm_publish.outputs.publication_url || '—' }} |"
             echo "| Homebrew (${HOMEBREW_TAP_REPOSITORY}) | ${VERSION#v} | ${{ needs.homebrew_publish.outputs.publication_result || needs.homebrew_publish.result }} | ${{ needs.homebrew_publish.outputs.publication_url || '—' }} |"
-            echo "| Herdr plugin | — | not enabled; Spec 016 remains a separate release tranche | — |"
+            echo "| Herdr plugin | ${VERSION#v} | ${{ needs.plugin_smoke.result == 'success' && 'validated' || needs.npm_publish.outputs.publication_result == 'action-required' && 'action-required' || needs.plugin_smoke.result }} | https://github.com/IvoryHeart/herdr-world |"
             echo
             echo "Source commit: $GITHUB_SHA"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 /bridge/target/
 /vendor/herdr-compat/target/
 /dist-packages/
+/.herdr-world-plugin/
 /_site/
 .specs/
 .scratch/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
 
 ### Added
 
+- Added the Herdr World plugin manifest and lifecycle controller. Herdr can install the exact
+  release-matched npm payload privately, supervise one loopback bridge per session, and expose
+  start/stop/restart/status/open/doctor actions without changing the standalone npm, Homebrew,
+  desktop, or Android distributions.
+
 ### Changed
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -200,17 +200,17 @@ session. It does not build Rust or web sources, use a global npm/Homebrew
 installation, or host the Android client.
 
 Inspect the manifest and controller before installing a plugin that runs code
-as your user, then install a release ref:
-
-```bash
-herdr plugin install IvoryHeart/herdr-world --ref v0.1.0-rc.5
-herdr plugin action invoke start --plugin ivoryheart.herdr-world
-```
-
-The unpinned form follows the repository's current default branch:
+as your user, then install the current default branch:
 
 ```bash
 herdr plugin install IvoryHeart/herdr-world
+herdr plugin action invoke start --plugin ivoryheart.herdr-world
+```
+
+To pin a release, use a tag that contains the plugin implementation:
+
+```bash
+herdr plugin install IvoryHeart/herdr-world --ref vX.Y.Z
 ```
 
 Plugin installation and runtime actions require Node.js `22.14.0` or newer
@@ -236,6 +236,14 @@ free port in `8787`–`8877`. Non-loopback binding requires explicit host and
 origin allow-lists and an operator-managed VPN, SSH forward, or authenticated
 reverse proxy; Host and Origin checks are not authentication. Stopping the
 plugin bridge disconnects browser clients but does not stop Herdr or its panes.
+
+The plugin has no uninstall cleanup hook. Stop the bridge before removing the
+managed plugin checkout:
+
+```bash
+herdr plugin action invoke stop --plugin ivoryheart.herdr-world
+herdr plugin uninstall ivoryheart.herdr-world
+```
 
 The plugin is separate from the standalone npm package, Homebrew Formula,
 desktop tarball, and Android companion distribution. See [docs/packaging.md](docs/packaging.md)

--- a/README.md
+++ b/README.md
@@ -73,6 +73,9 @@ site/                Dependency-free GitHub Pages project site
 android/             Capacitor Android shell for the bundled web app
 bridge/              Slim Rust HTTP/WebSocket bridge executable
 vendor/herdr-compat/ minimal Herdr protocol/API compatibility crate
+herdr-plugin.toml    Herdr plugin manifest
+scripts/herdr-world-plugin.sh
+scripts/live-plugin-smoke.sh
 scripts/run-bridge.sh
 scripts/check-vendor.sh
 docs/android.md
@@ -187,6 +190,56 @@ bin/herdr-world --host 0.0.0.0 --port 4000 \
 
 See [docs/packaging.md](docs/packaging.md) for release artifact layout and
 [docs/android.md](docs/android.md) for Android behavior.
+
+## Herdr Plugin
+
+The Herdr plugin is a lifecycle facade for the browser client. It installs the
+exact release-matched `@ivoryheart/herdr-world` payload into Herdr's managed
+plugin checkout, then supervises one local bridge for the invoking Herdr
+session. It does not build Rust or web sources, use a global npm/Homebrew
+installation, or host the Android client.
+
+Inspect the manifest and controller before installing a plugin that runs code
+as your user, then install a release ref:
+
+```bash
+herdr plugin install IvoryHeart/herdr-world --ref v0.1.0-rc.5
+herdr plugin action invoke start --plugin ivoryheart.herdr-world
+```
+
+The unpinned form follows the repository's current default branch:
+
+```bash
+herdr plugin install IvoryHeart/herdr-world
+```
+
+Plugin installation and runtime actions require Node.js `22.14.0` or newer
+and npm. Node must remain installed because the supervised bridge runs through
+the package's Node entrypoint. Local linking skips the build command; after
+linking, install the exact payload explicitly with the command printed by:
+
+```bash
+bash scripts/herdr-world-plugin.sh build
+```
+
+The plugin uses loopback `http://127.0.0.1:8787` by default. Its editable JSON
+configuration is outside the managed checkout; find its directory with:
+
+```bash
+herdr plugin config-dir ivoryheart.herdr-world
+```
+
+Set `host`, `port`, `port_range`, `session_name` or `socket_path`,
+`upload_dir`, `allowed_hosts`, `allowed_origins`, `allowed_connect_origins`,
+and `bridge_label` in `config.json` as needed. Named sessions use the first
+free port in `8787`–`8877`. Non-loopback binding requires explicit host and
+origin allow-lists and an operator-managed VPN, SSH forward, or authenticated
+reverse proxy; Host and Origin checks are not authentication. Stopping the
+plugin bridge disconnects browser clients but does not stop Herdr or its panes.
+
+The plugin is separate from the standalone npm package, Homebrew Formula,
+desktop tarball, and Android companion distribution. See [docs/packaging.md](docs/packaging.md)
+and [docs/release.md](docs/release.md) for their independent workflows.
 
 ## Development Setup
 

--- a/README.md
+++ b/README.md
@@ -238,12 +238,32 @@ reverse proxy; Host and Origin checks are not authentication. Stopping the
 plugin bridge disconnects browser clients but does not stop Herdr or its panes.
 
 The plugin has no uninstall cleanup hook. Stop the bridge before removing the
-managed plugin checkout:
+managed plugin checkout. Plugin action invocation is asynchronous and target-
+scoped, so repeat the stop-and-status sequence for every Herdr target or named
+session that has a managed bridge. Wait for each action's `log_id` to report
+`status: succeeded`; a returned `status: running` only means that Herdr queued
+the action.
 
 ```bash
+# For the current/default target:
 herdr plugin action invoke stop --plugin ivoryheart.herdr-world
+herdr plugin log list --plugin ivoryheart.herdr-world --limit 100
+herdr plugin action invoke status --plugin ivoryheart.herdr-world
+herdr plugin log list --plugin ivoryheart.herdr-world --limit 100
+
+# Repeat the same four commands for every named target, replacing NAME:
+herdr --session NAME plugin action invoke stop --plugin ivoryheart.herdr-world
+herdr --session NAME plugin log list --plugin ivoryheart.herdr-world --limit 100
+herdr --session NAME plugin action invoke status --plugin ivoryheart.herdr-world
+herdr --session NAME plugin log list --plugin ivoryheart.herdr-world --limit 100
+
+# Only after every stop/status action reports succeeded and the target is not running:
 herdr plugin uninstall ivoryheart.herdr-world
 ```
+
+Run the `log list` command again until the corresponding action's `log_id` has
+`status: succeeded`; for `status`, also confirm its output says the bridge is
+not running. Then uninstall the plugin.
 
 The plugin is separate from the standalone npm package, Homebrew Formula,
 desktop tarball, and Android companion distribution. See [docs/packaging.md](docs/packaging.md)

--- a/docs/npm-readme.md
+++ b/docs/npm-readme.md
@@ -23,3 +23,17 @@ Content Security Policy checks are request protections, not user authentication.
 
 The package includes the complete application legal notices and dependency inventories. The exact
 source release and package checksums are recorded in the corresponding GitHub release workflow.
+
+## Using Herdr's plugin
+
+The Herdr plugin is installed from the Herdr World GitHub repository, not from this npm package:
+
+```bash
+herdr plugin install IvoryHeart/herdr-world --ref vX.Y.Z
+```
+
+It installs the exact matching npm payload privately inside Herdr's managed plugin checkout and
+supervises its bridge for the invoking Herdr session. The plugin requires Node.js 22.14.0 or newer
+and npm at installation and runtime; it does not use this package's global installation or a
+Homebrew installation. See the repository [plugin documentation](https://github.com/IvoryHeart/herdr-world#herdr-plugin) for
+configuration, lifecycle actions, security, and the standalone distribution relationship.

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -37,9 +37,12 @@ The plugin's config and service state live in Herdr's injected per-user plugin d
 the repository checkout or release archives. It uses the invoking `HERDR_SOCKET_PATH` by default,
 binds loopback port `8787`, and allocates named-session bridges from `8787`–`8877`. Its packaged
 static assets are fixed to the npm payload; only the upload directory is configurable. The plugin
-has no uninstall cleanup hook, so stop the plugin bridge before uninstalling the plugin. Stopping
-the bridge disconnects browser clients but does not stop Herdr or its panes. The plugin and the
-standalone distributions below are independent install paths.
+has no uninstall cleanup hook, so stop the plugin bridge before uninstalling the plugin. Plugin
+actions are asynchronous and target-scoped: wait for each stop action's log to report success,
+then run and wait for a successful status action showing that target is not running. Repeat this
+for every managed Herdr session before uninstalling. Stopping the bridge disconnects browser
+clients but does not stop Herdr or its panes. The plugin and the standalone distributions below are
+independent install paths.
 
 ## Release Artifacts
 

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -36,10 +36,10 @@ tarball is used. Node must remain installed for runtime supervision.
 The plugin's config and service state live in Herdr's injected per-user plugin directories, not in
 the repository checkout or release archives. It uses the invoking `HERDR_SOCKET_PATH` by default,
 binds loopback port `8787`, and allocates named-session bridges from `8787`–`8877`. Its packaged
-static assets are fixed to the npm payload; only the upload directory is configurable. Stop and
-uninstall operations affect the plugin bridge only: they disconnect browser clients but do not stop
-Herdr or its panes. The plugin and the standalone distributions below are independent install
-paths.
+static assets are fixed to the npm payload; only the upload directory is configurable. The plugin
+has no uninstall cleanup hook, so stop the plugin bridge before uninstalling the plugin. Stopping
+the bridge disconnects browser clients but does not stop Herdr or its panes. The plugin and the
+standalone distributions below are independent install paths.
 
 ## Release Artifacts
 

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -17,6 +17,30 @@ candidates in `IvoryHeart/homebrew-tap`. Each Formula installs the complete bund
 exposes only the `herdr-world` launcher. The two Formulae conflict so they cannot both provide the
 same command.
 
+## Herdr Plugin Payload
+
+The Herdr plugin is installed from this GitHub repository and acquires the exact version named by
+`herdr-plugin.toml`:
+
+```bash
+herdr plugin install IvoryHeart/herdr-world --ref vX.Y.Z
+```
+
+Herdr builds the manifest's controller checkout, which runs Node.js `22.14.0` or newer and npm to
+install `@ivoryheart/herdr-world@X.Y.Z` into `.herdr-world-plugin/`. The npm and scope registries
+are pinned to npmjs, lifecycle scripts are disabled, and the package name, version, selected native
+bridge, web assets, and legal payload are validated before the plugin is registered. No Rust,
+Cargo, compiler, web dependency tree, global npm package, Homebrew installation, or desktop
+tarball is used. Node must remain installed for runtime supervision.
+
+The plugin's config and service state live in Herdr's injected per-user plugin directories, not in
+the repository checkout or release archives. It uses the invoking `HERDR_SOCKET_PATH` by default,
+binds loopback port `8787`, and allocates named-session bridges from `8787`–`8877`. Its packaged
+static assets are fixed to the npm payload; only the upload directory is configurable. Stop and
+uninstall operations affect the plugin bridge only: they disconnect browser clients but do not stop
+Herdr or its panes. The plugin and the standalone distributions below are independent install
+paths.
+
 ## Release Artifacts
 
 Recommended GitHub release assets:

--- a/docs/release.md
+++ b/docs/release.md
@@ -9,6 +9,7 @@ the release tag.
 
 - Clean `main` branch.
 - Node.js 22 or newer.
+- npm, with Node.js `22.14.0` or newer required for Herdr plugin payload installation and runtime.
 - Rust stable.
 - `cargo-about` 0.9.2 (`cargo install cargo-about --version 0.9.2 --locked --features cli`).
 - JDK 21 and Android SDK when validating the Android shell.
@@ -40,6 +41,16 @@ scripts/check-vendor.sh
 npm run check
 ```
 
+4. From the current `main`, explicitly start the complete distribution preflight:
+
+```bash
+gh workflow run release.yml --ref main
+```
+
+Wait for the `Release distribution` run to pass before cutting the release. Rerun it if `main`
+advances before release preparation continues. The preflight builds and exercises synthetic
+artifacts but cannot publish.
+
 Do not cut a release without bridge test/build coverage.
 
 Corrections use a new release-candidate number. For example, a correction after
@@ -48,11 +59,38 @@ Corrections use a new release-candidate number. For example, a correction after
 ## Package Artifacts
 
 Desktop artifacts are built from the final tag by `.github/workflows/release.yml`; do not upload a
-locally built substitute. Pull requests that affect the desktop assembly run the same Linux,
-Apple-Silicon, and Intel matrix without publishing. Each job checks the native CPU format and bundle
-contents, then exercises the packaged bridge against two checksum-pinned stock Herdr v0.8.2 daemons.
-One required notice gate validates the complete cross-platform dependency closure before any native
-job starts, avoiding three redundant builds of the notice generator.
+locally built substitute. The explicit distribution preflight runs the same Linux, Apple-Silicon,
+and Intel matrix without publishing; ordinary pull requests rely on the normal CI workflow,
+including its release unit tests. Each native job checks the CPU format and bundle contents, then
+exercises the packaged bridge against two checksum-pinned stock Herdr v0.8.2 daemons. One required
+notice gate validates the complete cross-platform dependency closure before any native job starts,
+avoiding three redundant builds of the notice generator.
+
+## Herdr Plugin Release
+
+The plugin is released with the application tag but does not publish a second application artifact.
+After the exact npm package has been published or verified at the unprefixed tag version, the
+workflow installs `IvoryHeart/herdr-world --ref vX.Y.Z` and runs the plugin lifecycle smoke on all
+three supported targets: Linux x86-64/glibc 2.34+, macOS ARM64, and macOS x86-64. The smoke uses a
+checksum-pinned stock Herdr v0.8.2 daemon, checks action listing, first/repeated start, status,
+open, doctor, restart, browser readiness, a second session/port, stop, and uninstall. Its result
+and public repository URL appear in the common release summary. It does not publish, rebuild, or
+substitute the npm payload.
+
+Install the plugin from the default branch or pin a release:
+
+```bash
+herdr plugin install IvoryHeart/herdr-world
+herdr plugin install IvoryHeart/herdr-world --ref vX.Y.Z
+```
+
+Plugin installation requires Node.js `22.14.0` or newer and npm. Rust and Cargo are not required;
+the build installs the exact prebuilt npm payload with lifecycle scripts disabled. Global npm and
+Homebrew installations are ignored. Local `herdr plugin link` skips the build command, so run the
+exact payload install command printed by `bash scripts/herdr-world-plugin.sh build` before invoking
+actions. Reinstalling the GitHub plugin is the refresh mechanism; config and state remain in
+Herdr's per-user plugin directories. Add the `herdr-plugin` GitHub topic only after the tagged
+install and three-platform smoke pass.
 
 Linux desktop tarball:
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -72,7 +72,7 @@ After the exact npm package has been published or verified at the unprefixed tag
 workflow installs `IvoryHeart/herdr-world --ref vX.Y.Z` and runs the plugin lifecycle smoke on all
 three supported targets: Linux x86-64/glibc 2.34+, macOS ARM64, and macOS x86-64. The smoke uses a
 checksum-pinned stock Herdr v0.8.2 daemon, checks action listing, first/repeated start, status,
-open, doctor, restart, browser readiness, a second session/port, stop, and uninstall. Its result
+open, doctor, restart, browser readiness, a second session/port, and stop-before-uninstall. Its result
 and public repository URL appear in the common release summary. It does not publish, rebuild, or
 substitute the npm payload.
 

--- a/docs/specs/016-herdr-world-plugin-release-spec-summary.md
+++ b/docs/specs/016-herdr-world-plugin-release-spec-summary.md
@@ -1,0 +1,99 @@
+# Implementation summary — Herdr World plugin distribution and lifecycle facade
+
+- **Parent spec:** [`016-herdr-world-plugin-release-spec.md`](016-herdr-world-plugin-release-spec.md)
+- **Implemented at:** 2026-08-29
+- **Implementation status:** Complete
+
+> The approved parent specification remains immutable. This summary records
+> the delivered implementation, decisions, validation evidence, and the
+> release-time operational gate.
+
+## Delivered implementation
+
+### 2026-08-29 — Exact npm payload and lifecycle controller
+
+- Added the root `herdr-plugin.toml` for `ivoryheart.herdr-world`, with the
+  approved versioned build command and workspace actions: `start`, `stop`,
+  `restart`, `status`, `open`, and `doctor`.
+- Added `scripts/herdr-world-plugin.sh` and its Node controller. The build
+  installs exactly `@ivoryheart/herdr-world@<manifest-version>` into the
+  private `.herdr-world-plugin` prefix using npmjs registry pinning,
+  `--ignore-scripts`, and no dist-tag or global-package lookup.
+- Validated Node.js `22.14.0` or newer, npm, Linux x64/glibc 2.34+, macOS
+  ARM64, and macOS x64 before build or runtime use. The selected package,
+  native bridge, web assets, launcher, and legal manifest/files are checked
+  before the plugin can start.
+- Implemented per-session target identities, JSON configuration, atomic
+  records and locks, default loopback port `8787`, named-session allocation
+  across `8787`–`8877`, explicit remote Host/Origin configuration, and
+  redacted human-readable diagnostics.
+- Implemented readiness checks against `/api/capabilities` requiring bridge
+  API 1, web compatibility 1+, Herdr 0.8.2+, and terminal protocol 20.
+- Implemented idempotent lifecycle control with absolute Node paths,
+  Herdr-onboarding disabled, systemd `--user` on Linux, launchd on macOS,
+  and bounded process-group fallback supervision. Ownership checks refuse to
+  signal stale or unrelated processes.
+- Kept static assets paired to the private package; only the upload directory
+  is configurable. Stop/restart/uninstall messaging distinguishes the bridge
+  from the Herdr server and its panes.
+
+### Release and documentation integration
+
+- Updated release version stamping and protected release validation so the
+  `v`-prefixed tag and unprefixed plugin/package version remain aligned.
+- Added a post-publication `plugin_smoke` release job with the approved full
+  three-platform matrix. It downloads checksum-pinned stock Herdr 0.8.2,
+  installs the tagged GitHub plugin, exercises its actions and a second
+  session/port, and contributes its result to the common release summary.
+- Removed the complete distribution matrix from pull-request triggers; the
+  explicit workflow-dispatch preflight remains available while ordinary PRs
+  use normal CI.
+- Documented plugin installation, local-link behavior, configuration,
+  security, upgrades, standalone npm/Homebrew/desktop/Android boundaries,
+  and release operations. Added the plugin change to `CHANGELOG.md` and
+  ignored the generated private payload directory.
+
+## Decisions recorded
+
+- JSON `config.json` in Herdr's injected per-user plugin config directory.
+- Default port `8787`; named sessions use the first available port in
+  `8787`–`8877` and are documented.
+- Hashed stable target identities and service names.
+- `open` uses only the platform browser helper, with a headless manual URL
+  fallback; no separate `logs` or `url` actions were added.
+- The current `0.1.0-rc.5` release is the initial advertised version.
+- No offline cache or binary-first desktop-artifact installer was added.
+
+## Acceptance evidence
+
+- `herdr plugin link` accepted the manifest and listed all six actions in a
+  temporary Herdr configuration.
+- A real npm build installed and validated
+  `@ivoryheart/herdr-world@0.1.0-rc.5` on Linux without generating a source
+  or Rust build.
+- Live local checks passed for systemd start/status/restart/stop, doctor,
+  action invocation, an isolated named Herdr session, and capability
+  readiness. The pre-existing unrelated bridge on port 8787 was left alone.
+- `npm run test:release` — passed, including 59 tests and plugin manifest,
+  payload, configuration, ownership, readiness, supervisor, and workflow
+  coverage.
+- `npm run check` — passed, including vendor and notice checks, web lint,
+  442 web tests, compatibility and protocol-fixture tests, 162 bridge tests,
+  production web build, and bridge build.
+- `git diff --check` — passed.
+
+## Constraints and operational notes
+
+- The three-platform published-ref smoke is implemented in CI but cannot be
+  fully run from this Linux worktree until this branch is published/tagged and
+  the matching npm version is available. The release job is intentionally
+  gated on npm publication or same-version integrity verification.
+- The public `herdr-plugin` GitHub topic remains a release-operator decision;
+  add it only after the tagged install and three-platform smoke pass.
+- No generated `.herdr-world-plugin`, `web/dist`, bridge target, or release
+  archive is part of the source changes. Existing user screenshot changes in
+  the worktree were preserved untouched.
+
+**Drift from approved spec:** None.
+
+**Follow-up extension:** None.

--- a/docs/specs/016-herdr-world-plugin-release-spec-summary.md
+++ b/docs/specs/016-herdr-world-plugin-release-spec-summary.md
@@ -2,7 +2,7 @@
 
 - **Parent spec:** [`016-herdr-world-plugin-release-spec.md`](016-herdr-world-plugin-release-spec.md)
 - **Implemented at:** 2026-08-29
-- **Implementation status:** Complete
+- **Implementation status:** Implementation complete; first tagged release validation pending
 
 > The approved parent specification remains immutable. This summary records
 > the delivered implementation, decisions, validation evidence, and the
@@ -61,7 +61,9 @@
 - Hashed stable target identities and service names.
 - `open` uses only the platform browser helper, with a headless manual URL
   fallback; no separate `logs` or `url` actions were added.
-- The current `0.1.0-rc.5` release is the initial advertised version.
+- The manifest starts at `0.1.0-rc.5` for exact npm payload compatibility; the
+  `v0.1.0-rc.5` tag predates this plugin implementation and is not advertised as
+  the first tagged plugin release.
 - No offline cache or binary-first desktop-artifact installer was added.
 
 ## Acceptance evidence
@@ -74,7 +76,7 @@
 - Live local checks passed for systemd start/status/restart/stop, doctor,
   action invocation, an isolated named Herdr session, and capability
   readiness. The pre-existing unrelated bridge on port 8787 was left alone.
-- `npm run test:release` — passed, including 59 tests and plugin manifest,
+- `npm run test:release` — passed, including 62 tests and plugin manifest,
   payload, configuration, ownership, readiness, supervisor, and workflow
   coverage.
 - `npm run check` — passed, including vendor and notice checks, web lint,
@@ -85,15 +87,17 @@
 ## Constraints and operational notes
 
 - The three-platform published-ref smoke is implemented in CI but cannot be
-  fully run from this Linux worktree until this branch is published/tagged and
-  the matching npm version is available. The release job is intentionally
-  gated on npm publication or same-version integrity verification.
+  fully run from this Linux worktree until a tag containing this implementation
+  is published and the matching npm version is available. The release job is
+  intentionally gated on npm publication or same-version integrity
+  verification.
 - The public `herdr-plugin` GitHub topic remains a release-operator decision;
   add it only after the tagged install and three-platform smoke pass.
 - No generated `.herdr-world-plugin`, `web/dist`, bridge target, or release
   archive is part of the source changes. Existing user screenshot changes in
   the worktree were preserved untouched.
 
-**Drift from approved spec:** None.
+**Drift from approved spec:** None identified in the implementation; first
+tagged post-publication three-platform smoke remains pending.
 
 **Follow-up extension:** None.

--- a/docs/specs/016-herdr-world-plugin-release-spec.md
+++ b/docs/specs/016-herdr-world-plugin-release-spec.md
@@ -1,12 +1,12 @@
 # Herdr World plugin distribution and lifecycle facade
 
 - **Spec ID:** `016-herdr-world-plugin-release`
-- **Status:** Draft
+- **Status:** Approved
 - **Created:** 2026-08-27
 - **Owner:** IvoryHeart / Herdr World
 - **Reviewers:** IvoryHeart (repository owner)
-- **Approved by:** —
-- **Approved at:** —
+- **Approved by:** IvoryHeart
+- **Approved at:** 2026-08-29
 
 > This document may be edited only while its status is `Draft` or `In review`.
 > After approval it is immutable. After implementation completes, record
@@ -16,19 +16,22 @@
 ## 1. Purpose
 
 Herdr World currently ships as a downstream browser/mobile application with a
-Rust HTTP/WebSocket bridge. Users must build or unpack that application and
+Rust HTTP/WebSocket bridge. Users must install or unpack that application and
 start the bridge independently of Herdr. This specification defines the
 smallest Herdr plugin integration that makes the existing application
 installable and operable through Herdr's plugin ecosystem without changing its
 browser-first product shape.
 
-The outcome is a public Herdr plugin that builds the existing web assets and
-bridge, starts one bridge service for the invoking Herdr runtime, reports its
-state, and gives the user a URL for the browser or PWA client. The existing
-desktop tarball and Android distribution remain supported products.
+The outcome is a public Herdr plugin that installs the exact version-matched
+`@ivoryheart/herdr-world` npm payload inside its managed checkout, starts one
+bridge service for the invoking Herdr runtime, reports its state, and gives the
+user a URL for the browser or PWA client. The standalone npm, Homebrew, desktop
+tarball, and Android distributions remain supported products.
 
 The companion research and ecosystem record is
 [Herdr plugin release analysis](../analysis/herdr-plugin-release-analysis-2026-08-26.md).
+That analysis predates this approved npm-payload decision; its source-build-first
+packaging recommendation is superseded by this specification.
 The integration relies on the [Herdr plugin manifest and runtime contract](https://herdr.dev/docs/plugins/),
 the [Herdr socket/CLI API](https://herdr.dev/docs/socket-api/), and the
 [automatic marketplace listing rules](https://herdr.dev/docs/marketplace/).
@@ -40,11 +43,11 @@ This feature includes:
 - a root-level `herdr-plugin.toml` in this repository;
 - plugin metadata for `ivoryheart.herdr-world`, versioned with the application
   release version and requiring Herdr `0.8.2` or newer;
-- Linux and macOS plugin support, matching the currently tested desktop
-  release platforms;
+- Linux x86-64 with glibc `2.34` or newer, macOS ARM64, and macOS x86-64 plugin
+  support, matching the published npm payload matrix;
 - a plugin controller at `scripts/herdr-world-plugin.sh`;
-- an install-time source build using the repository's existing web and Cargo
-  dependency trees;
+- install-time acquisition of the exact release-matched
+  `@ivoryheart/herdr-world` npm payload into a private plugin-local prefix;
 - lifecycle and diagnostic actions for starting, stopping, restarting,
   inspecting, opening, and diagnosing the bridge;
 - service state and editable configuration stored outside the managed plugin
@@ -54,8 +57,8 @@ This feature includes:
 - loopback-safe defaults, explicit remote-access configuration, readiness
   probing, and actionable diagnostics;
 - automated controller tests and manual Herdr plugin install/link smoke tests;
-- release validation that keeps the manifest version aligned with the tagged
-  application release; and
+- release validation that keeps the manifest, tagged application release, and
+  npm payload versions aligned and validates the plugin after npm publication;
 - documentation for installation, configuration, actions, upgrades,
   uninstall, security, and the relationship to the existing tarballs and
   Android client.
@@ -75,8 +78,11 @@ This feature includes:
   that connects to a configured bridge.
 - Removing or changing the desktop tarball launcher, its consent-based Herdr
   setup behavior, or its documented artifact layout.
-- Shipping a separate binary-download plugin repository in the first
-  implementation tranche.
+- Shipping a separate plugin repository or downloading desktop archives from a
+  plugin-specific installer.
+- Rebuilding the web application or native bridge during plugin installation.
+- Using a global npm or Homebrew installation as the plugin runtime, or making
+  Homebrew a plugin prerequisite.
 - Supporting Windows before the bridge controller and service lifecycle are
   implemented and tested on that platform.
 - Adding plugin-owned credentials, authentication, or a claim that Host,
@@ -117,14 +123,32 @@ browser reload, or Herdr server handoff.
 ### Release and repository constraints
 
 The repository's public application release tag is the source of truth. Root
-and web npm package versions remain `0.0.0` because this repository does not
-publish npm packages. The release helper currently stamps `release.json`,
-README, and Pages references, so plugin version stamping must be added as an
-explicit release concern rather than inferred from npm metadata.
+and web development manifests remain private at version `0.0.0`; the release
+workflow generates and publishes the separate public
+`@ivoryheart/herdr-world` package at the release version. Plugin version
+stamping remains an explicit release concern and SHALL agree with that
+generated package rather than either private development manifest.
 
-The current desktop tarball builds the same web assets and bridge but does not
-include Herdr. Plugin installation likewise requires a compatible Herdr
-installation and local toolchains for the initial source-build path.
+Release `v0.1.0-rc.5` established the distribution baseline: the exact npm
+package is public, the Homebrew RC Formula is published and validated, and the
+GitHub release contains all three desktop archives and checksums. RC5 is
+implementation and validation evidence, not a permanently fixed plugin
+version.
+
+Herdr installs marketplace plugins from GitHub and runs their `[[build]]`
+commands; it does not install Herdr plugins directly from npm. The root
+manifest and controller therefore remain in this repository while the
+version-matched npm package supplies the prebuilt application payload. The
+package contains the verified web assets, legal payload, and bridges for Linux
+x86-64, macOS ARM64, and macOS x86-64. Plugin installation requires Node.js
+`22.14.0` or newer and npm. Node.js remains a runtime dependency of the
+packaged launcher and must stay available to plugin actions and the user
+supervisor after installation. The plugin SHALL NOT require Rust, Cargo, a
+native compiler, or the web development dependency tree.
+
+Herdr's manifest platform field distinguishes operating systems but not CPU or
+Linux libc. The controller SHALL enforce the narrower published payload
+matrix.
 
 ## 5. Requirements
 
@@ -163,44 +187,68 @@ initial release.
 - **THEN** Herdr refuses the plugin using its normal minimum-version error
   before any plugin build or runtime action executes.
 
-### Requirement: Build the existing application from the plugin checkout
+### Requirement: Install the exact released application payload
 
-The `build` controller action SHALL build the web distribution and release
-bridge from the plugin checkout using the repository's existing lockfiles and
-targets. It SHALL perform the equivalent of:
+The `build` controller action SHALL read the plugin version from the root
+manifest and install exactly
+`@ivoryheart/herdr-world@<manifest-version>` into the deterministic private
+prefix `.herdr-world-plugin/` under the managed plugin checkout. It SHALL use
+the equivalent of:
 
 ```text
-npm ci --prefix web
-npm run build:web
-cargo build --release --manifest-path bridge/Cargo.toml --bin herdr-web-bridge
+npm install --registry=https://registry.npmjs.org/ \
+  --@ivoryheart:registry=https://registry.npmjs.org/ \
+  --prefix .herdr-world-plugin --ignore-scripts --no-save \
+  --package-lock=false --no-audit --no-fund --omit=dev \
+  @ivoryheart/herdr-world@<manifest-version>
 ```
 
-The build SHALL fail closed if Node.js, npm, Rust, Cargo, lockfiles, or a
-required dependency is unavailable. It SHALL not download or install a
-toolchain on the user's behalf. The resulting paths SHALL be deterministic:
+The build SHALL use an exact version, never an npm dist-tag, `npx`, a global
+installation, or a package selected from the ambient `PATH`. It SHALL disable
+package lifecycle scripts and SHALL NOT run a web build, Cargo, a native
+compiler, an installer embedded in another distribution, or Herdr onboarding.
+It SHALL pin both the default registry and the `@ivoryheart` scope to
+`https://registry.npmjs.org/` at npm's command-line configuration precedence
+so user, project, global, environment, or scope registry configuration cannot
+redirect the native payload request or any dependency request to another
+registry.
 
-- web assets: `web/dist/`;
-- bridge binary: `bridge/target/release/herdr-web-bridge`.
+Before installation the build SHALL fail closed unless Node.js `22.14.0` or
+newer and npm are available and the current OS, architecture, and Linux libc
+are supported. After installation it SHALL verify the installed package name
+and version, the private `node_modules/.bin/herdr-world` entrypoint, packaged
+web assets, selected native bridge, and required legal payload. A missing
+registry version, engine mismatch, unsupported target, package mismatch, or
+incomplete payload SHALL abort installation before Herdr registers the plugin.
 
-The source-build path SHALL preserve the repository's existing legal asset
-staging and dependency-notice expectations. It SHALL not modify generated
-outputs outside the plugin checkout's normal build directories.
+The resulting package root and executable SHALL be deterministic:
 
-#### Scenario: A GitHub installation builds successfully
+- package root:
+  `.herdr-world-plugin/node_modules/@ivoryheart/herdr-world/`;
+- executable: `.herdr-world-plugin/node_modules/.bin/herdr-world`.
 
-- **GIVEN** a clean checkout, Node.js 22 or newer, npm, Rust stable, and a
-  compatible Herdr installation
+Generated package files SHALL remain inside `.herdr-world-plugin/` and SHALL
+not be committed. npm's integrity verification against the package metadata
+served by the pinned npmjs registry, together with the release workflow's
+recorded package integrity, remain authoritative for the payload.
+
+#### Scenario: A GitHub installation acquires the package successfully
+
+- **GIVEN** a clean checkout, Node.js `22.14.0` or newer, npm, a supported
+  target, the exact manifest-version package published on npm, and a compatible
+  Herdr installation
 - **WHEN** Herdr runs the manifest build command during `plugin install`
-- **THEN** the web assets and release bridge are produced at the documented
-  paths and the plugin is registered only after the build succeeds.
+- **THEN** the exact prebuilt payload is installed and validated at the
+  documented private paths, no source or native build runs, and the plugin is
+  registered only after installation succeeds.
 
 #### Scenario: Local linking is used
 
-- **GIVEN** a linked checkout with no prebuilt web assets or release bridge
+- **GIVEN** a linked checkout with no private npm payload
 - **WHEN** the user invokes an action
 - **THEN** the controller prints that local linking does not run manifest build
-  commands and provides the exact build command; it does not silently run a
-  partial or debug build.
+  commands and provides the exact payload-install command; it does not use a
+  global package, a dist-tag, or silently build from source.
 
 ### Requirement: Start one bridge for one Herdr runtime
 
@@ -208,7 +256,8 @@ The `start` action SHALL:
 
 1. Resolve the target socket from the invocation's `HERDR_SOCKET_PATH`, unless
    the user has explicitly configured a named session or socket target.
-2. Use the release bridge and `web/dist` from the plugin checkout.
+2. Use only the exact private npm payload installed for the manifest version;
+   it SHALL not resolve `herdr-world` from the ambient `PATH`.
 3. Bind to `127.0.0.1` by default on port `8787` for the default profile.
 4. Allocate or validate a distinct port for another concurrently managed
    runtime; it SHALL never attach a second bridge to the same service record.
@@ -224,6 +273,22 @@ The `start` action SHALL:
    and web compatibility before reporting success.
 10. Print the bridge URL, target session, bridge/Herdr compatibility, and
     whether the endpoint is loopback-only or remotely exposed.
+
+The controller SHALL supervise the package's foreground `herdr-world`
+entrypoint with Herdr onboarding explicitly disabled. The package entrypoint
+remains responsible for selecting its verified native bridge and bundled web
+assets. The controller SHALL pass the selected Herdr target and all bridge
+security options explicitly and SHALL reject a missing or version-mismatched
+private payload before creating supervisor state.
+
+Before starting or restarting a service, the controller SHALL resolve an
+absolute Node.js executable, verify that it is version `22.14.0` or newer, and
+place that exact executable in the supervisor command rather than depending
+on `#!/usr/bin/env node` or the supervisor's `PATH`. `doctor` SHALL perform the
+same check without starting anything and report whether the recorded Node path
+still exists and meets the version floor. `start`, `restart`, and `doctor`
+SHALL fail closed with an actionable diagnostic when Node is absent, too old,
+or unavailable to the selected supervisor environment.
 
 The controller SHALL be idempotent. If a healthy matching service already
 exists, `start` SHALL report it and return success without spawning another
@@ -266,7 +331,7 @@ The controller SHALL implement these action behaviors:
 | `restart` | Stop and start the selected service, then verify readiness. |
 | `status` | Report service ownership, target, pid/supervisor state, endpoint, and capability state without starting anything. |
 | `open` | Ensure the service is ready, print the URL, and request the platform default browser when one is available; remain usable on headless hosts. |
-| `doctor` | Run non-destructive checks for platform, tools, Herdr target, build outputs, config, state, service ownership, port, and capability compatibility. |
+| `doctor` | Run non-destructive checks for platform, tools, Herdr target, private payload, config, state, service ownership, port, and capability compatibility. |
 
 Action output SHALL be human-readable by default and SHALL never print
 credentials, full socket contents, or arbitrary environment values. Failures
@@ -300,9 +365,12 @@ Configuration SHALL support, at minimum:
 
 - bind host, default port or a safe port range;
 - optional explicit Herdr session/socket target;
-- static asset and upload directory overrides only when explicitly needed;
+- an upload directory override only when explicitly needed;
 - allowed hosts/origins for non-loopback use; and
 - optional bridge label.
+
+The packaged static assets SHALL not be replaceable through initial plugin
+configuration; their version must remain paired with the packaged bridge.
 
 The controller SHALL validate ports, paths, session names, hosts, origins, and
 platform values before launching the bridge. It SHALL not write editable
@@ -347,14 +415,27 @@ boundary.
 ### Requirement: Align plugin and application release versions
 
 The release process SHALL treat the plugin manifest version as a public
-release reference. Before a release commit is created, validation SHALL prove
-that:
+release reference. Before a release commit is created, static validation SHALL
+prove that:
 
 - the manifest version equals the application release version without `v`;
+- the version is exactly `X.Y.Z` or `X.Y.Z-rc.N`;
 - `min_herdr_version` and the advertised platform list are intentional;
 - all declared controller entrypoints exist and are executable;
-- the release tag can install the plugin from GitHub; and
-- no npm package publication is implied.
+- the build controller derives the exact npm package version from the manifest
+  and cannot select a dist-tag or global installation; and
+- the plugin introduces no second release command or independently rebuilt
+  application artifact.
+
+After the release workflow publishes or verifies the exact npm package, its
+plugin job SHALL install the tagged GitHub plugin, exercise the declared
+actions, and include the plugin version, result, and public URL in the common
+release summary. The plugin job SHALL depend on successful npm publication or
+same-version integrity verification; it SHALL not publish, rebuild, or
+substitute an application payload itself. Explicit manual validation runs MAY
+use the exact generated npm tarball but SHALL NOT publish or advertise the
+plugin. Ordinary pull requests rely on the normal CI release tests and do not
+run the complete distribution matrix.
 
 The release documentation SHALL explain both installation forms:
 
@@ -363,33 +444,39 @@ herdr plugin install IvoryHeart/herdr-world
 herdr plugin install IvoryHeart/herdr-world --ref vX.Y.Z
 ```
 
-It SHALL explain that the first release uses source builds, requires Node.js
-22 and Rust, local linking does not run build commands, and reinstalling is
-Herdr v1's refresh mechanism for a GitHub-managed plugin. The repository SHALL
-add the GitHub topic `herdr-plugin` only when the manifest and install flow
-are ready for public discovery.
+It SHALL explain that plugin installation requires Node.js `22.14.0` or newer
+and npm to acquire the exact prebuilt payload, that Node must remain installed
+for the supervised package launcher, that Rust and Cargo are not required, and
+that global npm and Homebrew installations are ignored. It SHALL also explain
+that local linking does not run build commands and reinstalling is Herdr v1's
+refresh mechanism for a GitHub-managed plugin. The repository SHALL add the
+GitHub topic `herdr-plugin` only when the tagged install flow succeeds against
+the published matching npm package and is ready for public discovery.
 
 #### Scenario: A release version drifts
 
-- **GIVEN** `release.json`, the manifest, or a public release reference names
-  different versions
+- **GIVEN** `release.json`, the manifest, the generated npm package, or another
+  public release reference names different versions
 - **WHEN** release validation runs
 - **THEN** it fails with the mismatched paths and does not create or publish a
   release commit or tag.
 
 ### Requirement: Preserve standalone distributions
 
-The plugin changes SHALL not require the desktop tarball or Android client to
-install the plugin. Existing tarball packaging SHALL continue to use its
-bundled `bin/herdr-world` launcher and `bin/herdr-world-bridge`; plugin
-actions SHALL use the source checkout's `web/dist` and release bridge.
+The plugin SHALL install its own exact npm payload inside the managed checkout.
+It SHALL not require, discover, modify, or remove a global npm package,
+Homebrew Formula, desktop tarball installation, or Android client. Existing
+tarball packaging SHALL continue to use its bundled `bin/herdr-world` launcher
+and `bin/herdr-world-bridge`; plugin actions SHALL use only the private package
+installed for the manifest version.
 
 Documentation SHALL distinguish:
 
 - the Herdr plugin as a lifecycle/install facade;
 - the browser/PWA as the main World client;
 - the Android application as a companion client; and
-- the desktop tarball as an independently usable distribution.
+- npm, Homebrew, and the desktop tarball as independently usable
+  distributions.
 
 #### Scenario: Existing tarball packaging is checked
 
@@ -397,6 +484,14 @@ Documentation SHALL distinguish:
 - **WHEN** the documented desktop packaging check runs
 - **THEN** the tarball still contains its documented files, does not require a
   plugin-managed checkout, and its launcher behavior remains unchanged.
+
+#### Scenario: A standalone installation is present
+
+- **GIVEN** a different Herdr World version is installed globally through npm
+  or Homebrew
+- **WHEN** a plugin action runs
+- **THEN** the controller uses its manifest-matched private payload and leaves
+  the standalone installation unchanged.
 
 ## 6. Data and interface contract
 
@@ -407,10 +502,16 @@ entries. All commands SHALL be argv arrays and SHALL invoke the controller by
 path. The controller SHALL derive the repository root from its own location,
 so its behavior does not depend on Herdr's current working directory.
 
-The manifest version is a SemVer value without the leading release-tag `v`.
+The manifest version is a SemVer value without the leading release-tag `v` and
+SHALL have exactly one of these forms:
+
+```text
+MAJOR.MINOR.PATCH
+MAJOR.MINOR.PATCH-rc.NUMBER
+```
+
 The Git tag and application release metadata retain their existing `v` prefix.
-Prerelease identifiers are allowed and SHALL be copied exactly between the
-release tag and manifest version.
+No other prerelease identifier or build metadata is allowed.
 
 ### Controller invocation contract
 
@@ -424,7 +525,9 @@ Unknown or missing commands SHALL return a usage error without side effects.
 Runtime actions SHALL use `HERDR_BIN_PATH` for calls back into Herdr and SHALL
 honor `HERDR_SOCKET_PATH` as the default target. The controller SHALL not
 assume `herdr` is on `PATH` and SHALL not parse human-oriented Herdr output
-when a stable CLI/socket response is available.
+when a stable CLI/socket response is available. It SHALL resolve the
+application entrypoint only from the deterministic private npm prefix and run
+it with Herdr onboarding disabled.
 
 ### Service record contract
 
@@ -440,21 +543,26 @@ file under `HERDR_PLUGIN_STATE_DIR`. The schema SHALL include at least:
   "host": "127.0.0.1",
   "port": 8787,
   "url": "http://127.0.0.1:8787",
-  "bridge_path": "/managed/checkout/bridge/target/release/herdr-web-bridge",
-  "static_dir": "/managed/checkout/web/dist",
+  "package_name": "@ivoryheart/herdr-world",
+  "package_version": "0.1.0-rc.5",
+  "payload_root": "/managed/checkout/.herdr-world-plugin/node_modules/@ivoryheart/herdr-world",
+  "payload_entrypoint": "/managed/checkout/.herdr-world-plugin/node_modules/.bin/herdr-world",
+  "node_path": "/absolute/path/to/node",
   "supervisor": "systemd-user|launchd|fallback",
   "service_name": "opaque-owned-service-name",
   "pid": 12345,
-  "application_version": "0.1.0-rc.1",
+  "application_version": "0.1.0-rc.5",
   "herdr_protocol": 20,
   "updated_at": "RFC-3339 timestamp"
 }
 ```
 
-The exact identity derivation, filename, supervisor unit/plist contents, and
-config file format are implementation details, but they SHALL be documented
-and tested. Socket paths and records are local control data; diagnostics must
-redact them when full disclosure is not required.
+The package version shown above is illustrative; every record SHALL contain the
+actual manifest-matched version. The exact identity derivation, filename,
+supervisor unit/plist contents, and config file format are implementation
+details, but they SHALL be documented and tested. Socket paths and records are
+local control data; diagnostics must redact them when full disclosure is not
+required.
 
 ### Readiness contract
 
@@ -466,10 +574,18 @@ or live process without a valid capability response is not readiness.
 ## 7. Privacy and security
 
 - Plugin installation and build commands execute arbitrary repository code as
-  the installing user. README and install documentation SHALL direct users to
-  inspect the manifest and controller before confirming installation.
+  the installing user and acquire a prebuilt native npm payload. README and
+  install documentation SHALL direct users to inspect the manifest,
+  controller, exact npm version, and release provenance before confirming
+  installation.
 - The marketplace topic and listing are discovery metadata, not a security
   review or endorsement.
+- npm installation SHALL disable lifecycle scripts and remain inside the
+  managed checkout. The build SHALL pin the default registry and the
+  `@ivoryheart` scope to the public npmjs registry and SHALL not trust registry
+  integrity metadata from an operator-configured alternate registry. Runtime
+  actions SHALL neither resolve nor mutate a global package or Homebrew
+  installation.
 - No secret may be placed in the manifest, plugin checkout, service command
   line, or ordinary action output.
 - Config/state directories SHALL be user-scoped and excluded from repository
@@ -492,14 +608,23 @@ evidence:
 
 - manifest parsing/validation tests cover required metadata, action IDs,
   platform fields, version alignment, and missing entrypoints;
+- payload installation tests cover the exact package selector, Node.js floor,
+  supported OS/architecture/libc matrix, disabled lifecycle scripts, private
+  prefix, missing registry version, mismatched package metadata, incomplete
+  payload, command-line pinning of the default registry and `@ivoryheart`
+  scope to npmjs despite conflicting configuration, and refusal to use
+  dist-tags or global installations;
 - controller tests cover argument validation, config/state paths, atomic
-  records, port allocation, idempotent start, stale ownership, readiness
-  failure, redaction, and security defaults;
+  records, package-version ownership, port allocation, idempotent start, stale
+  ownership, readiness failure, absolute Node resolution, missing/old/removed
+  Node behavior, supervisor environment isolation, redaction, and security
+  defaults;
 - Linux supervisor behavior is tested with deterministic fakes for
   `systemd --user`, and macOS behavior with deterministic fakes for `launchd`;
 - fallback supervision is tested for bounded shutdown and stale-process
   refusal;
-- release tests cover manifest version stamping and mismatch failure; and
+- release tests cover manifest version stamping, exact npm payload derivation,
+  post-publication plugin job ordering, and mismatch failure; and
 - `git diff --check`, `npm run test:release`, and the repository's normal
   `npm run check` pass when the implementation is complete.
 
@@ -508,8 +633,10 @@ evidence:
 Against a local Herdr `v0.8.2` daemon reporting terminal protocol `20`, the
 implementation SHALL demonstrate:
 
-1. `herdr plugin link` followed by an explicit local build;
-2. GitHub-style installation from a release ref;
+1. `herdr plugin link` followed by explicit installation of the exact private
+   npm payload;
+2. GitHub-style installation from a release ref after the matching npm version
+   is published or verified;
 3. action listing and invocation;
 4. first start, repeated start, status, open, restart, and stop;
 5. browser load through the reported URL;
@@ -518,12 +645,20 @@ implementation SHALL demonstrate:
 7. two browser clients attached to the same bridge;
 8. two distinct Herdr sessions with isolated service records and ports;
 9. incompatible protocol, missing socket, stale process, and port collision
-   failures; and
-10. uninstall/refresh behavior with service cleanup and retained config/state.
+   failures;
+10. uninstall/refresh behavior with service cleanup and retained config/state;
+11. a different globally installed npm or Homebrew version remaining unused
+    and unchanged; and
+12. unsupported architecture, musl or unknown libc, missing Node/npm during
+    installation, missing or old Node during runtime, missing package version,
+    alternate scoped-registry configuration, and package/manifest mismatch
+    failures without a service.
 
 The existing `npm run check:acceptance` and packaged desktop smoke suite remain
-required. Plugin-specific tests may use fakes for supervisors and HTTP probes,
-but the final smoke must use an unmodified compatible Herdr daemon.
+required. The existing npm install tests and Homebrew Formula validation SHALL
+remain green. Plugin-specific tests may use fakes for supervisors and HTTP
+probes, but the final smoke must use an unmodified compatible Herdr daemon and
+the exact published package for the selected release.
 
 ### Marketplace readiness
 
@@ -532,10 +667,11 @@ branch that:
 
 - the root manifest parses with the minimum supported Herdr;
 - a reviewer can inspect every build/runtime command;
-- source-build prerequisites and security posture are documented;
+- npm-payload prerequisites, exact-version behavior, prebuilt-code trust, and
+  security posture are documented;
 - the default branch contains the versioned manifest and controller; and
 - `herdr plugin install IvoryHeart/herdr-world --ref vX.Y.Z` succeeds for the
-  tagged release.
+  tagged release using the matching published npm package.
 
 ## 9. Deferred decisions
 
@@ -549,20 +685,20 @@ implementation PR SHALL record its selected value in the delivery summary:
 - whether `open` uses only platform browser helpers or supports an explicit
   `HERDR_WORLD_BROWSER` override;
 - whether `logs` and `url` become separate actions or remain part of `status`
-  and diagnostics;
-- whether the first public plugin release advertises the current prerelease
-  tag or waits for a stable application release; and
-- the later binary-first installer that downloads and checksum-verifies the
-  existing desktop artifacts.
+  and diagnostics; and
+- whether an explicit offline package-cache input is needed after the public
+  registry path is established and measured.
 
 The following are intentionally not deferred: the thin-facade architecture,
-root-repository manifest, plugin ID, source-build-first strategy, loopback
-default, Herdr protocol-20 gate, external config/state ownership, and Linux/
-macOS-only initial platform scope.
+root-repository manifest, plugin ID, exact npm-payload strategy, private
+plugin-local installation, loopback default, Herdr protocol-20 gate,
+external config/state ownership, and the Linux x86-64/glibc 2.34+, macOS
+ARM64, and macOS x86-64 initial target matrix.
 
 ## Related repository documentation
 
 - [Herdr World plugin release analysis](../analysis/herdr-plugin-release-analysis-2026-08-26.md)
+- [Automated release distribution](017-herdr-world-automated-release-distribution-spec.md)
 - [World packaging and upstream boundaries](004-world-packaging-and-upstream-boundaries-spec.md)
 - [Development](../development.md)
 - [Packaging](../packaging.md)

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -1,0 +1,45 @@
+id = "ivoryheart.herdr-world"
+name = "Herdr World"
+version = "0.1.0-rc.5"
+min_herdr_version = "0.8.2"
+description = "Browser and mobile client for monitoring and controlling Herdr agents."
+platforms = ["linux", "macos"]
+
+[[build]]
+command = ["bash", "scripts/herdr-world-plugin.sh", "build"]
+
+[[actions]]
+id = "start"
+title = "Start Herdr World"
+contexts = ["workspace"]
+command = ["bash", "scripts/herdr-world-plugin.sh", "start"]
+
+[[actions]]
+id = "stop"
+title = "Stop Herdr World"
+contexts = ["workspace"]
+command = ["bash", "scripts/herdr-world-plugin.sh", "stop"]
+
+[[actions]]
+id = "restart"
+title = "Restart Herdr World"
+contexts = ["workspace"]
+command = ["bash", "scripts/herdr-world-plugin.sh", "restart"]
+
+[[actions]]
+id = "status"
+title = "Herdr World Status"
+contexts = ["workspace"]
+command = ["bash", "scripts/herdr-world-plugin.sh", "status"]
+
+[[actions]]
+id = "open"
+title = "Open Herdr World"
+contexts = ["workspace"]
+command = ["bash", "scripts/herdr-world-plugin.sh", "open"]
+
+[[actions]]
+id = "doctor"
+title = "Diagnose Herdr World"
+contexts = ["workspace"]
+command = ["bash", "scripts/herdr-world-plugin.sh", "doctor"]

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "notices:generate": "node scripts/dependency-notices.mjs --generate",
     "notices:check": "node scripts/dependency-notices.mjs --check",
     "test:dev": "node --test scripts/dev.test.mjs",
-    "test:release": "node --test scripts/release-target.test.mjs scripts/release-version.test.mjs scripts/release-notes.test.mjs scripts/release-publication.test.mjs scripts/npm-launcher.test.mjs scripts/npm-registry-query.test.mjs scripts/homebrew-formula.test.mjs scripts/herdr-world-installer.test.mjs scripts/herdr-world-launcher.test.mjs scripts/terminal-screen.test.mjs",
+    "test:release": "node --test scripts/release-target.test.mjs scripts/release-version.test.mjs scripts/release-notes.test.mjs scripts/release-publication.test.mjs scripts/npm-launcher.test.mjs scripts/npm-registry-query.test.mjs scripts/homebrew-formula.test.mjs scripts/herdr-world-installer.test.mjs scripts/herdr-world-launcher.test.mjs scripts/herdr-world-plugin.test.mjs scripts/terminal-screen.test.mjs",
     "test:pages": "node --test scripts/pages.test.mjs",
     "test:web": "npm run test --prefix web",
     "test:observability": "npm run test --prefix web -- observability.test.ts && cargo test --manifest-path bridge/Cargo.toml --bin herdr-web-bridge observability",

--- a/scripts/herdr-world-plugin.mjs
+++ b/scripts/herdr-world-plugin.mjs
@@ -433,11 +433,11 @@ export function resolveTargetIdentity(config, env) {
   };
 }
 
-function targetRecordPath(stateDir, identity) {
+export function targetRecordPath(stateDir, identity) {
   return path.join(stateDir, "runtimes", `${hash(identity).slice(0, 32)}.json`);
 }
 
-function serviceName(identity, supervisor) {
+export function serviceName(identity, supervisor) {
   const suffix = hash(identity).slice(0, 24);
   return supervisor === "launchd" ? `io.ivoryheart.herdr-world.${suffix}` : `herdr-world-${suffix}.service`;
 }
@@ -805,6 +805,7 @@ export async function choosePort(config, identity, stateDir, { portFree = portIs
   const requested = config.port;
   const explicit = config.port_was_explicit === true;
   const namedTarget = config.session_name !== null || config.socket_path !== null;
+  const hasDifferentTarget = records.some(({ record }) => record.target_identity !== identity);
   if (explicit) {
     if (recordActivePort(records, identity, requested) || !(await portFree(config.host, requested))) {
       throw new PluginError(`configured bridge port ${requested} is already in use; choose another port`);
@@ -812,7 +813,7 @@ export async function choosePort(config, identity, stateDir, { portFree = portIs
     return requested;
   }
   if (!recordActivePort(records, identity, requested) && await portFree(config.host, requested)) return requested;
-  if (!namedTarget) {
+  if (!namedTarget && !hasDifferentTarget) {
     throw new PluginError(`default bridge port ${requested} is already in use; stop the owner or configure another port`);
   }
   for (let port = config.port_range[0]; port <= config.port_range[1]; port += 1) {
@@ -1259,7 +1260,7 @@ function printService(record, capabilities, prefix = "Herdr World") {
   console.log(`  access: ${displayPosture(record.host)}`);
 }
 
-async function startAction({ root = ROOT, env = process.env, platform = process.platform, arch = process.arch, glibcVersion } = {}) {
+function prepareStart({ root = ROOT, env = process.env, platform = process.platform, arch = process.arch, glibcVersion } = {}) {
   const manifestVersion = readManifestVersion(root);
   const targetPlatform = selectTarget({ platform, arch, glibcVersion });
   const node = checkNode(resolveNode({ env }));
@@ -1267,7 +1268,13 @@ async function startAction({ root = ROOT, env = process.env, platform = process.
   const targetStatus = resolveHerdrTarget(context.config, env);
   const target = { ...context.target, socket_path: targetStatus.socket_path };
   const payload = requirePayload(root, manifestVersion, targetPlatform.target);
-  return withTargetLock(context.stateDir, context.target.identity, async () => {
+  const supervisor = selectSupervisor(platform, env);
+  return { root, env, platform, context, manifestVersion, targetPlatform, node, target, payload, supervisor };
+}
+
+async function startPrepared(plan, { lockHeld = false } = {}) {
+  const { root, env, platform, context, manifestVersion, node, target, payload, supervisor } = plan;
+  const start = async () => {
     const recordPath = targetRecordPath(context.stateDir, context.target.identity);
     const previous = readRecord(recordPath);
     if (previous) {
@@ -1283,7 +1290,6 @@ async function startAction({ root = ROOT, env = process.env, platform = process.
       removeRecord(recordPath);
     }
     const port = await choosePort(context.config, context.target.identity, context.stateDir);
-    const supervisor = selectSupervisor(platform, env);
     const { record, environment } = createRecord({
       identity: context.target.identity,
       target,
@@ -1320,7 +1326,12 @@ async function startAction({ root = ROOT, env = process.env, platform = process.
       if (error instanceof PluginError) throw error;
       throw new PluginError(`could not start Herdr World: ${error.message}`);
     }
-  });
+  };
+  return lockHeld ? start() : withTargetLock(context.stateDir, context.target.identity, start);
+}
+
+async function startAction(options = {}) {
+  return startPrepared(prepareStart(options));
 }
 
 function contextRecord(context) {
@@ -1342,16 +1353,19 @@ async function stopAction({ root = ROOT, env = process.env, platform = process.p
   return record;
 }
 
-async function restartAction(options) {
-  const context = runtimeContext(options.env ?? process.env);
+export async function restartAction(options = {}) {
+  const plan = prepareStart(options);
+  const { context, env, platform } = plan;
   const recordPath = targetRecordPath(context.stateDir, context.target.identity);
-  const record = readRecord(recordPath);
-  if (record) {
-    await stopRecord(record, options.env ?? process.env, options.platform ?? process.platform);
-    removeRecord(recordPath);
-    console.log("Restarting Herdr World; browser clients will disconnect briefly.");
-  }
-  return startAction(options);
+  return withTargetLock(context.stateDir, context.target.identity, async () => {
+    const record = readRecord(recordPath);
+    if (record) {
+      await stopRecord(record, env, platform);
+      removeRecord(recordPath);
+      console.log("Restarting Herdr World; browser clients will disconnect briefly.");
+    }
+    return startPrepared(plan, { lockHeld: true });
+  });
 }
 
 async function statusAction({ env = process.env, platform = process.platform } = {}) {

--- a/scripts/herdr-world-plugin.mjs
+++ b/scripts/herdr-world-plugin.mjs
@@ -1,0 +1,1520 @@
+#!/usr/bin/env node
+
+import { execFileSync, spawn, spawnSync } from "node:child_process";
+import { createHash, randomBytes } from "node:crypto";
+import {
+  accessSync,
+  chmodSync,
+  closeSync,
+  existsSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  readdirSync,
+  readlinkSync,
+  renameSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import net from "node:net";
+import os from "node:os";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+
+export const PLUGIN_ID = "ivoryheart.herdr-world";
+export const PACKAGE_NAME = "@ivoryheart/herdr-world";
+export const MIN_NODE_VERSION = "22.14.0";
+export const MIN_HERDR_VERSION = "0.8.2";
+export const TERMINAL_PROTOCOL = 20;
+export const BRIDGE_API_VERSION = 1;
+export const WEB_COMPAT_VERSION = 1;
+export const DEFAULT_PORT = 8787;
+export const DEFAULT_PORT_RANGE = [8787, 8877];
+export const CONFIG_FILE = "config.json";
+export const SERVICE_SCHEMA_VERSION = 1;
+export const ACTIONS = ["build", "start", "stop", "restart", "status", "open", "doctor"];
+export const SUPPORTED_TARGETS = {
+  "linux-x64": "linux-x64",
+  "darwin-arm64": "macos-arm64",
+  "darwin-x64": "macos-x64",
+};
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const REGISTRY = "https://registry.npmjs.org/";
+const RUNTIME_TIMEOUT_MS = 5_000;
+const START_TIMEOUT_MS = 15_000;
+const STOP_TIMEOUT_MS = 5_000;
+const LOCK_TIMEOUT_MS = 10_000;
+
+export class PluginError extends Error {
+  constructor(message, options = {}) {
+    super(message, options);
+    this.name = "PluginError";
+  }
+}
+
+function fail(message) {
+  throw new PluginError(message);
+}
+
+function isObject(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function parseVersion(value) {
+  if (typeof value !== "string") return null;
+  const normalized = value.startsWith("v") ? value.slice(1) : value;
+  const match = normalized.match(/^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-rc\.([1-9]\d*))?$/);
+  if (!match) return null;
+  return {
+    major: Number(match[1]),
+    minor: Number(match[2]),
+    patch: Number(match[3]),
+    rc: match[4] === undefined ? null : Number(match[4]),
+    value: normalized,
+  };
+}
+
+export function compareVersions(left, right) {
+  const a = typeof left === "string" ? parseVersion(left) : left;
+  const b = typeof right === "string" ? parseVersion(right) : right;
+  if (!a || !b) throw new PluginError(`invalid version comparison: ${left} and ${right}`);
+  for (const key of ["major", "minor", "patch"]) {
+    if (a[key] !== b[key]) return a[key] > b[key] ? 1 : -1;
+  }
+  if (a.rc === b.rc) return 0;
+  if (a.rc === null) return 1;
+  if (b.rc === null) return -1;
+  return a.rc > b.rc ? 1 : -1;
+}
+
+export function minimumVersionSatisfied(value, minimum) {
+  const parsed = parseVersion(value);
+  const required = parseVersion(minimum);
+  return Boolean(parsed && required && compareVersions(parsed, required) >= 0);
+}
+
+function parseTomlValue(value) {
+  const trimmed = value.trim();
+  if (trimmed.startsWith("[") && trimmed.endsWith("]")) {
+    return [...trimmed.matchAll(/"(?:\\.|[^"\\])*"/g)].map((match) => JSON.parse(match[0]));
+  }
+  if (trimmed.startsWith('"') && trimmed.endsWith('"')) return JSON.parse(trimmed);
+  return null;
+}
+
+export function parsePluginManifest(text) {
+  if (typeof text !== "string") throw new PluginError("plugin manifest must be text");
+  const top = {};
+  const blocks = [];
+  let block = null;
+  for (const [index, rawLine] of text.split(/\r?\n/).entries()) {
+    const line = rawLine.replace(/\s+#.*$/, "").trim();
+    if (!line) continue;
+    const section = line.match(/^\[\[([^\]]+)\]\]$/);
+    if (section) {
+      block = { type: section[1], line: index + 1 };
+      blocks.push(block);
+      continue;
+    }
+    const assignment = line.match(/^([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.+)$/);
+    if (!assignment) throw new PluginError(`invalid plugin manifest line ${index + 1}`);
+    const [, key, rawValue] = assignment;
+    const value = parseTomlValue(rawValue);
+    if (value === null) throw new PluginError(`unsupported plugin manifest value for ${key} on line ${index + 1}`);
+    if (block) block[key] = value;
+    else top[key] = value;
+  }
+  return { ...top, blocks };
+}
+
+function arraysEqual(left, right) {
+  return JSON.stringify(left) === JSON.stringify(right);
+}
+
+export function validatePluginManifest(manifest) {
+  const errors = [];
+  if (!isObject(manifest)) return ["manifest is not an object"];
+  if (manifest.id !== PLUGIN_ID) errors.push(`id must be ${PLUGIN_ID}`);
+  if (manifest.name !== "Herdr World") errors.push("name must be Herdr World");
+  if (!parseVersion(manifest.version) || manifest.version.startsWith("v")) {
+    errors.push("version must be an unprefixed release version");
+  }
+  if (manifest.min_herdr_version !== MIN_HERDR_VERSION) {
+    errors.push(`min_herdr_version must be ${MIN_HERDR_VERSION}`);
+  }
+  if (!arraysEqual(manifest.platforms, ["linux", "macos"])) {
+    errors.push('platforms must be ["linux", "macos"]');
+  }
+  const build = manifest.blocks?.filter((entry) => entry.type === "build") ?? [];
+  if (build.length !== 1 || !arraysEqual(build[0]?.command, ["bash", "scripts/herdr-world-plugin.sh", "build"])) {
+    errors.push("manifest must declare the exact plugin build command");
+  }
+  for (const forbidden of ["startup", "events", "panes", "link_handlers"]) {
+    if (manifest.blocks?.some((entry) => entry.type === forbidden)) {
+      errors.push(`manifest must not declare [[${forbidden}]]`);
+    }
+  }
+  const actions = manifest.blocks?.filter((entry) => entry.type === "actions") ?? [];
+  if (actions.length !== 6) errors.push("manifest must declare exactly six actions");
+  const actionIds = actions.map((entry) => entry.id);
+  if (!arraysEqual([...actionIds].sort(), ["doctor", "open", "restart", "start", "status", "stop"])) {
+    errors.push("manifest action ids must be start, stop, restart, status, open, and doctor");
+  }
+  for (const action of actions) {
+    if (!ACTIONS.includes(action.id) || action.id === "build") continue;
+    if (!arraysEqual(action.contexts, ["workspace"])) {
+      errors.push(`${action.id} must be workspace-scoped`);
+    }
+    if (!arraysEqual(action.command, ["bash", "scripts/herdr-world-plugin.sh", action.id])) {
+      errors.push(`${action.id} must invoke the controller by path`);
+    }
+  }
+  return errors;
+}
+
+export function assertPluginManifest(manifest) {
+  const errors = validatePluginManifest(manifest);
+  if (errors.length > 0) throw new PluginError(`invalid herdr-plugin.toml: ${errors.join("; ")}`);
+  return manifest;
+}
+
+export function readPluginManifest(root = ROOT) {
+  const manifestPath = path.join(root, "herdr-plugin.toml");
+  try {
+    return assertPluginManifest(parsePluginManifest(readFileSync(manifestPath, "utf8")));
+  } catch (error) {
+    if (error instanceof PluginError) throw error;
+    throw new PluginError(`could not read ${manifestPath}: ${error.message}`);
+  }
+}
+
+function executable(pathname) {
+  try {
+    accessSync(pathname, os.platform() === "win32" ? 0 : 1);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function resolveExecutable(command, { env = process.env, explicitPath } = {}) {
+  const candidate = explicitPath ?? (path.isAbsolute(command) ? command : null);
+  if (candidate) {
+    if (!path.isAbsolute(candidate) || !executable(candidate)) {
+      throw new PluginError(`required executable is not available: ${candidate}`);
+    }
+    return path.resolve(candidate);
+  }
+  const pathEntries = String(env.PATH ?? "").split(path.delimiter).filter(Boolean);
+  for (const entry of pathEntries) {
+    const pathname = path.join(entry, command);
+    if (executable(pathname)) return path.resolve(pathname);
+  }
+  throw new PluginError(`required executable is not available on PATH: ${command}`);
+}
+
+function commandResult(command, args, options = {}) {
+  return spawnSync(command, args, {
+    cwd: options.cwd,
+    env: options.env,
+    encoding: "utf8",
+    timeout: options.timeout ?? RUNTIME_TIMEOUT_MS,
+    stdio: options.stdio ?? ["ignore", "pipe", "pipe"],
+  });
+}
+
+function commandOutput(command, args, options = {}) {
+  const result = commandResult(command, args, options);
+  if (result.error) throw new PluginError(`${path.basename(command)} ${args.join(" ")} failed: ${result.error.message}`);
+  if (result.status !== 0) {
+    const detail = String(result.stderr || result.stdout || `exit status ${result.status}`).trim();
+    throw new PluginError(`${path.basename(command)} ${args.join(" ")} failed: ${detail}`);
+  }
+  return String(result.stdout ?? "").trim();
+}
+
+function toolVersion(command, args = ["--version"], options = {}) {
+  const output = commandOutput(command, args, options);
+  const match = output.match(/v?(\d+\.\d+\.\d+)/);
+  if (!match || !parseVersion(match[1])) throw new PluginError(`could not determine ${path.basename(command)} version`);
+  return match[1];
+}
+
+export function resolveNode({ env = process.env, nodePath } = {}) {
+  return resolveExecutable("node", { env, explicitPath: nodePath ?? env.HERDR_WORLD_NODE_PATH });
+}
+
+export function checkNode(nodePath, { runner = commandOutput } = {}) {
+  let version;
+  try {
+    version = runner(nodePath, ["--version"], { timeout: RUNTIME_TIMEOUT_MS });
+  } catch (error) {
+    throw new PluginError(`Node.js could not be executed at ${nodePath}: ${error.message}`);
+  }
+  const match = String(version).match(/v?(\d+\.\d+\.\d+)/);
+  if (!match || !minimumVersionSatisfied(match[1], MIN_NODE_VERSION)) {
+    throw new PluginError(`Node.js ${MIN_NODE_VERSION} or newer is required; found ${String(version).trim() || "unknown"}`);
+  }
+  return { path: path.resolve(nodePath), version: match[1] };
+}
+
+export function selectTarget({ platform = process.platform, arch = process.arch, glibcVersion } = {}) {
+  const key = `${platform}-${arch}`;
+  const target = SUPPORTED_TARGETS[key];
+  if (!target) throw new PluginError(`unsupported Herdr World plugin target: ${key}`);
+  if (platform === "linux") {
+    const detected = glibcVersion ?? process.report?.getReport?.().header?.glibcVersionRuntime;
+    if (typeof detected !== "string" || !/^\d+\.\d+$/.test(detected)) {
+      throw new PluginError("Linux musl or unknown libc is unsupported; a detectable glibc 2.34 or newer is required");
+    }
+    const [major, minor] = detected.split(".").map(Number);
+    if (major < 2 || (major === 2 && minor < 34)) {
+      throw new PluginError(`Linux glibc 2.34 or newer is required; found ${detected}`);
+    }
+  }
+  return { key, target };
+}
+
+function ensureDirectory(directory) {
+  mkdirSync(directory, { recursive: true, mode: 0o700 });
+  try {
+    chmodSync(directory, 0o700);
+  } catch {
+    // Windows has no equivalent user-only directory mode.
+  }
+  return directory;
+}
+
+function ensureRuntimeDirectories(env) {
+  const configDir = env.HERDR_PLUGIN_CONFIG_DIR;
+  const stateDir = env.HERDR_PLUGIN_STATE_DIR;
+  if (!configDir || !stateDir) {
+    throw new PluginError("Herdr plugin config/state directories are unavailable; invoke this action through Herdr");
+  }
+  if (!path.isAbsolute(configDir) || !path.isAbsolute(stateDir)) {
+    throw new PluginError("Herdr plugin config/state directories must be absolute paths");
+  }
+  ensureDirectory(configDir);
+  ensureDirectory(stateDir);
+  ensureDirectory(path.join(stateDir, "runtimes"));
+  ensureDirectory(path.join(stateDir, "logs"));
+  ensureDirectory(path.join(stateDir, "supervisors"));
+  return { configDir, stateDir };
+}
+
+const DEFAULT_CONFIG = {
+  host: "127.0.0.1",
+  port: DEFAULT_PORT,
+  port_range: DEFAULT_PORT_RANGE,
+  session_name: null,
+  socket_path: null,
+  upload_dir: null,
+  allowed_hosts: [],
+  allowed_origins: [],
+  allowed_connect_origins: [],
+  bridge_label: null,
+};
+
+function validHost(value) {
+  if (typeof value !== "string" || value.length === 0 || value.length > 253 || /[\s\0\r\n]/.test(value)) return false;
+  if (net.isIP(value)) return true;
+  return !value.includes("/") && !value.includes("\\") &&
+    /^(?=.{1,253}$)(?:[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?)(?:\.(?:[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?))*$/.test(value);
+}
+
+function validSession(value) {
+  return typeof value === "string" && /^[A-Za-z0-9._-]{1,64}$/.test(value);
+}
+
+function validOrigin(value) {
+  if (typeof value !== "string" || value.includes("*") || /[\r\n]/.test(value)) return false;
+  try {
+    const parsed = new URL(value);
+    return (parsed.protocol === "http:" || parsed.protocol === "https:") &&
+      parsed.username === "" && parsed.password === "" && parsed.pathname === "/" &&
+      parsed.search === "" && parsed.hash === "" && parsed.hostname !== "" &&
+      parsed.origin === value;
+  } catch {
+    return false;
+  }
+}
+
+function validStringArray(value, validator, label) {
+  if (!Array.isArray(value) || value.length > 32 || value.some((item) => !validator(item))) {
+    throw new PluginError(`${label} must be an array of valid values`);
+  }
+  return [...new Set(value)];
+}
+
+export function validateConfig(input) {
+  if (!isObject(input)) throw new PluginError("plugin config must be a JSON object");
+  const config = { ...DEFAULT_CONFIG, ...input };
+  config.port_was_explicit = input.port_was_explicit === true;
+  if (!validHost(config.host)) throw new PluginError("config host must be a non-empty hostname or IP literal");
+  if (!Number.isInteger(config.port) || config.port < 1 || config.port > 65535) {
+    throw new PluginError("config port must be an integer between 1 and 65535");
+  }
+  if (!Array.isArray(config.port_range) || config.port_range.length !== 2 ||
+      config.port_range.some((port) => !Number.isInteger(port) || port < 1 || port > 65535) ||
+      config.port_range[0] > config.port_range[1]) {
+    throw new PluginError("config port_range must contain two ordered ports between 1 and 65535");
+  }
+  if (config.session_name !== null && !validSession(config.session_name)) {
+    throw new PluginError("config session_name must contain only ASCII letters, digits, '.', '_', or '-'");
+  }
+  if (config.socket_path !== null && (!path.isAbsolute(String(config.socket_path)) || /[\0\r\n]/.test(config.socket_path))) {
+    throw new PluginError("config socket_path must be an absolute path");
+  }
+  if (config.session_name !== null && config.socket_path !== null) {
+    throw new PluginError("config session_name and socket_path are mutually exclusive");
+  }
+  if (config.upload_dir !== null && (!path.isAbsolute(String(config.upload_dir)) || /[\0\r\n]/.test(config.upload_dir))) {
+    throw new PluginError("config upload_dir must be an absolute path");
+  }
+  if (config.bridge_label !== null && (typeof config.bridge_label !== "string" || config.bridge_label.length === 0 || config.bridge_label.length > 80 || /[\0\r\n]/.test(config.bridge_label))) {
+    throw new PluginError("config bridge_label must be 1-80 characters without control characters");
+  }
+  config.allowed_hosts = validStringArray(config.allowed_hosts, validHost, "config allowed_hosts");
+  config.allowed_origins = validStringArray(config.allowed_origins, validOrigin, "config allowed_origins");
+  config.allowed_connect_origins = validStringArray(config.allowed_connect_origins, validOrigin, "config allowed_connect_origins");
+  if (!isLoopbackHost(config.host) && (config.allowed_hosts.length === 0 || config.allowed_origins.length === 0)) {
+    throw new PluginError("non-loopback binding requires explicit allowed_hosts and allowed_origins configuration");
+  }
+  return config;
+}
+
+export function loadConfig(configDir) {
+  const configPath = path.join(configDir, CONFIG_FILE);
+  if (!existsSync(configPath)) return validateConfig({ ...DEFAULT_CONFIG, port_was_explicit: false });
+  let parsed;
+  try {
+    parsed = JSON.parse(readFileSync(configPath, "utf8"));
+  } catch (error) {
+    throw new PluginError(`could not parse ${configPath}: ${error.message}`);
+  }
+  return validateConfig({ ...parsed, port_was_explicit: Object.hasOwn(parsed, "port") });
+}
+
+function isLoopbackHost(host) {
+  return host === "localhost" || host === "127.0.0.1" || host === "::1";
+}
+
+function hash(value) {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function absolutePath(value) {
+  return path.resolve(value);
+}
+
+export function resolveTargetIdentity(config, env) {
+  if (config.session_name !== null) {
+    const key = `session:${config.session_name}`;
+    return {
+      key,
+      identity: `session:${hash(key).slice(0, 32)}`,
+      session_name: config.session_name,
+      socket_path: null,
+    };
+  }
+  const selected = config.socket_path ?? env.HERDR_SOCKET_PATH;
+  if (!selected) throw new PluginError("no Herdr target is selected; start Herdr or configure socket_path/session_name");
+  if (!path.isAbsolute(selected)) throw new PluginError("selected HERDR_SOCKET_PATH must be absolute");
+  const socketPath = absolutePath(selected);
+  const key = `socket:${socketPath}`;
+  return {
+    key,
+    identity: `socket:${hash(key).slice(0, 32)}`,
+    session_name: null,
+    socket_path: socketPath,
+  };
+}
+
+function targetRecordPath(stateDir, identity) {
+  return path.join(stateDir, "runtimes", `${hash(identity).slice(0, 32)}.json`);
+}
+
+function serviceName(identity, supervisor) {
+  const suffix = hash(identity).slice(0, 24);
+  return supervisor === "launchd" ? `io.ivoryheart.herdr-world.${suffix}` : `herdr-world-${suffix}.service`;
+}
+
+export function npmInstallArgs(version, prefix = ".herdr-world-plugin") {
+  return [
+    "install",
+    `--registry=${REGISTRY}`,
+    `--@ivoryheart:registry=${REGISTRY}`,
+    "--prefix",
+    prefix,
+    "--ignore-scripts",
+    "--no-save",
+    "--package-lock=false",
+    "--no-audit",
+    "--no-fund",
+    "--omit=dev",
+    `${PACKAGE_NAME}@${version}`,
+  ];
+}
+
+export function npmInstallCommand(version) {
+  return ["npm", ...npmInstallArgs(version)].join(" ");
+}
+
+function payloadPaths(root, version, target) {
+  const prefix = path.join(root, ".herdr-world-plugin");
+  const packageRoot = path.join(prefix, "node_modules", "@ivoryheart", "herdr-world");
+  return {
+    prefix,
+    packageRoot,
+    packageJson: path.join(packageRoot, "package.json"),
+    entrypoint: path.join(prefix, "node_modules", ".bin", "herdr-world"),
+    bridge: path.join(packageRoot, "lib", "bridges", target, "herdr-world-bridge"),
+    staticIndex: path.join(packageRoot, "share", "herdr-world", "web", "index.html"),
+    legalManifest: path.join(packageRoot, "share", "herdr-world", "web", "legal", "manifest.json"),
+    launcher: path.join(packageRoot, "lib", "herdr-world-launcher.sh"),
+  };
+}
+
+export function validatePayload(root, version, target) {
+  const paths = payloadPaths(root, version, target);
+  let packageJson;
+  let legalManifest;
+  try {
+    packageJson = JSON.parse(readFileSync(paths.packageJson, "utf8"));
+  } catch (error) {
+    throw new PluginError(`private npm payload is incomplete: could not read ${paths.packageJson}: ${error.message}`);
+  }
+  if (packageJson.name !== PACKAGE_NAME || packageJson.version !== version) {
+    throw new PluginError(`private npm payload version mismatch: expected ${PACKAGE_NAME}@${version}`);
+  }
+  try {
+    legalManifest = JSON.parse(readFileSync(paths.legalManifest, "utf8"));
+  } catch (error) {
+    throw new PluginError(`private npm payload has an invalid legal manifest: ${error.message}`);
+  }
+  if (legalManifest.schema_version !== 1 || !Array.isArray(legalManifest.files)) {
+    throw new PluginError("private npm payload has an invalid legal manifest schema");
+  }
+  const required = [
+    [paths.entrypoint, "private npm herdr-world entrypoint"],
+    [paths.bridge, `${target} native bridge`],
+    [paths.staticIndex, "packaged web assets"],
+    [paths.legalManifest, "packaged legal manifest"],
+    [paths.launcher, "packaged launcher"],
+    [path.join(paths.packageRoot, "LICENSE"), "package license"],
+    [path.join(paths.packageRoot, "THIRD_PARTY_NOTICES.md"), "third-party notices"],
+    [path.join(paths.packageRoot, "UPSTREAM.md"), "upstream record"],
+  ];
+  for (const [pathname, label] of required) {
+    if (!existsSync(pathname)) throw new PluginError(`private npm payload is missing ${label}: ${pathname}`);
+  }
+  if (!executable(paths.entrypoint) || !executable(paths.bridge) || !executable(paths.launcher)) {
+    throw new PluginError("private npm payload contains a non-executable launcher or native bridge");
+  }
+  const legalRoot = path.dirname(paths.legalManifest);
+  for (const entry of legalManifest.files) {
+    if (!isObject(entry) || typeof entry.path !== "string" || path.isAbsolute(entry.path) || entry.path.includes("..")) {
+      throw new PluginError("private npm payload legal manifest contains an unsafe path");
+    }
+    const legalPath = path.resolve(legalRoot, entry.path);
+    if (path.relative(legalRoot, legalPath).startsWith(`..${path.sep}`) || !existsSync(legalPath)) {
+      throw new PluginError(`private npm payload is missing a legal file: ${entry.path}`);
+    }
+  }
+  return { ...paths, packageJson, legalManifest };
+}
+
+export function requirePayload(root, version, target) {
+  try {
+    return validatePayload(root, version, target);
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    throw new PluginError(`${detail}\nInstall the exact private payload with:\n  ${npmInstallCommand(version)}`);
+  }
+}
+
+function readManifestVersion(root) {
+  return readPluginManifest(root).version;
+}
+
+export function buildPayload({ root = ROOT, env = process.env, nodePath, npmPath, platform = process.platform, arch = process.arch, glibcVersion } = {}) {
+  const manifest = readPluginManifest(root);
+  const target = selectTarget({ platform, arch, glibcVersion });
+  const node = checkNode(resolveNode({ env, nodePath }));
+  const npm = resolveExecutable("npm", { env, explicitPath: npmPath ?? env.HERDR_WORLD_NPM_PATH });
+  try {
+    toolVersion(npm, ["--version"]);
+  } catch (error) {
+    throw new PluginError(`npm is unavailable: ${error.message}`);
+  }
+  const prefix = path.join(root, ".herdr-world-plugin");
+  rmSync(prefix, { recursive: true, force: true });
+  ensureDirectory(prefix);
+  try {
+    const result = spawnSync(npm, npmInstallArgs(manifest.version, prefix), {
+      cwd: root,
+      env: { ...env },
+      stdio: "inherit",
+      timeout: 20 * 60 * 1000,
+    });
+    if (result.error) throw new PluginError(`npm payload installation failed: ${result.error.message}`);
+    if (result.status !== 0) throw new PluginError(`npm payload installation failed with exit status ${result.status}`);
+    const payload = validatePayload(root, manifest.version, target.target);
+    console.log(`Installed ${PACKAGE_NAME}@${manifest.version} for ${target.target}`);
+    console.log(`  payload: ${payload.packageRoot}`);
+    console.log(`  Node.js: ${node.version} (${node.path})`);
+    return payload;
+  } catch (error) {
+    rmSync(prefix, { recursive: true, force: true });
+    if (error instanceof PluginError) throw error;
+    throw new PluginError(`npm payload installation failed: ${error.message}`);
+  }
+}
+
+function runtimeContext(env) {
+  const directories = ensureRuntimeDirectories(env);
+  const config = loadConfig(directories.configDir);
+  const target = resolveTargetIdentity(config, env);
+  return { ...directories, config, target };
+}
+
+function herdrBinary(env) {
+  const value = env.HERDR_BIN_PATH;
+  if (!value || !path.isAbsolute(value) || !executable(value)) {
+    throw new PluginError("HERDR_BIN_PATH is missing or is not an executable absolute path; run the action from Herdr");
+  }
+  return path.resolve(value);
+}
+
+function statusJson(herdr, args, env) {
+  const result = commandResult(herdr, args, {
+    env,
+    timeout: RUNTIME_TIMEOUT_MS,
+  });
+  if (result.error) throw new PluginError(`could not query the selected Herdr target: ${result.error.message}`);
+  if (result.status !== 0) {
+    throw new PluginError("could not query the selected Herdr target; start Herdr or select a running session");
+  }
+  try {
+    return JSON.parse(String(result.stdout ?? "").trim());
+  } catch {
+    throw new PluginError("Herdr returned an invalid JSON status response");
+  }
+}
+
+export function resolveHerdrTarget(config, env, { requireRunning = true } = {}) {
+  const herdr = herdrBinary(env);
+  const queryEnv = { ...env };
+  delete queryEnv.HERDR_SESSION;
+  const args = [];
+  if (config.session_name !== null) {
+    args.push("--session", config.session_name);
+    delete queryEnv.HERDR_SOCKET_PATH;
+  } else {
+    queryEnv.HERDR_SOCKET_PATH = config.socket_path ?? env.HERDR_SOCKET_PATH;
+  }
+  args.push("status", "server", "--json");
+  const status = statusJson(herdr, args, queryEnv);
+  if (requireRunning && (status.running !== true || status.status !== "running")) {
+    throw new PluginError("selected Herdr target is not running; start Herdr before starting Herdr World");
+  }
+  const socketPath = config.session_name !== null ? status.socket : queryEnv.HERDR_SOCKET_PATH;
+  if (typeof socketPath !== "string" || !path.isAbsolute(socketPath)) {
+    throw new PluginError("selected Herdr target did not report an absolute socket path");
+  }
+  if (requireRunning && status.compatible !== true) {
+    throw new PluginError(`selected Herdr target is incompatible; Herdr ${MIN_HERDR_VERSION} or protocol ${TERMINAL_PROTOCOL} is required`);
+  }
+  if (requireRunning && !minimumVersionSatisfied(status.version, MIN_HERDR_VERSION)) {
+    throw new PluginError(`selected Herdr target reports Herdr ${status.version ?? "unknown"}; ${MIN_HERDR_VERSION} or newer is required`);
+  }
+  if (requireRunning && status.protocol !== TERMINAL_PROTOCOL) {
+    throw new PluginError(`selected Herdr target reports terminal protocol ${status.protocol ?? "unknown"}; expected ${TERMINAL_PROTOCOL}`);
+  }
+  if (requireRunning) {
+    try {
+      if (!statSync(socketPath).isSocket()) throw new Error("not a socket");
+    } catch {
+      throw new PluginError(`selected Herdr socket is unavailable: ${path.basename(socketPath)}`);
+    }
+  }
+  return {
+    ...status,
+    herdr_path: herdr,
+    socket_path: path.resolve(socketPath),
+    session_name: config.session_name,
+  };
+}
+
+function bridgeUrl(host, port) {
+  const displayHost = net.isIP(host) === 6 ? `[${host}]` : host;
+  return `http://${displayHost}:${port}`;
+}
+
+function probeHost(host) {
+  if (host === "0.0.0.0") return "127.0.0.1";
+  if (host === "::") return "::1";
+  return host;
+}
+
+function probeUrl(host, port) {
+  return bridgeUrl(probeHost(host), port);
+}
+
+function safeCapability(capabilities, expectedVersion) {
+  if (!isObject(capabilities)) return "capabilities response is not an object";
+  if (capabilities.bridge_api_version !== BRIDGE_API_VERSION) return `bridge API ${String(capabilities.bridge_api_version)} is incompatible; expected ${BRIDGE_API_VERSION}`;
+  if (capabilities.terminal_protocol !== TERMINAL_PROTOCOL) return `terminal protocol ${String(capabilities.terminal_protocol)} is incompatible; expected ${TERMINAL_PROTOCOL}`;
+  if (!minimumVersionSatisfied(capabilities.herdr_version, MIN_HERDR_VERSION)) return `Herdr ${String(capabilities.herdr_version)} is incompatible; expected ${MIN_HERDR_VERSION} or newer`;
+  if (!Number.isInteger(capabilities.web_compat) || capabilities.web_compat < WEB_COMPAT_VERSION) return `bridge web compatibility ${String(capabilities.web_compat)} is incompatible; expected ${WEB_COMPAT_VERSION}`;
+  if (expectedVersion && capabilities.bridge_version && !parseVersion(capabilities.bridge_version) && capabilities.bridge_version !== "0.0.0") return "bridge reported an invalid version";
+  return null;
+}
+
+export async function probeCapabilities(url, { timeoutMs = 750, fetchImpl = globalThis.fetch } = {}) {
+  try {
+    const response = await fetchImpl(`${url}/api/capabilities`, {
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+    if (!response.ok) {
+      await response.body?.cancel?.();
+      return { ok: false, error: `HTTP ${response.status}` };
+    }
+    let capabilities;
+    try {
+      capabilities = await response.json();
+    } catch {
+      return { ok: false, error: "invalid JSON capabilities response" };
+    }
+    return { ok: true, capabilities };
+  } catch (error) {
+    return { ok: false, error: error instanceof Error ? error.message : String(error) };
+  }
+}
+
+export async function waitForReadiness(url, expected, { timeoutMs = START_TIMEOUT_MS, fetchImpl } = {}) {
+  const deadline = Date.now() + timeoutMs;
+  let lastError = "no response";
+  while (Date.now() < deadline) {
+    const result = await probeCapabilities(url, { fetchImpl });
+    if (result.ok) {
+      const compatibility = safeCapability(result.capabilities, expected.package_version);
+      if (!compatibility) return result.capabilities;
+      lastError = compatibility;
+    } else {
+      lastError = result.error;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new PluginError(`bridge did not become ready at ${url} within ${timeoutMs}ms: ${lastError}`);
+}
+
+function atomicWrite(pathname, content) {
+  const directory = path.dirname(pathname);
+  ensureDirectory(directory);
+  const temporary = path.join(directory, `.${path.basename(pathname)}.${process.pid}.${randomBytes(6).toString("hex")}.tmp`);
+  try {
+    writeFileSync(temporary, content, { mode: 0o600 });
+    try { chmodSync(temporary, 0o600); } catch {}
+    renameSync(temporary, pathname);
+  } finally {
+    if (existsSync(temporary)) rmSync(temporary, { force: true });
+  }
+}
+
+function writeRecord(pathname, record) {
+  atomicWrite(pathname, `${JSON.stringify(record, null, 2)}\n`);
+}
+
+function readRecord(pathname) {
+  try {
+    return JSON.parse(readFileSync(pathname, "utf8"));
+  } catch (error) {
+    if (error.code === "ENOENT") return null;
+    throw new PluginError(`could not read service record ${path.basename(pathname)}: ${error.message}`);
+  }
+}
+
+function listRecords(stateDir) {
+  const directory = path.join(stateDir, "runtimes");
+  ensureDirectory(directory);
+  const records = [];
+  for (const name of readdirSync(directory)) {
+    if (!name.endsWith(".json")) continue;
+    const pathname = path.join(directory, name);
+    const record = readRecord(pathname);
+    if (record) records.push({ path: pathname, record });
+  }
+  return records;
+}
+
+function removeRecord(pathname) {
+  rmSync(pathname, { force: true });
+}
+
+function lockPath(stateDir, identity) {
+  return path.join(stateDir, "runtimes", `.${hash(identity).slice(0, 32)}.lock`);
+}
+
+export async function withTargetLock(stateDir, identity, callback) {
+  ensureDirectory(path.join(stateDir, "runtimes"));
+  const pathname = lockPath(stateDir, identity);
+  const deadline = Date.now() + LOCK_TIMEOUT_MS;
+  let descriptor;
+  while (Date.now() < deadline) {
+    try {
+      descriptor = openSync(pathname, "wx", 0o600);
+      break;
+    } catch (error) {
+      if (error.code !== "EEXIST") throw error;
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    }
+  }
+  if (descriptor === undefined) throw new PluginError("another Herdr World action is managing this target; retry shortly");
+  try {
+    return await callback();
+  } finally {
+    closeSync(descriptor);
+    rmSync(pathname, { force: true });
+  }
+}
+
+function portIsFree(host, port) {
+  return new Promise((resolve) => {
+    const server = net.createServer();
+    let settled = false;
+    const finish = (free) => {
+      if (settled) return;
+      settled = true;
+      server.close(() => resolve(free));
+    };
+    server.once("error", () => finish(false));
+    server.listen(port, probeHost(host), () => finish(true));
+  });
+}
+
+function recordActivePort(records, identity, port) {
+  return records.some(({ record }) => record.target_identity !== identity && record.port === port);
+}
+
+export async function choosePort(config, identity, stateDir, { portFree = portIsFree } = {}) {
+  const records = listRecords(stateDir);
+  const requested = config.port;
+  const explicit = config.port_was_explicit === true;
+  const namedTarget = config.session_name !== null || config.socket_path !== null;
+  if (explicit) {
+    if (recordActivePort(records, identity, requested) || !(await portFree(config.host, requested))) {
+      throw new PluginError(`configured bridge port ${requested} is already in use; choose another port`);
+    }
+    return requested;
+  }
+  if (!recordActivePort(records, identity, requested) && await portFree(config.host, requested)) return requested;
+  if (!namedTarget) {
+    throw new PluginError(`default bridge port ${requested} is already in use; stop the owner or configure another port`);
+  }
+  for (let port = config.port_range[0]; port <= config.port_range[1]; port += 1) {
+    if (recordActivePort(records, identity, port)) continue;
+    if (await portFree(config.host, port)) return port;
+  }
+  throw new PluginError(`no free bridge port is available in ${config.port_range[0]}-${config.port_range[1]}`);
+}
+
+function selectedEnvironment(env, target, serviceId) {
+  const result = {
+    HERDR_SOCKET_PATH: target.socket_path,
+    HERDR_WORLD_SETUP: "never",
+    HERDR_WORLD_PLUGIN_SERVICE_ID: serviceId,
+    PATH: env.PATH || "/usr/local/bin:/usr/bin:/bin",
+  };
+  for (const name of ["HOME", "XDG_CONFIG_HOME", "XDG_DATA_HOME", "XDG_STATE_HOME", "HERDR_CONFIG_PATH", "TMPDIR", "LANG", "LC_ALL"]) {
+    if (env[name]) result[name] = env[name];
+  }
+  return result;
+}
+
+function bridgeArguments(config, target, port) {
+  const args = [];
+  if (target.session_name) args.push("--session", target.session_name);
+  args.push("--host", config.host, "--port", String(port));
+  if (config.upload_dir) args.push("--upload-dir", config.upload_dir);
+  for (const host of config.allowed_hosts) args.push("--allow-host", host);
+  for (const origin of config.allowed_origins) args.push("--allow-origin", origin);
+  for (const origin of config.allowed_connect_origins) args.push("--allow-connect-origin", origin);
+  if (config.bridge_label) args.push("--bridge-label", config.bridge_label);
+  return args;
+}
+
+function commandForRecord(record) {
+  return [record.node_path, record.payload_entrypoint, ...(record.bridge_args ?? [])];
+}
+
+function commandSignature(command) {
+  return hash(JSON.stringify(command));
+}
+
+function configSignature(config) {
+  return hash(JSON.stringify({
+    host: config.host,
+    upload_dir: config.upload_dir,
+    allowed_hosts: config.allowed_hosts,
+    allowed_origins: config.allowed_origins,
+    allowed_connect_origins: config.allowed_connect_origins,
+    bridge_label: config.bridge_label,
+  }));
+}
+
+function pathForSupervisor(stateDir, record, suffix) {
+  if (suffix === "service" && record.supervisor === "systemd-user") {
+    return path.join(stateDir, "supervisors", record.service_name);
+  }
+  return path.join(stateDir, "supervisors", `${hash(record.target_identity).slice(0, 32)}.${suffix}`);
+}
+
+function systemdEscape(value) {
+  return `"${String(value).replaceAll("%", "%%").replaceAll("\\", "\\\\").replaceAll('"', '\\"').replace(/[\r\n]/g, "")}"`;
+}
+
+export function renderSystemdUnit(record, environment) {
+  const command = commandForRecord(record).map(systemdEscape).join(" ");
+  const lines = [
+    "[Unit]",
+    "Description=Herdr World bridge",
+    "",
+    "[Service]",
+    "Type=simple",
+    `ExecStart=${command}`,
+    "Restart=on-failure",
+    "RestartSec=1",
+  ];
+  for (const [key, value] of Object.entries(environment)) lines.push(`Environment=${systemdEscape(`${key}=${value}`)}`);
+  lines.push("");
+  return `${lines.join("\n")}\n`;
+}
+
+function systemdUnit(record, environment, unitPath) {
+  atomicWrite(unitPath, renderSystemdUnit(record, environment));
+}
+
+function xmlEscape(value) {
+  return String(value)
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&apos;");
+}
+
+function plistString(value) {
+  return `<string>${xmlEscape(value)}</string>`;
+}
+
+export function renderLaunchdPlist(record, environment, logPath) {
+  const programArguments = commandForRecord(record).map(plistString).join("");
+  const environmentVariables = Object.entries(environment)
+    .map(([key, value]) => `<key>${xmlEscape(key)}</key>${plistString(value)}`)
+    .join("");
+  const content = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict>
+<key>Label</key>${plistString(record.service_name)}
+<key>ProgramArguments</key><array>${programArguments}</array>
+<key>EnvironmentVariables</key><dict>${environmentVariables}</dict>
+<key>RunAtLoad</key><true/>
+<key>KeepAlive</key><true/>
+<key>StandardOutPath</key>${plistString(logPath)}
+<key>StandardErrorPath</key>${plistString(logPath)}
+</dict></plist>
+`;
+  return content;
+}
+
+function launchdPlist(record, environment, plistPath, logPath) {
+  atomicWrite(plistPath, renderLaunchdPlist(record, environment, logPath));
+}
+
+function supervisorCommand(name, env) {
+  const override = env[name];
+  if (override) return resolveExecutable(name === "HERDR_WORLD_SYSTEMCTL" ? "systemctl" : "launchctl", { env, explicitPath: override });
+  return resolveExecutable(name === "HERDR_WORLD_SYSTEMCTL" ? "systemctl" : "launchctl", { env });
+}
+
+function runChecked(command, args, options = {}) {
+  const result = commandResult(command, args, {
+    cwd: options.cwd,
+    env: options.env,
+    timeout: options.timeout ?? RUNTIME_TIMEOUT_MS,
+    stdio: options.stdio ?? ["ignore", "pipe", "pipe"],
+  });
+  if (result.error) throw new PluginError(`${path.basename(command)} failed: ${result.error.message}`);
+  if (result.status !== 0) {
+    const detail = String(result.stderr || result.stdout || `exit status ${result.status}`).trim();
+    throw new PluginError(`${path.basename(command)} ${args.join(" ")} failed: ${detail}`);
+  }
+  return String(result.stdout ?? "").trim();
+}
+
+function systemdAvailable(env) {
+  let command;
+  try {
+    command = supervisorCommand("HERDR_WORLD_SYSTEMCTL", env);
+  } catch {
+    return null;
+  }
+  const result = commandResult(command, ["--user", "show-environment"], { env, timeout: RUNTIME_TIMEOUT_MS });
+  if (result.status !== 0) return null;
+  return command;
+}
+
+function launchdAvailable(env) {
+  let command;
+  try {
+    command = supervisorCommand("HERDR_WORLD_LAUNCHCTL", env);
+  } catch {
+    return null;
+  }
+  const uid = typeof process.getuid === "function" ? process.getuid() : null;
+  if (uid === null) return null;
+  const result = commandResult(command, ["print", `gui/${uid}`], { env, timeout: RUNTIME_TIMEOUT_MS });
+  if (result.status !== 0) return null;
+  return command;
+}
+
+export function selectSupervisor(platform, env) {
+  if (platform === "linux") {
+    const systemctl = systemdAvailable(env);
+    if (systemctl) return { kind: "systemd-user", command: systemctl };
+  }
+  if (platform === "darwin") {
+    const launchctl = launchdAvailable(env);
+    if (launchctl) return { kind: "launchd", command: launchctl };
+  }
+  return { kind: "fallback", command: null };
+}
+
+function createRecord({ identity, target, config, payload, node, port, supervisor, root, env }) {
+  const args = bridgeArguments(config, target, port);
+  const record = {
+    schema_version: SERVICE_SCHEMA_VERSION,
+    target_identity: identity,
+    session_name: target.session_name,
+    socket_path: target.socket_path,
+    host: config.host,
+    port,
+    url: bridgeUrl(config.host, port),
+    package_name: PACKAGE_NAME,
+    package_version: payload.packageJson.version,
+    payload_root: payload.packageRoot,
+    payload_entrypoint: payload.entrypoint,
+    node_path: node.path,
+    supervisor: supervisor.kind,
+    service_name: serviceName(identity, supervisor.kind),
+    pid: 0,
+    application_version: payload.packageJson.version,
+    herdr_protocol: TERMINAL_PROTOCOL,
+    bridge_args: args,
+    command_signature: commandSignature([node.path, payload.entrypoint, ...args]),
+    config_signature: configSignature(config),
+    root: path.resolve(root),
+    updated_at: new Date().toISOString(),
+  };
+  return { record, environment: selectedEnvironment(env, target, record.service_name) };
+}
+
+function spawnFallback(record, environment, stateDir) {
+  const logPath = pathForSupervisor(stateDir, record, "log");
+  const fd = openSync(logPath, "a", 0o600);
+  try {
+    const child = spawn(record.node_path, commandForRecord(record).slice(1), {
+      cwd: record.root,
+      env: environment,
+      detached: true,
+      stdio: ["ignore", fd, fd],
+    });
+    if (!Number.isInteger(child.pid)) throw new PluginError("fallback supervisor did not return a process id");
+    child.unref();
+    return child.pid;
+  } finally {
+    closeSync(fd);
+  }
+}
+
+function startUnderSupervisor(record, environment, stateDir, supervisor) {
+  if (supervisor.kind === "fallback") return spawnFallback(record, environment, stateDir);
+  if (supervisor.kind === "systemd-user") {
+    const unitPath = pathForSupervisor(stateDir, record, "service");
+    systemdUnit(record, environment, unitPath);
+    runChecked(supervisor.command, ["--user", "link", unitPath]);
+    runChecked(supervisor.command, ["--user", "daemon-reload"]);
+    runChecked(supervisor.command, ["--user", "start", record.service_name]);
+    return systemdPid(record, supervisor.command);
+  }
+  const plistPath = pathForSupervisor(stateDir, record, "plist");
+  const logPath = pathForSupervisor(stateDir, record, "log");
+  launchdPlist(record, environment, plistPath, logPath);
+  const domain = `gui/${process.getuid()}`;
+  runChecked(supervisor.command, ["bootstrap", domain, plistPath]);
+  runChecked(supervisor.command, ["kickstart", "-k", `${domain}/${record.service_name}`]);
+  return launchdPid(record, supervisor.command);
+}
+
+function parsePid(value) {
+  const pid = Number(String(value).trim());
+  return Number.isInteger(pid) && pid > 0 ? pid : 0;
+}
+
+function systemdPid(record, command) {
+  try {
+    return parsePid(runChecked(command, ["--user", "show", record.service_name, "--property=MainPID", "--value"]));
+  } catch {
+    return 0;
+  }
+}
+
+function launchdPid(record, command) {
+  try {
+    const output = runChecked(command, ["print", `gui/${process.getuid()}/${record.service_name}`]);
+    return parsePid(output.match(/\bpid\s*=\s*(\d+)/)?.[1] ?? 0);
+  } catch {
+    return 0;
+  }
+}
+
+function processCommandLine(pid, platform = process.platform) {
+  if (!pid) return "";
+  if (platform === "linux") {
+    try {
+      return readFileSync(`/proc/${pid}/cmdline`).toString().replaceAll("\0", " ").trim();
+    } catch {
+      return "";
+    }
+  }
+  try {
+    return commandOutput(resolveExecutable("ps", { env: process.env }), ["-p", String(pid), "-o", "command="], { timeout: RUNTIME_TIMEOUT_MS });
+  } catch {
+    return "";
+  }
+}
+
+export function processMatchesRecord(record, commandLine) {
+  if (!commandLine || !record?.node_path || !record?.payload_entrypoint) return false;
+  return commandLine.includes(record.node_path) && commandLine.includes(record.payload_entrypoint) &&
+    record.command_signature === commandSignature(commandForRecord(record));
+}
+
+function processExists(pid) {
+  if (!pid) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return error.code === "EPERM";
+  }
+}
+
+function supervisorStatus(record, supervisor, platform = process.platform) {
+  if (record.supervisor === "fallback") {
+    const alive = processExists(record.pid);
+    const commandLine = alive ? processCommandLine(record.pid, platform) : "";
+    return {
+      active: alive,
+      pid: record.pid,
+      owned: !alive || processMatchesRecord(record, commandLine),
+      detail: alive ? (commandLine || "running") : "not running",
+    };
+  }
+  if (record.supervisor === "systemd-user") {
+    try {
+      const activeState = runChecked(supervisor.command, ["--user", "show", record.service_name, "--property=ActiveState", "--value"]);
+      const subState = runChecked(supervisor.command, ["--user", "show", record.service_name, "--property=SubState", "--value"]);
+      const pid = systemdPid(record, supervisor.command);
+      const active = activeState === "active" && subState !== "dead" && subState !== "failed";
+      const commandLine = pid ? processCommandLine(pid, platform) : "";
+      return { active, pid, owned: !active || processMatchesRecord(record, commandLine), detail: `${activeState}/${subState}` };
+    } catch (error) {
+      return { active: false, pid: 0, owned: true, detail: `supervisor unavailable: ${error.message}` };
+    }
+  }
+  try {
+    const output = runChecked(supervisor.command, ["print", `gui/${process.getuid()}/${record.service_name}`]);
+    const pid = parsePid(output.match(/\bpid\s*=\s*(\d+)/)?.[1] ?? 0);
+    const active = Boolean(pid) || /state\s*=\s*(running|spawned)/.test(output);
+    const commandLine = pid ? processCommandLine(pid, platform) : "";
+    return { active, pid, owned: !active || processMatchesRecord(record, commandLine), detail: active ? "loaded" : "not loaded" };
+  } catch (error) {
+    return { active: false, pid: 0, owned: true, detail: `supervisor unavailable: ${error.message}` };
+  }
+}
+
+function supervisorForRecord(record, env, platform = process.platform) {
+  if (record.supervisor === "fallback") return { kind: "fallback", command: null };
+  if (record.supervisor === "systemd-user") {
+    const command = systemdAvailable(env);
+    if (!command) throw new PluginError("recorded systemd --user supervisor is unavailable; do not signal the recorded process manually");
+    return { kind: "systemd-user", command };
+  }
+  if (record.supervisor === "launchd") {
+    const command = launchdAvailable(env);
+    if (!command) throw new PluginError("recorded launchd supervisor is unavailable; do not signal the recorded process manually");
+    return { kind: "launchd", command };
+  }
+  throw new PluginError(`unknown recorded supervisor: ${record.supervisor}`);
+}
+
+function expectedService(record) {
+  return serviceName(record.target_identity, record.supervisor);
+}
+
+function assertRecordOwnership(record, env, platform = process.platform) {
+  if (!record || record.schema_version !== SERVICE_SCHEMA_VERSION) throw new PluginError("service record is missing or has an unsupported schema");
+  if (record.package_name !== PACKAGE_NAME || record.service_name !== expectedService(record)) {
+    throw new PluginError("service record ownership is stale; refusing to signal an unrelated process");
+  }
+  const supervisor = supervisorForRecord(record, env, platform);
+  const state = supervisorStatus(record, supervisor, platform);
+  if (state.active && !state.owned) throw new PluginError("recorded service ownership is stale; refusing to signal an unrelated process");
+  return { supervisor, state };
+}
+
+function stopProcessGroup(pid) {
+  if (!pid) return;
+  try {
+    process.kill(-pid, "SIGTERM");
+  } catch (error) {
+    if (!(["ESRCH", "EPERM"].includes(error.code))) throw error;
+  }
+}
+
+async function waitForStopped(record, supervisor, platform = process.platform) {
+  const deadline = Date.now() + STOP_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    const state = supervisorStatus(record, supervisor, platform);
+    if (!state.active) return;
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new PluginError(`service ${record.service_name} did not stop within ${STOP_TIMEOUT_MS}ms`);
+}
+
+async function stopRecord(record, env, platform = process.platform) {
+  const { supervisor, state } = assertRecordOwnership(record, env, platform);
+  if (!state.active) return { stopped: false, state };
+  if (record.supervisor === "fallback") {
+    stopProcessGroup(record.pid);
+  } else if (record.supervisor === "systemd-user") {
+    runChecked(supervisor.command, ["--user", "stop", record.service_name]);
+  } else {
+    runChecked(supervisor.command, ["bootout", `gui/${process.getuid()}/${record.service_name}`]);
+  }
+  await waitForStopped(record, supervisor, platform);
+  if (record.supervisor === "systemd-user") {
+    try {
+      runChecked(supervisor.command, ["--user", "disable", record.service_name]);
+    } catch {
+      // A stopped unit may already have been disabled by the user supervisor.
+    }
+  }
+  return { stopped: true, state };
+}
+
+function recordCompatible(record, manifestVersion, payload, config, target, node) {
+  return record?.schema_version === SERVICE_SCHEMA_VERSION &&
+    record.package_version === manifestVersion &&
+    record.payload_entrypoint === payload.entrypoint &&
+    record.payload_root === payload.packageRoot &&
+    record.node_path === node.path &&
+    record.host === config.host &&
+    record.socket_path === target.socket_path &&
+    record.session_name === target.session_name &&
+    (config.port_was_explicit !== true || record.port === config.port) &&
+    record.config_signature === configSignature(config) &&
+    record.command_signature === commandSignature(commandForRecord(record));
+}
+
+async function currentRecordReadiness(record) {
+  if (!record?.url) return { ready: false, error: "service record has no URL" };
+  const result = await probeCapabilities(probeUrl(record.host, record.port));
+  if (!result.ok) return { ready: false, error: result.error };
+  const error = safeCapability(result.capabilities, record.package_version);
+  return error ? { ready: false, error } : { ready: true, capabilities: result.capabilities };
+}
+
+function displayTarget(recordOrTarget) {
+  if (recordOrTarget.session_name) return `session ${recordOrTarget.session_name}`;
+  const socket = recordOrTarget.socket_path;
+  return socket ? `socket …/${path.basename(socket)}` : "no selected socket";
+}
+
+function displayPosture(host) {
+  return isLoopbackHost(host) ? "loopback-only" : "remotely exposed; Host/Origin checks are not authentication";
+}
+
+function printService(record, capabilities, prefix = "Herdr World") {
+  console.log(`${prefix}: ${record.url}`);
+  console.log(`  target: ${displayTarget(record)}`);
+  console.log(`  supervisor: ${record.supervisor} (${record.service_name})`);
+  console.log(`  pid: ${record.pid || "not reported"}`);
+  console.log(`  compatibility: Herdr ${capabilities?.herdr_version ?? "unknown"}, protocol ${capabilities?.terminal_protocol ?? "unknown"}, web ${capabilities?.web_compat ?? "unknown"}`);
+  console.log(`  access: ${displayPosture(record.host)}`);
+}
+
+async function startAction({ root = ROOT, env = process.env, platform = process.platform, arch = process.arch, glibcVersion } = {}) {
+  const manifestVersion = readManifestVersion(root);
+  const targetPlatform = selectTarget({ platform, arch, glibcVersion });
+  const node = checkNode(resolveNode({ env }));
+  const context = runtimeContext(env);
+  const targetStatus = resolveHerdrTarget(context.config, env);
+  const target = { ...context.target, socket_path: targetStatus.socket_path };
+  const payload = requirePayload(root, manifestVersion, targetPlatform.target);
+  return withTargetLock(context.stateDir, context.target.identity, async () => {
+    const recordPath = targetRecordPath(context.stateDir, context.target.identity);
+    const previous = readRecord(recordPath);
+    if (previous) {
+      const ownership = assertRecordOwnership(previous, env, platform);
+      if (ownership.state.active && recordCompatible(previous, manifestVersion, payload, context.config, target, node)) {
+        const ready = await currentRecordReadiness(previous);
+        if (ready.ready) {
+          printService(previous, ready.capabilities, "Herdr World already running");
+          return previous;
+        }
+      }
+      if (ownership.state.active) await stopRecord(previous, env, platform);
+      removeRecord(recordPath);
+    }
+    const port = await choosePort(context.config, context.target.identity, context.stateDir);
+    const supervisor = selectSupervisor(platform, env);
+    const { record, environment } = createRecord({
+      identity: context.target.identity,
+      target,
+      config: context.config,
+      payload,
+      node,
+      port,
+      supervisor,
+      root,
+      env,
+    });
+    let started = false;
+    try {
+      record.pid = startUnderSupervisor(record, environment, context.stateDir, supervisor);
+      record.updated_at = new Date().toISOString();
+      writeRecord(recordPath, record);
+      started = true;
+      const capabilities = await waitForReadiness(probeUrl(record.host, record.port), record);
+      record.herdr_protocol = capabilities.terminal_protocol;
+      record.pid = supervisor.kind === "systemd-user" ? systemdPid(record, supervisor.command) : supervisor.kind === "launchd" ? launchdPid(record, supervisor.command) : record.pid;
+      record.updated_at = new Date().toISOString();
+      writeRecord(recordPath, record);
+      printService(record, capabilities);
+      return record;
+    } catch (error) {
+      if (started) {
+        try { await stopRecord(record, env, platform); } catch {}
+      } else if (record.supervisor === "systemd-user") {
+        try {
+          runChecked(supervisor.command, ["--user", "disable", record.service_name]);
+        } catch {}
+      }
+      removeRecord(recordPath);
+      if (error instanceof PluginError) throw error;
+      throw new PluginError(`could not start Herdr World: ${error.message}`);
+    }
+  });
+}
+
+function contextRecord(context) {
+  return readRecord(targetRecordPath(context.stateDir, context.target.identity));
+}
+
+async function stopAction({ root = ROOT, env = process.env, platform = process.platform } = {}) {
+  const context = runtimeContext(env);
+  const recordPath = targetRecordPath(context.stateDir, context.target.identity);
+  const record = readRecord(recordPath);
+  if (!record) {
+    console.log(`Herdr World is not running for ${displayTarget(context.target)}`);
+    return null;
+  }
+  await stopRecord(record, env, platform);
+  removeRecord(recordPath);
+  console.log(`Stopped Herdr World for ${displayTarget(record)}.`);
+  console.log("The bridge disconnected browser clients; it did not stop the Herdr server or its panes.");
+  return record;
+}
+
+async function restartAction(options) {
+  const context = runtimeContext(options.env ?? process.env);
+  const recordPath = targetRecordPath(context.stateDir, context.target.identity);
+  const record = readRecord(recordPath);
+  if (record) {
+    await stopRecord(record, options.env ?? process.env, options.platform ?? process.platform);
+    removeRecord(recordPath);
+    console.log("Restarting Herdr World; browser clients will disconnect briefly.");
+  }
+  return startAction(options);
+}
+
+async function statusAction({ env = process.env, platform = process.platform } = {}) {
+  const context = runtimeContext(env);
+  const recordPath = targetRecordPath(context.stateDir, context.target.identity);
+  const record = readRecord(recordPath);
+  if (!record) {
+    console.log(`Herdr World is not running for ${displayTarget(context.target)}.`);
+    console.log(`  access: ${displayPosture(context.config.host)}`);
+    return null;
+  }
+  let ownership;
+  try {
+    ownership = assertRecordOwnership(record, env, platform);
+  } catch (error) {
+    console.error(`Herdr World service state is stale: ${error.message}`);
+    console.error("No process was signaled. Inspect or remove the stale service through its recorded supervisor.");
+    throw error;
+  }
+  const ready = ownership.state.active ? await currentRecordReadiness(record) : { ready: false, error: "service is not running" };
+  printService(record, ready.ready ? ready.capabilities : undefined, ready.ready ? "Herdr World" : "Herdr World not ready");
+  console.log(`  service state: ${ownership.state.detail}${ready.error ? ` (${ready.error})` : ""}`);
+  return record;
+}
+
+async function openAction(options = {}) {
+  const record = await startAction(options);
+  const platform = options.platform ?? process.platform;
+  const openerName = platform === "darwin" ? "open" : platform === "linux" ? "xdg-open" : null;
+  if (!openerName) {
+    console.log(`Open this URL in a browser: ${record.url}`);
+    return record;
+  }
+  try {
+    const opener = resolveExecutable(openerName, { env: options.env ?? process.env });
+    const result = spawnSync(opener, [record.url], {
+      stdio: "ignore",
+      timeout: RUNTIME_TIMEOUT_MS,
+    });
+    if (result.error || result.status !== 0) console.log(`Browser helper ${openerName} was unavailable; open ${record.url} manually.`);
+  } catch {
+    console.log(`No desktop browser helper is available; open ${record.url} manually.`);
+  }
+  return record;
+}
+
+function doctorCheck(checks, label, callback) {
+  try {
+    const result = callback();
+    checks.push({ label, ok: true, detail: result ?? "ok" });
+    return result;
+  } catch (error) {
+    checks.push({ label, ok: false, detail: error instanceof Error ? error.message : String(error) });
+    return null;
+  }
+}
+
+async function doctorCheckAsync(checks, label, callback) {
+  try {
+    const result = await callback();
+    checks.push({ label, ok: true, detail: result ?? "ok" });
+    return result;
+  } catch (error) {
+    checks.push({ label, ok: false, detail: error instanceof Error ? error.message : String(error) });
+    return null;
+  }
+}
+
+async function doctorAction({ root = ROOT, env = process.env, platform = process.platform, arch = process.arch, glibcVersion } = {}) {
+  const checks = [];
+  const targetPlatform = doctorCheck(checks, "platform and libc", () => selectTarget({ platform, arch, glibcVersion }).target);
+  let directories;
+  doctorCheck(checks, "Herdr plugin config/state directories", () => {
+    directories = ensureRuntimeDirectories(env);
+    return `${directories.configDir}, ${directories.stateDir}`;
+  });
+  let config;
+  if (directories) config = doctorCheck(checks, "configuration", () => loadConfig(directories.configDir));
+  let node;
+  node = doctorCheck(checks, "Node.js version and absolute path", () => {
+    const resolved = checkNode(resolveNode({ env }));
+    return `${resolved.version} at ${resolved.path}`;
+  });
+  doctorCheck(checks, "npm availability", () => {
+    const npm = resolveExecutable("npm", { env, explicitPath: env.HERDR_WORLD_NPM_PATH });
+    return `${toolVersion(npm, ["--version"])} at ${npm}`;
+  });
+  if (config) doctorCheck(checks, "Herdr target compatibility", () => {
+    const resolved = resolveHerdrTarget(config, env);
+    return `Herdr ${resolved.version}, protocol ${resolved.protocol}, ${displayTarget(resolved)}`;
+  });
+  const manifestVersion = doctorCheck(checks, "plugin manifest", () => readManifestVersion(root));
+  if (manifestVersion && targetPlatform) doctorCheck(checks, "private npm payload", () => {
+    const payload = requirePayload(root, manifestVersion, targetPlatform);
+    return `${PACKAGE_NAME}@${payload.packageJson.version} (${targetPlatform})`;
+  });
+  let record;
+  let recordPath;
+  if (directories && config) {
+    let targetIdentity;
+    doctorCheck(checks, "target identity", () => {
+      targetIdentity = resolveTargetIdentity(config, env);
+      return `${targetIdentity.identity} (${displayTarget(targetIdentity)})`;
+    });
+    if (targetIdentity) {
+      recordPath = targetRecordPath(directories.stateDir, targetIdentity.identity);
+      doctorCheck(checks, "service record", () => {
+        record = contextRecord({ stateDir: directories.stateDir, target: targetIdentity });
+        return record ? `${record.supervisor} ${record.url}` : null;
+      });
+      if (!record) checks.push({ label: "service ownership", ok: true, detail: "no recorded service" });
+    }
+  }
+  if (record) {
+    const ownership = doctorCheck(checks, "service ownership", () => assertRecordOwnership(record, env, platform));
+    if (ownership) {
+      await doctorCheckAsync(checks, "service port", async () => ownership.state.active ? "occupied by recorded service" : "available");
+      if (ownership.state.active) await doctorCheckAsync(checks, "capability readiness", async () => {
+        const readiness = await currentRecordReadiness(record);
+        if (!readiness.ready) throw new PluginError(readiness.error);
+        return `Herdr ${readiness.capabilities.herdr_version}, protocol ${readiness.capabilities.terminal_protocol}`;
+      });
+    }
+    if (record) {
+      doctorCheck(checks, "recorded Node path", () => {
+        const recorded = checkNode(record.node_path);
+        return `${recorded.version} at ${recorded.path}`;
+      });
+      if (node && record.node_path !== node.path) checks.push({ label: "current Node matches service", ok: false, detail: `record uses ${record.node_path}; current Node resolves to ${node.path}` });
+      else if (node) checks.push({ label: "current Node matches service", ok: true, detail: node.path });
+    }
+  } else if (config) {
+    await doctorCheckAsync(checks, "service port", async () => {
+      if (!(await portIsFree(config.host, config.port))) throw new PluginError(`configured bridge port ${config.port} is already in use`);
+      return `${config.port} is available`;
+    });
+  }
+  for (const check of checks) console.log(`[${check.ok ? "ok" : "fail"}] ${check.label}: ${typeof check.detail === "string" ? check.detail : JSON.stringify(check.detail)}`);
+  const failures = checks.filter((check) => !check.ok);
+  if (failures.length > 0) throw new PluginError(`doctor found ${failures.length} issue${failures.length === 1 ? "" : "s"}; fix the failed checks above and retry`);
+  console.log("Herdr World doctor found no issues.");
+  return checks;
+}
+
+export async function runAction(action, options = {}) {
+  if (!ACTIONS.includes(action)) throw new PluginError(`unknown action ${action}; expected ${ACTIONS.join(" | ")}`);
+  if (action === "build") return buildPayload(options);
+  if (action === "start") return startAction(options);
+  if (action === "stop") return stopAction(options);
+  if (action === "restart") return restartAction(options);
+  if (action === "status") return statusAction(options);
+  if (action === "open") return openAction(options);
+  return doctorAction(options);
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === path.resolve(fileURLToPath(import.meta.url))) {
+  const [action, ...extra] = process.argv.slice(2);
+  if (!action || extra.length > 0 || !ACTIONS.includes(action)) {
+    console.error(`Usage: herdr-world-plugin.sh ${ACTIONS.join(" | ")}`);
+    process.exit(2);
+  }
+  runAction(action).catch((error) => {
+    console.error(`Herdr World plugin ${action} failed: ${error.message}`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/herdr-world-plugin.sh
+++ b/scripts/herdr-world-plugin.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_PATH="${BASH_SOURCE[0]}"
+while [[ -L "$SCRIPT_PATH" ]]; do
+  SCRIPT_DIR="$(cd -P "$(dirname "$SCRIPT_PATH")" && pwd)"
+  LINK_TARGET="$(readlink "$SCRIPT_PATH")"
+  case "$LINK_TARGET" in
+    /*) SCRIPT_PATH="$LINK_TARGET" ;;
+    *) SCRIPT_PATH="$SCRIPT_DIR/$LINK_TARGET" ;;
+  esac
+done
+SCRIPT_DIR="$(cd -P "$(dirname "$SCRIPT_PATH")" && pwd)"
+
+exec node "$SCRIPT_DIR/herdr-world-plugin.mjs" "$@"

--- a/scripts/herdr-world-plugin.test.mjs
+++ b/scripts/herdr-world-plugin.test.mjs
@@ -310,7 +310,12 @@ test("documents and tests the explicit stop-before-uninstall contract", () => {
   const smoke = readFileSync(path.join(ROOT, "scripts/live-plugin-smoke.sh"), "utf8");
   assert.match(readme, /herdr plugin action invoke stop --plugin ivoryheart\.herdr-world/);
   assert.match(readme, /herdr plugin uninstall ivoryheart\.herdr-world/);
+  assert.match(readme, /asynchronous and target-\s*scoped/);
+  assert.match(readme, /every Herdr target or named\s*session/);
+  assert.match(readme, /status: succeeded/);
+  assert.match(readme, /herdr --session NAME plugin action invoke stop/);
   assert.match(packaging, /stop the plugin bridge before uninstalling the plugin/);
+  assert.match(packaging, /actions are asynchronous and target-scoped/);
   assert.ok(smoke.indexOf("invoke_default stop") < smoke.indexOf('plugin uninstall "$PLUGIN_ID"'));
   assert.match(smoke, /no uninstall hook/);
 });

--- a/scripts/herdr-world-plugin.test.mjs
+++ b/scripts/herdr-world-plugin.test.mjs
@@ -1,0 +1,271 @@
+import assert from "node:assert/strict";
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import process from "node:process";
+import test from "node:test";
+
+import {
+  ACTIONS,
+  DEFAULT_PORT_RANGE,
+  MIN_NODE_VERSION,
+  PACKAGE_NAME,
+  assertPluginManifest,
+  buildPayload,
+  checkNode,
+  choosePort,
+  compareVersions,
+  minimumVersionSatisfied,
+  npmInstallArgs,
+  parsePluginManifest,
+  processMatchesRecord,
+  requirePayload,
+  renderLaunchdPlist,
+  renderSystemdUnit,
+  selectSupervisor,
+  selectTarget,
+  validateConfig,
+  validatePluginManifest,
+  waitForReadiness,
+  withTargetLock,
+} from "./herdr-world-plugin.mjs";
+
+const ROOT = path.resolve(import.meta.dirname, "..");
+
+function temporaryDirectory(prefix = "herdr-world-plugin-test-") {
+  return mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+function executableScript(pathname, body) {
+  writeFileSync(pathname, body);
+  chmodSync(pathname, 0o755);
+}
+
+test("the checked-in manifest declares the exact plugin contract", () => {
+  const manifest = parsePluginManifest(readFileSync(path.join(ROOT, "herdr-plugin.toml"), "utf8"));
+  assert.doesNotThrow(() => assertPluginManifest(manifest));
+  assert.equal(manifest.version, "0.1.0-rc.5");
+  assert.deepEqual(ACTIONS, ["build", "start", "stop", "restart", "status", "open", "doctor"]);
+});
+
+test("manifest validation rejects panes, startup hooks, and malformed actions", () => {
+  const manifest = parsePluginManifest(readFileSync(path.join(ROOT, "herdr-plugin.toml"), "utf8"));
+  manifest.blocks.push({ type: "panes", id: "world", command: ["sh"] });
+  assert.match(validatePluginManifest(manifest).join("\n"), /must not declare \[\[panes\]\]/);
+});
+
+test("release versions use strict stable or numbered RC syntax", () => {
+  assert.equal(compareVersions("0.1.0-rc.5", "0.1.0"), -1);
+  assert.equal(compareVersions("0.1.1", "0.1.0-rc.5"), 1);
+  assert.equal(minimumVersionSatisfied("22.14.0", MIN_NODE_VERSION), true);
+  assert.equal(minimumVersionSatisfied("22.13.9", MIN_NODE_VERSION), false);
+  assert.equal(minimumVersionSatisfied("22.14.0-beta.1", MIN_NODE_VERSION), false);
+  assert.throws(() => checkNode(process.execPath, { runner: () => "v22.13.9" }), /22.14.0 or newer/);
+});
+
+test("target selection enforces the published platform and libc matrix", () => {
+  assert.deepEqual(selectTarget({ platform: "linux", arch: "x64", glibcVersion: "2.39" }).target, "linux-x64");
+  assert.deepEqual(selectTarget({ platform: "darwin", arch: "arm64" }).target, "macos-arm64");
+  assert.deepEqual(selectTarget({ platform: "darwin", arch: "x64" }).target, "macos-x64");
+  assert.throws(() => selectTarget({ platform: "linux", arch: "arm64", glibcVersion: "2.39" }), /unsupported/);
+  assert.throws(() => selectTarget({ platform: "linux", arch: "x64", glibcVersion: "2.33" }), /glibc 2.34/);
+  assert.throws(() => selectTarget({ platform: "linux", arch: "x64", glibcVersion: "musl" }), /glibc/);
+});
+
+test("configuration validates safe remote access and mutually exclusive targets", () => {
+  assert.deepEqual(validateConfig({}).port_range, DEFAULT_PORT_RANGE);
+  assert.throws(() => validateConfig({ host: "0.0.0.0" }), /allowed_hosts and allowed_origins/);
+  assert.doesNotThrow(() => validateConfig({
+    host: "0.0.0.0",
+    allowed_hosts: ["world.example"],
+    allowed_origins: ["https://world.example"],
+  }));
+  assert.throws(() => validateConfig({ session_name: "a", socket_path: "/tmp/herdr.sock" }), /mutually exclusive/);
+  assert.throws(() => validateConfig({ allowed_origins: ["https://world.example/path"] }), /allowed_origins/);
+  assert.throws(() => validateConfig({ host: "https://world.example" }), /hostname or IP/);
+});
+
+test("npm installation is exact, private, script-free, and registry-pinned", () => {
+  assert.deepEqual(npmInstallArgs("0.1.0-rc.5", ".herdr-world-plugin"), [
+    "install",
+    "--registry=https://registry.npmjs.org/",
+    "--@ivoryheart:registry=https://registry.npmjs.org/",
+    "--prefix",
+    ".herdr-world-plugin",
+    "--ignore-scripts",
+    "--no-save",
+    "--package-lock=false",
+    "--no-audit",
+    "--no-fund",
+    "--omit=dev",
+    `${PACKAGE_NAME}@0.1.0-rc.5`,
+  ]);
+  assert.doesNotMatch(npmInstallArgs("0.1.0-rc.5").join(" "), /latest|next|npx|--global/);
+});
+
+test("missing private payload reports the exact recovery command", () => {
+  const root = temporaryDirectory();
+  try {
+    assert.throws(
+      () => requirePayload(root, "0.1.0-rc.5", "linux-x64"),
+      /npm install --registry=https:\/\/registry\.npmjs\.org\/.*@ivoryheart\/herdr-world@0\.1\.0-rc\.5/s,
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("build installs and verifies the exact payload using a private prefix", () => {
+  const root = temporaryDirectory();
+  const bin = path.join(root, "bin");
+  mkdirSync(bin);
+  writeFileSync(path.join(root, "herdr-plugin.toml"), readFileSync(path.join(ROOT, "herdr-plugin.toml")));
+  const log = path.join(root, "npm-args.json");
+  const fakeNpm = path.join(bin, "npm");
+  executableScript(fakeNpm, `#!${process.execPath}
+const fs = require("node:fs");
+const path = require("node:path");
+const args = process.argv.slice(2);
+if (args[0] === "--version") { console.log("11.5.1"); process.exit(0); }
+fs.writeFileSync(process.env.FAKE_NPM_LOG, JSON.stringify(args));
+const prefix = args[args.indexOf("--prefix") + 1];
+const packageRoot = path.join(prefix, "node_modules/@ivoryheart/herdr-world");
+fs.mkdirSync(path.join(packageRoot, "lib/bridges/linux-x64"), { recursive: true });
+fs.mkdirSync(path.join(packageRoot, "share/herdr-world/web/legal"), { recursive: true });
+fs.mkdirSync(path.join(prefix, "node_modules/.bin"), { recursive: true });
+fs.writeFileSync(path.join(packageRoot, "package.json"), JSON.stringify({ name: "@ivoryheart/herdr-world", version: "0.1.0-rc.5" }));
+  for (const file of ["LICENSE", "THIRD_PARTY_NOTICES.md", "UPSTREAM.md", "lib/herdr-world-launcher.sh", "share/herdr-world/web/index.html"]) fs.writeFileSync(path.join(packageRoot, file), "ok");
+  fs.writeFileSync(path.join(packageRoot, "share/herdr-world/web/legal/manifest.json"), JSON.stringify({ schema_version: 1, files: [] }));
+  for (const file of [path.join(packageRoot, "lib/bridges/linux-x64/herdr-world-bridge"), path.join(prefix, "node_modules/.bin/herdr-world"), path.join(packageRoot, "lib/herdr-world-launcher.sh")]) { fs.writeFileSync(file, "#!/bin/sh\\n"); fs.chmodSync(file, 0o755); }
+`);
+  try {
+    buildPayload({
+      root,
+      env: { ...process.env, PATH: bin, FAKE_NPM_LOG: log },
+      nodePath: process.execPath,
+      npmPath: fakeNpm,
+      platform: "linux",
+      arch: "x64",
+      glibcVersion: "2.39",
+    });
+    const args = JSON.parse(readFileSync(log, "utf8"));
+    assert.equal(args.at(-1), `${PACKAGE_NAME}@0.1.0-rc.5`);
+    assert.equal(args[args.indexOf("--ignore-scripts")], "--ignore-scripts");
+    assert.equal(args[args.indexOf("--registry=https://registry.npmjs.org/")], "--registry=https://registry.npmjs.org/");
+    assert.equal(args[args.indexOf("--@ivoryheart:registry=https://registry.npmjs.org/")], "--@ivoryheart:registry=https://registry.npmjs.org/");
+    assert.equal(fsExists(path.join(root, ".herdr-world-plugin/node_modules/@ivoryheart/herdr-world/package.json")), true);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("port allocation keeps the default port fixed and separates named targets", async () => {
+  const state = temporaryDirectory();
+  try {
+    const config = validateConfig({ session_name: "secondary", port_range: [8787, 8789] });
+    const first = await choosePort(config, "session:first", state, { portFree: async (host, port) => port !== 8787 });
+    assert.equal(first, 8788);
+    await assert.rejects(
+      choosePort(validateConfig({ port_range: [8787, 8787] }), "socket:default", state, { portFree: async () => false }),
+      /default bridge port/,
+    );
+  } finally {
+    rmSync(state, { recursive: true, force: true });
+  }
+});
+
+test("readiness requires bridge, Herdr, protocol, and web compatibility", async () => {
+  const response = (body, ok = true) => ({ ok, status: ok ? 200 : 503, json: async () => body, body: { cancel: async () => {} } });
+  const expected = { package_version: "0.1.0-rc.5" };
+  await assert.rejects(
+    waitForReadiness("http://127.0.0.1:8787", expected, {
+      timeoutMs: 120,
+      fetchImpl: async () => response({ bridge_api_version: 1, herdr_version: "0.8.2", terminal_protocol: 19, web_compat: 1 }),
+    }),
+    /terminal protocol 19/,
+  );
+  const capabilities = await waitForReadiness("http://127.0.0.1:8787", expected, {
+    fetchImpl: async () => response({ bridge_api_version: 1, herdr_version: "0.8.2", terminal_protocol: 20, web_compat: 1 }),
+  });
+  assert.equal(capabilities.terminal_protocol, 20);
+});
+
+test("service ownership rejects command or signature drift", () => {
+  const record = {
+    node_path: "/usr/bin/node",
+    payload_entrypoint: "/managed/.bin/herdr-world",
+    bridge_args: ["--host", "127.0.0.1", "--port", "8787"],
+    command_signature: "not-the-command-signature",
+  };
+  assert.equal(processMatchesRecord(record, "/usr/bin/node /managed/.bin/herdr-world --host 127.0.0.1 --port 8787"), false);
+});
+
+test("supervisor fakes select only the user-owned platform supervisors", () => {
+  const root = temporaryDirectory();
+  const bin = path.join(root, "bin");
+  mkdirSync(bin);
+  const fakeSystemctl = path.join(bin, "systemctl");
+  const fakeLaunchctl = path.join(bin, "launchctl");
+  executableScript(fakeSystemctl, "#!/bin/sh\nexit 0\n");
+  executableScript(fakeLaunchctl, "#!/bin/sh\nexit 0\n");
+  try {
+    assert.equal(selectSupervisor("linux", { PATH: bin, HERDR_WORLD_SYSTEMCTL: fakeSystemctl }).kind, "systemd-user");
+    assert.equal(selectSupervisor("darwin", { PATH: bin, HERDR_WORLD_LAUNCHCTL: fakeLaunchctl }).kind, "launchd");
+    assert.equal(selectSupervisor("linux", { PATH: path.join(root, "missing") }).kind, "fallback");
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("supervisor definitions contain the absolute Node command and safe environment", () => {
+  const record = {
+    node_path: "/opt/node/bin/node",
+    payload_entrypoint: "/managed/.herdr-world-plugin/node_modules/.bin/herdr-world",
+    bridge_args: ["--host", "127.0.0.1", "--port", "8787"],
+    service_name: "herdr-world-owned.service",
+  };
+  const environment = {
+    HERDR_SOCKET_PATH: "/private/herdr.sock",
+    HERDR_WORLD_SETUP: "never",
+    PATH: "/usr/bin",
+  };
+  const unit = renderSystemdUnit(record, environment);
+  assert.match(unit, /ExecStart="\/opt\/node\/bin\/node" "\/managed\/\.herdr-world-plugin\/node_modules\/\.bin\/herdr-world"/);
+  assert.match(unit, /Environment="HERDR_WORLD_SETUP=never"/);
+  assert.match(unit, /Environment="HERDR_SOCKET_PATH=\/private\/herdr\.sock"/);
+  const plist = renderLaunchdPlist(record, environment, "/private/service.log");
+  assert.match(plist, /<key>ProgramArguments<\/key>/);
+  assert.match(plist, /<string>\/opt\/node\/bin\/node<\/string>/);
+  assert.match(plist, /<key>HERDR_WORLD_SETUP<\/key><string>never<\/string>/);
+});
+
+test("release workflow gates the three-platform plugin smoke on npm publication", () => {
+  const workflow = readFileSync(path.join(ROOT, ".github/workflows/release.yml"), "utf8");
+  const npmJob = workflow.indexOf("  npm_publish:");
+  const pluginJob = workflow.indexOf("  plugin_smoke:");
+  assert.ok(npmJob >= 0 && pluginJob > npmJob);
+  assert.match(workflow.slice(pluginJob, workflow.indexOf("  homebrew_publish:", pluginJob)), /needs: \[npm_publish\]/);
+  assert.match(workflow.slice(pluginJob, workflow.indexOf("  homebrew_publish:", pluginJob)), /live-plugin-smoke\.sh/);
+  assert.equal((workflow.match(/platform: linux-x86_64/g) ?? []).length >= 2, true);
+  assert.match(workflow.slice(pluginJob), /platform: macos-arm64/);
+  assert.match(workflow.slice(pluginJob), /platform: macos-x86_64/);
+});
+
+test("target locks are atomic and cleaned up after completion", async () => {
+  const state = temporaryDirectory();
+  try {
+    const result = await withTargetLock(state, "socket:/tmp/herdr.sock", async () => "locked");
+    assert.equal(result, "locked");
+    assert.equal(readFileNames(path.join(state, "runtimes")).some((name) => name.endsWith(".lock")), false);
+  } finally {
+    rmSync(state, { recursive: true, force: true });
+  }
+});
+
+function fsExists(pathname) {
+  try { readFileSync(pathname); return true; } catch { return false; }
+}
+
+function readFileNames(directory) {
+  try { return readdirSync(directory); } catch { return []; }
+}

--- a/scripts/herdr-world-plugin.test.mjs
+++ b/scripts/herdr-world-plugin.test.mjs
@@ -22,8 +22,12 @@ import {
   requirePayload,
   renderLaunchdPlist,
   renderSystemdUnit,
+  resolveTargetIdentity,
+  runAction,
   selectSupervisor,
   selectTarget,
+  serviceName,
+  targetRecordPath,
   validateConfig,
   validatePluginManifest,
   waitForReadiness,
@@ -174,6 +178,55 @@ test("port allocation keeps the default port fixed and separates named targets",
   }
 });
 
+test("distinct injected sockets allocate another default-range port without config changes", async () => {
+  const state = temporaryDirectory();
+  try {
+    const config = validateConfig({});
+    assert.equal(await choosePort(config, "socket:first", state, { portFree: async () => true }), 8787);
+    mkdirSync(path.join(state, "runtimes"), { recursive: true });
+    writeFileSync(path.join(state, "runtimes", "first.json"), JSON.stringify({ target_identity: "socket:first", port: 8787 }));
+    assert.equal(
+      await choosePort(config, "socket:second", state, { portFree: async (host, port) => port !== 8787 }),
+      8788,
+    );
+  } finally {
+    rmSync(state, { recursive: true, force: true });
+  }
+});
+
+test("restart validates its start plan before stopping the existing service", async () => {
+  const configDir = temporaryDirectory("herdr-world-plugin-config-");
+  const stateDir = temporaryDirectory("herdr-world-plugin-state-");
+  const env = {
+    ...process.env,
+    HERDR_PLUGIN_CONFIG_DIR: configDir,
+    HERDR_PLUGIN_STATE_DIR: stateDir,
+    HERDR_SOCKET_PATH: path.join(stateDir, "herdr.sock"),
+    HERDR_WORLD_NODE_PATH: path.join(stateDir, "missing-node"),
+  };
+  try {
+    const target = resolveTargetIdentity(validateConfig({}), env);
+    const recordPath = targetRecordPath(stateDir, target.identity);
+    mkdirSync(path.dirname(recordPath), { recursive: true });
+    writeFileSync(recordPath, JSON.stringify({
+      schema_version: 1,
+      target_identity: target.identity,
+      package_name: PACKAGE_NAME,
+      service_name: serviceName(target.identity, "fallback"),
+      supervisor: "fallback",
+      pid: 999999999,
+    }));
+    await assert.rejects(
+      runAction("restart", { root: ROOT, env, platform: "linux", arch: "x64", glibcVersion: "2.39" }),
+      /required executable is not available/,
+    );
+    assert.equal(fsExists(recordPath), true);
+  } finally {
+    rmSync(configDir, { recursive: true, force: true });
+    rmSync(stateDir, { recursive: true, force: true });
+  }
+});
+
 test("readiness requires bridge, Herdr, protocol, and web compatibility", async () => {
   const response = (body, ok = true) => ({ ok, status: ok ? 200 : 503, json: async () => body, body: { cancel: async () => {} } });
   const expected = { package_version: "0.1.0-rc.5" };
@@ -249,6 +302,17 @@ test("release workflow gates the three-platform plugin smoke on npm publication"
   assert.equal((workflow.match(/platform: linux-x86_64/g) ?? []).length >= 2, true);
   assert.match(workflow.slice(pluginJob), /platform: macos-arm64/);
   assert.match(workflow.slice(pluginJob), /platform: macos-x86_64/);
+});
+
+test("documents and tests the explicit stop-before-uninstall contract", () => {
+  const readme = readFileSync(path.join(ROOT, "README.md"), "utf8");
+  const packaging = readFileSync(path.join(ROOT, "docs/packaging.md"), "utf8");
+  const smoke = readFileSync(path.join(ROOT, "scripts/live-plugin-smoke.sh"), "utf8");
+  assert.match(readme, /herdr plugin action invoke stop --plugin ivoryheart\.herdr-world/);
+  assert.match(readme, /herdr plugin uninstall ivoryheart\.herdr-world/);
+  assert.match(packaging, /stop the plugin bridge before uninstalling the plugin/);
+  assert.ok(smoke.indexOf("invoke_default stop") < smoke.indexOf('plugin uninstall "$PLUGIN_ID"'));
+  assert.match(smoke, /no uninstall hook/);
 });
 
 test("target locks are atomic and cleaned up after completion", async () => {

--- a/scripts/live-plugin-smoke.sh
+++ b/scripts/live-plugin-smoke.sh
@@ -1,0 +1,214 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Release smoke for the GitHub-installed plugin. The caller supplies a stock
+# Herdr binary for the runner's platform; the plugin itself supplies the
+# published npm payload and its platform-specific bridge.
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+HERDR_BIN="${HERDR_BIN:?set HERDR_BIN to the stock Herdr binary}"
+VERSION="${VERSION:?set VERSION to the release tag, including v}"
+PLUGIN_ID="ivoryheart.herdr-world"
+
+[[ -x "$HERDR_BIN" ]] || { echo "stock Herdr binary is not executable: $HERDR_BIN" >&2; exit 1; }
+[[ "$VERSION" == v* ]] || { echo "VERSION must be a v-prefixed release tag" >&2; exit 1; }
+
+SMOKE_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/herdr-world-plugin-smoke.XXXXXX")"
+CONFIG_HOME="$SMOKE_ROOT/config"
+STATE_HOME="$SMOKE_ROOT/state"
+SOCKET_A="$SMOKE_ROOT/herdr-a.sock"
+LOG_A="$SMOKE_ROOT/herdr-a.log"
+LOG_B="$SMOKE_ROOT/herdr-b.log"
+PID_A=0
+PID_B=0
+PLUGIN_CONFIG_DIR=""
+
+cleanup() {
+  set +e
+  if [[ -n "$PLUGIN_CONFIG_DIR" && -d "$PLUGIN_CONFIG_DIR" ]]; then
+    invoke_action default stop >/dev/null 2>&1
+  fi
+  [[ "$PID_A" == 0 ]] || kill "$PID_A" 2>/dev/null
+  [[ "$PID_B" == 0 ]] || kill "$PID_B" 2>/dev/null
+  [[ "$PID_A" == 0 ]] || wait "$PID_A" 2>/dev/null
+  [[ "$PID_B" == 0 ]] || wait "$PID_B" 2>/dev/null
+  rm -rf "$SMOKE_ROOT"
+}
+trap cleanup EXIT
+
+mkdir -p "$CONFIG_HOME" "$STATE_HOME"
+
+start_default_herdr() {
+  HERDR_SOCKET_PATH="$SOCKET_A" XDG_CONFIG_HOME="$CONFIG_HOME" XDG_STATE_HOME="$STATE_HOME" \
+    "$HERDR_BIN" server >"$LOG_A" 2>&1 &
+  PID_A=$!
+}
+
+start_named_herdr() {
+  XDG_CONFIG_HOME="$CONFIG_HOME" XDG_STATE_HOME="$STATE_HOME" \
+    "$HERDR_BIN" --session secondary server >"$LOG_B" 2>&1 &
+  PID_B=$!
+}
+
+wait_for_herdr() {
+  local command=("$HERDR_BIN" status server --json)
+  local extra_env=(HERDR_SOCKET_PATH="$SOCKET_A")
+  if [[ "${1:-default}" == secondary ]]; then
+    command=("$HERDR_BIN" --session secondary status server --json)
+    extra_env=()
+  fi
+  local status=""
+  local ready=false
+  for _ in $(seq 1 100); do
+    if [[ ${#extra_env[@]} -gt 0 ]]; then
+      status="$(env "${extra_env[@]}" XDG_CONFIG_HOME="$CONFIG_HOME" XDG_STATE_HOME="$STATE_HOME" "${command[@]}" 2>/dev/null || true)"
+    else
+      status="$(XDG_CONFIG_HOME="$CONFIG_HOME" XDG_STATE_HOME="$STATE_HOME" "${command[@]}" 2>/dev/null || true)"
+    fi
+    if node --input-type=module - "$status" <<'NODE'
+try {
+  const value = JSON.parse(process.argv[2] || "null");
+  process.exit(value?.running === true && value?.status === "running" && value?.protocol === 20 ? 0 : 1);
+} catch {
+  process.exit(1);
+}
+NODE
+    then
+      ready=true
+      break
+    fi
+    sleep 0.2
+  done
+  if [[ "$ready" == true ]]; then return; fi
+  echo "Herdr did not become ready ($1)" >&2
+  cat "$LOG_A" "$LOG_B" >&2
+  exit 1
+}
+
+invoke_default() {
+  invoke_action default "$1"
+}
+
+invoke_secondary() {
+  invoke_action secondary "$1"
+}
+
+invoke_action() {
+  local session="$1" action="$2" output log_id logs state
+  if [[ "$session" == secondary ]]; then
+    output="$(XDG_CONFIG_HOME="$CONFIG_HOME" XDG_STATE_HOME="$STATE_HOME" \
+      "$HERDR_BIN" --session secondary plugin action invoke "$action" --plugin "$PLUGIN_ID")"
+  else
+    output="$(HERDR_SOCKET_PATH="$SOCKET_A" XDG_CONFIG_HOME="$CONFIG_HOME" XDG_STATE_HOME="$STATE_HOME" \
+      "$HERDR_BIN" plugin action invoke "$action" --plugin "$PLUGIN_ID")"
+  fi
+  log_id="$(node --input-type=module - "$output" <<'NODE'
+const value = JSON.parse(process.argv[2]);
+process.stdout.write(value.result?.log?.log_id ?? "");
+NODE
+  )"
+  [[ -n "$log_id" ]] || { echo "Herdr did not return a plugin action log id for $action" >&2; return 1; }
+  for _ in $(seq 1 100); do
+    if [[ "$session" == secondary ]]; then
+      logs="$(XDG_CONFIG_HOME="$CONFIG_HOME" XDG_STATE_HOME="$STATE_HOME" \
+        "$HERDR_BIN" --session secondary plugin log list --plugin "$PLUGIN_ID" --limit 100 2>/dev/null || true)"
+    else
+      logs="$(HERDR_SOCKET_PATH="$SOCKET_A" XDG_CONFIG_HOME="$CONFIG_HOME" XDG_STATE_HOME="$STATE_HOME" \
+        "$HERDR_BIN" plugin log list --plugin "$PLUGIN_ID" --limit 100 2>/dev/null || true)"
+    fi
+    state="$(node --input-type=module - "$logs" "$log_id" <<'NODE'
+try {
+  const value = JSON.parse(process.argv[2]);
+  const id = process.argv[3];
+  const log = value.result?.logs?.find((entry) => entry.log_id === id);
+  if (log) process.stdout.write(JSON.stringify({ status: log.status, stderr: log.stderr ?? "" }));
+} catch {}
+NODE
+    )"
+    if [[ "$state" == *'"status":"succeeded"'* ]]; then return 0; fi
+    if [[ "$state" == *'"status":"failed"'* ]]; then
+      node --input-type=module - "$state" <<'NODE' >&2
+const value = JSON.parse(process.argv[2]);
+process.stderr.write(value.stderr || "plugin action failed");
+NODE
+      return 1
+    fi
+    sleep 0.2
+  done
+  echo "plugin action did not finish: $action ($log_id)" >&2
+  return 1
+}
+
+wait_for_bridge() {
+  local url="$1"
+  for _ in $(seq 1 100); do
+    if curl --fail --silent --show-error "$url/api/capabilities" | \
+      node --input-type=module -e '
+let text = "";
+process.stdin.on("data", (chunk) => { text += chunk; });
+process.stdin.on("end", () => {
+  try {
+    const value = JSON.parse(text);
+    process.exit(value.bridge_api_version === 1 && value.herdr_version === "0.8.2" && value.terminal_protocol === 20 && value.web_compat >= 1 ? 0 : 1);
+  } catch {
+    process.exit(1);
+  }
+});'
+    then
+      return
+    fi
+    sleep 0.2
+  done
+  echo "bridge did not become ready: $url" >&2
+  exit 1
+}
+
+echo "Starting stock Herdr release smoke daemons"
+start_default_herdr
+wait_for_herdr default
+
+echo "Installing $PLUGIN_ID from GitHub at $VERSION"
+HERDR_SOCKET_PATH="$SOCKET_A" XDG_CONFIG_HOME="$CONFIG_HOME" XDG_STATE_HOME="$STATE_HOME" \
+  "$HERDR_BIN" plugin install IvoryHeart/herdr-world --ref "$VERSION" --yes
+PLUGIN_CONFIG_DIR="$(HERDR_SOCKET_PATH="$SOCKET_A" XDG_CONFIG_HOME="$CONFIG_HOME" XDG_STATE_HOME="$STATE_HOME" \
+  "$HERDR_BIN" plugin config-dir "$PLUGIN_ID")"
+[[ -d "$PLUGIN_CONFIG_DIR" ]] || { echo "plugin config directory was not retained" >&2; exit 1; }
+
+actions="$(HERDR_SOCKET_PATH="$SOCKET_A" XDG_CONFIG_HOME="$CONFIG_HOME" XDG_STATE_HOME="$STATE_HOME" \
+  "$HERDR_BIN" plugin action list --plugin "$PLUGIN_ID")"
+for action in start stop restart status open doctor; do
+  [[ "$actions" == *"$action"* ]] || { echo "plugin action is missing: $action" >&2; exit 1; }
+done
+
+echo "Starting and reusing the default plugin service"
+invoke_default start
+wait_for_bridge http://127.0.0.1:8787
+curl --fail --silent http://127.0.0.1:8787/ | grep -F '<title>' >/dev/null
+invoke_default start >/dev/null
+invoke_default status >/dev/null
+invoke_default open >/dev/null
+invoke_default doctor >/dev/null
+invoke_default restart >/dev/null
+wait_for_bridge http://127.0.0.1:8787
+
+echo "Starting a second Herdr session with an isolated bridge port"
+start_named_herdr
+wait_for_herdr secondary
+node --input-type=module - "$PLUGIN_CONFIG_DIR/config.json" <<'NODE'
+import { writeFileSync } from "node:fs";
+writeFileSync(process.argv[2], JSON.stringify({ session_name: "secondary" }) + "\n", { mode: 0o600 });
+NODE
+invoke_secondary start >/dev/null
+wait_for_bridge http://127.0.0.1:8788
+curl --fail --silent http://127.0.0.1:8787/api/capabilities >/dev/null
+invoke_secondary stop >/dev/null
+
+node --input-type=module - "$PLUGIN_CONFIG_DIR/config.json" <<'NODE'
+import { writeFileSync } from "node:fs";
+writeFileSync(process.argv[2], "{}\n", { mode: 0o600 });
+NODE
+invoke_default stop >/dev/null
+HERDR_SOCKET_PATH="$SOCKET_A" XDG_CONFIG_HOME="$CONFIG_HOME" XDG_STATE_HOME="$STATE_HOME" \
+  "$HERDR_BIN" plugin uninstall "$PLUGIN_ID"
+[[ -d "$PLUGIN_CONFIG_DIR" ]] || { echo "uninstall removed plugin config/state unexpectedly" >&2; exit 1; }
+
+echo "Herdr plugin release smoke passed for $VERSION"

--- a/scripts/live-plugin-smoke.sh
+++ b/scripts/live-plugin-smoke.sh
@@ -206,7 +206,9 @@ node --input-type=module - "$PLUGIN_CONFIG_DIR/config.json" <<'NODE'
 import { writeFileSync } from "node:fs";
 writeFileSync(process.argv[2], "{}\n", { mode: 0o600 });
 NODE
+# Herdr has no uninstall hook; stop the controller-owned bridge first.
 invoke_default stop >/dev/null
+invoke_default status >/dev/null
 HERDR_SOCKET_PATH="$SOCKET_A" XDG_CONFIG_HOME="$CONFIG_HOME" XDG_STATE_HOME="$STATE_HOME" \
   "$HERDR_BIN" plugin uninstall "$PLUGIN_ID"
 [[ -d "$PLUGIN_CONFIG_DIR" ]] || { echo "uninstall removed plugin config/state unexpectedly" >&2; exit 1; }

--- a/scripts/release-version.mjs
+++ b/scripts/release-version.mjs
@@ -89,7 +89,8 @@ export function assertCurrentReleaseReferences(root = process.cwd()) {
     (relativePath) => relativePath !== "release.json",
   )) {
     const contents = readFileSync(join(root, relativePath), "utf8");
-    if (!contents.includes(current)) {
+    const expected = relativePath === "herdr-plugin.toml" ? releaseVersion(current) : current;
+    if (!contents.includes(expected)) {
       throw new Error(`${relativePath} does not reference the current release ${current}`);
     }
   }
@@ -112,9 +113,11 @@ export function stampCurrentRelease(
     .map((relativePath) => {
     const path = join(root, relativePath);
     const contents = readFileSync(path, "utf8");
-    const updated = contents.replaceAll(current, newTag);
-    if (updated === contents || updated.includes(current)) {
-      throw new Error(`could not replace every ${current} reference in ${relativePath}`);
+    const oldReference = relativePath === "herdr-plugin.toml" ? releaseVersion(current) : current;
+    const newReference = relativePath === "herdr-plugin.toml" ? releaseVersion(newTag) : newTag;
+    const updated = contents.replaceAll(oldReference, newReference);
+    if (updated === contents || updated.includes(oldReference)) {
+      throw new Error(`could not replace every ${oldReference} reference in ${relativePath}`);
     }
     return { path, updated };
     });

--- a/scripts/release-version.test.mjs
+++ b/scripts/release-version.test.mjs
@@ -82,6 +82,24 @@ test("stamps every public release reference from one source of truth", () => {
   }
 });
 
+test("stamps the plugin manifest's intentionally unprefixed version", () => {
+  const root = mkdtempSync(join(tmpdir(), "herdr-world-release-plugin-"));
+  try {
+    mkdirSync(join(root, "site"));
+    writeFileSync(join(root, "release.json"), '{"current":"v1.2.3-rc.1"}\n');
+    writeFileSync(join(root, "README.md"), "v1.2.3-rc.1\n");
+    writeFileSync(join(root, "site", "index.html"), "v1.2.3-rc.1\n");
+    writeFileSync(join(root, "site", "site.js"), "v1.2.3-rc.1\n");
+    writeFileSync(join(root, "herdr-plugin.toml"), 'version = "1.2.3-rc.1"\n');
+
+    assert.equal(assertCurrentReleaseReferences(root), "v1.2.3-rc.1");
+    stampCurrentRelease("v1.2.3-rc.2", root);
+    assert.equal(readFileSync(join(root, "herdr-plugin.toml"), "utf8"), 'version = "1.2.3-rc.2"\n');
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test("fails closed when a required public surface has drifted", () => {
   const root = mkdtempSync(join(tmpdir(), "herdr-world-release-version-"));
   try {

--- a/scripts/validate-release.mjs
+++ b/scripts/validate-release.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { execFileSync } from "node:child_process";
-import { readFileSync } from "node:fs";
+import { readFileSync, statSync } from "node:fs";
 import { join } from "node:path";
 
 import {
@@ -9,6 +9,7 @@ import {
   normalizeReleaseTag,
   releaseVersion,
 } from "./release-version.mjs";
+import { assertPluginManifest, parsePluginManifest } from "./herdr-world-plugin.mjs";
 
 const root = process.cwd();
 const suppliedTag = process.argv[2] ?? process.env.GITHUB_REF_NAME;
@@ -87,12 +88,20 @@ for (const relativePath of ["package.json", "web/package.json"]) {
 const pluginPath = join(root, "herdr-plugin.toml");
 try {
   const plugin = readFileSync(pluginPath, "utf8");
-  const pluginVersion = plugin.match(/^version\s*=\s*"([^"]+)"\s*$/m)?.[1];
-  if (pluginVersion !== releaseVersion(tag)) {
-    fail(`herdr-plugin.toml version must be ${releaseVersion(tag)}`);
+  const manifest = assertPluginManifest(parsePluginManifest(plugin));
+  if (manifest.version !== releaseVersion(tag)) fail(`herdr-plugin.toml version must be ${releaseVersion(tag)}`);
+  for (const entrypoint of ["scripts/herdr-world-plugin.sh", "scripts/herdr-world-plugin.mjs"]) {
+    const pathname = join(root, entrypoint);
+    try {
+      const mode = statSync(pathname).mode;
+      if ((mode & 0o111) === 0) fail(`${entrypoint} must be executable`);
+    } catch (error) {
+      fail(`${entrypoint} is missing or unreadable: ${error.message}`);
+    }
   }
 } catch (error) {
-  if (error.code !== "ENOENT") fail(`could not read herdr-plugin.toml: ${error.message}`);
+  if (error.code === "ENOENT") fail("herdr-plugin.toml is required for plugin-enabled releases");
+  fail(`could not read herdr-plugin.toml: ${error.message}`);
 }
 
 console.log(`Validated protected release ${tag} at ${tagSha}`);


### PR DESCRIPTION
## Summary
- add the `ivoryheart.herdr-world` plugin manifest and controller with exact npm payload installation
- add lifecycle actions, platform/config validation, supervision, readiness checks, and recovery diagnostics
- add release-version validation, documentation, changelog coverage, and plugin tests
- add a post-publication live smoke gate covering Linux x64, macOS arm64, and macOS x64

## Review follow-ups
- allocate default-range ports for distinct injected Herdr sockets
- validate restart prerequisites before stopping an existing service
- document and smoke-test the explicit stop-before-uninstall contract
- avoid advertising the pre-plugin `v0.1.0-rc.5` tag and distinguish npm payload compatibility from first tagged plugin validation

## Validation
- `npm run check`
- `npm run test:release` (62 passed)
- real Linux npm payload, systemd, restart/stop, and named-session smoke tests
- syntax, workflow YAML, and diff checks

## Notes
- the 12 pre-existing screenshot modifications in the worktree were intentionally left out of this PR
- published-ref GitHub install smoke runs in release CI after npm publication; it cannot run against this unpublished branch