### PR TITLE
Release v0.1.0-rc.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,21 +6,27 @@
 
 ### Added
 
+### Changed
+
+### Fixed
+
+### Removed
+
+## [0.1.0-rc.6] - 2026-08-29
+
+### Added
+
 - Added the Herdr World plugin manifest and lifecycle controller. Herdr can install the exact
   release-matched npm payload privately, supervise one loopback bridge per session, and expose
   start/stop/restart/status/open/doctor actions without changing the standalone npm, Homebrew,
   desktop, or Android distributions.
   [Herdr World PR #36](https://github.com/IvoryHeart/herdr-world/pull/36)
 
-### Changed
-
 ### Fixed
 
 - Allowed npm release publication to wait for publish-time malware scanning before verifying the
   immutable version, integrity, and channel pointer.
   [Herdr World PR #34](https://github.com/IvoryHeart/herdr-world/pull/34)
-
-### Removed
 
 ## [0.1.0-rc.5] - 2026-08-29
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ navigation, multi-client viewing, mobile input controls, synchronized pane selec
 visualizations. The upstream relationship and synchronization record are documented in
 [`UPSTREAM.md`](UPSTREAM.md).
 
-> **Public preview:** [`v0.1.0-rc.5`](https://github.com/IvoryHeart/herdr-world/releases/tag/v0.1.0-rc.5)
+> **Public preview:** [`v0.1.0-rc.6`](https://github.com/IvoryHeart/herdr-world/releases/tag/v0.1.0-rc.6)
 > provides native archives for Linux x86-64 and macOS on Apple Silicon and Intel. Herdr World
 > currently requires Herdr `v0.8.2` or newer reporting terminal protocol `20`.
 
@@ -113,8 +113,8 @@ Android development also needs a JDK and Android SDK. See [docs/android.md](docs
 
 | Platform | Status |
 | --- | --- |
-| Linux x86-64 | Available in [`v0.1.0-rc.5`](https://github.com/IvoryHeart/herdr-world/releases/tag/v0.1.0-rc.5) |
-| macOS ARM64 / x86-64 | Available unsigned in [`v0.1.0-rc.5`](https://github.com/IvoryHeart/herdr-world/releases/tag/v0.1.0-rc.5) |
+| Linux x86-64 | Available in [`v0.1.0-rc.6`](https://github.com/IvoryHeart/herdr-world/releases/tag/v0.1.0-rc.6) |
+| macOS ARM64 / x86-64 | Available unsigned in [`v0.1.0-rc.6`](https://github.com/IvoryHeart/herdr-world/releases/tag/v0.1.0-rc.6) |
 | Android | Source and debug build workflow are available; no signed public APK yet |
 
 ## Quick Start From Release
@@ -123,7 +123,7 @@ Choose `linux-x86_64`, `macos-arm64` (Apple Silicon), or `macos-x86_64` (Intel),
 verify the current release candidate:
 
 ```bash
-VERSION=v0.1.0-rc.5
+VERSION=v0.1.0-rc.6
 PLATFORM=linux-x86_64
 curl -fLO "https://github.com/IvoryHeart/herdr-world/releases/download/${VERSION}/herdr-world-${VERSION}-${PLATFORM}.tar.gz"
 curl -fLO "https://github.com/IvoryHeart/herdr-world/releases/download/${VERSION}/herdr-world-${VERSION}-${PLATFORM}.tar.gz.sha256"

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -1,6 +1,6 @@
 id = "ivoryheart.herdr-world"
 name = "Herdr World"
-version = "0.1.0-rc.5"
+version = "0.1.0-rc.6"
 min_herdr_version = "0.8.2"
 description = "Browser and mobile client for monitoring and controlling Herdr agents."
 platforms = ["linux", "macos"]

--- a/release.json
+++ b/release.json
@@ -1,3 +1,3 @@
 {
-  "current": "v0.1.0-rc.5"
+  "current": "v0.1.0-rc.6"
 }

--- a/site/index.html
+++ b/site/index.html
@@ -44,7 +44,7 @@
           <h1 id="hero-title">Your agents.<br /><em>One office.</em></h1>
           <p class="hero-intro">Herdr World turns live Herdr sessions into one visual workspace: terminal-first Spaces, a multi-host Pixel Office, and the controls to move between them without losing context.</p>
           <div class="hero-actions">
-            <a class="button button-primary" href="https://github.com/IvoryHeart/herdr-world/releases/tag/v0.1.0-rc.5">Download the RC <span aria-hidden="true">↓</span></a>
+            <a class="button button-primary" href="https://github.com/IvoryHeart/herdr-world/releases/tag/v0.1.0-rc.6">Download the RC <span aria-hidden="true">↓</span></a>
             <a class="button button-secondary" href="#install">View install</a>
           </div>
           <dl class="hero-facts">
@@ -133,7 +133,7 @@
             <span class="terminal-title">HERDR WORLD / INSTALL</span>
             <button class="copy-button" type="button" data-copy-install><span data-copy-label>Copy</span><span aria-hidden="true">⧉</span></button>
           </div>
-          <pre tabindex="0" aria-label="Herdr World installation commands"><code data-install-command><span class="prompt">$</span> VERSION=v0.1.0-rc.5
+          <pre tabindex="0" aria-label="Herdr World installation commands"><code data-install-command><span class="prompt">$</span> VERSION=v0.1.0-rc.6
 <span class="prompt">$</span> curl -fLO "https://github.com/IvoryHeart/herdr-world/releases/download/${VERSION}/herdr-world-${VERSION}-linux-x86_64.tar.gz"
 <span class="prompt">$</span> curl -fLO "https://github.com/IvoryHeart/herdr-world/releases/download/${VERSION}/herdr-world-${VERSION}-linux-x86_64.tar.gz.sha256"
 <span class="prompt">$</span> sha256sum --check "herdr-world-${VERSION}-linux-x86_64.tar.gz.sha256"
@@ -160,7 +160,7 @@
         <p class="eyebrow">The office is open</p>
         <h2 id="cta-title">Bring your agents<br /><em>into the room.</em></h2>
         <div class="hero-actions">
-          <a class="button button-primary" href="https://github.com/IvoryHeart/herdr-world/releases/tag/v0.1.0-rc.5">Download v0.1.0-rc.5</a>
+          <a class="button button-primary" href="https://github.com/IvoryHeart/herdr-world/releases/tag/v0.1.0-rc.6">Download v0.1.0-rc.6</a>
           <a class="button button-secondary" href="https://github.com/IvoryHeart/herdr-world/discussions">Join the discussion</a>
         </div>
       </section>

--- a/site/site.js
+++ b/site/site.js
@@ -1,4 +1,4 @@
-const installCommand = `VERSION=v0.1.0-rc.5
+const installCommand = `VERSION=v0.1.0-rc.6
 curl -fLO "https://github.com/IvoryHeart/herdr-world/releases/download/\${VERSION}/herdr-world-\${VERSION}-linux-x86_64.tar.gz"
 curl -fLO "https://github.com/IvoryHeart/herdr-world/releases/download/\${VERSION}/herdr-world-\${VERSION}-linux-x86_64.tar.gz.sha256"
 sha256sum --check "herdr-world-\${VERSION}-linux-x86_64.tar.gz.sha256"


### PR DESCRIPTION
## RC6 release preparation\n\n- promote the merged Spec 16 plugin payload and release fixes to v0.1.0-rc.6\n- stamp the public README, Pages site, release metadata, plugin manifest, and changelog\n- retain a fresh Unreleased section for follow-up work\n\nThe release tag will be created from the squash-merged commit after this PR passes.\n\n## Validation\n\n- merged-main distribution preflight: https://github.com/IvoryHeart/herdr-world/actions/runs/33256841046\n- npm run check\n- npm run test:release\n- npm run test:pages