### PR TITLE
Release v0.1.0-rc.7

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -847,7 +847,9 @@ jobs:
               result="already complete"
               ;;
             publish)
-              npm publish "npm-output/herdr-world-${VERSION}.tgz" --access public --tag "$channel" --provenance
+              package_path="${GITHUB_WORKSPACE}/npm-output/herdr-world-${VERSION}.tgz"
+              [[ -f "$package_path" ]] || { echo "npm package artifact is missing: $package_path" >&2; exit 1; }
+              npm publish "$package_path" --access public --tag "$channel" --provenance
               result="published"
               ;;
             update-pointer)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- Fixed RC npm publication to pass the downloaded package tarball as an explicit filesystem path.
+
 ### Removed
 
 ## [0.1.0-rc.6] - 2026-08-29

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Fixed
 
 - Fixed RC npm publication to pass the downloaded package tarball as an explicit filesystem path.
+  [Herdr World PR #39](https://github.com/IvoryHeart/herdr-world/pull/39)
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ navigation, multi-client viewing, mobile input controls, synchronized pane selec
 visualizations. The upstream relationship and synchronization record are documented in
 [`UPSTREAM.md`](UPSTREAM.md).
 
-> **Public preview:** [`v0.1.0-rc.6`](https://github.com/IvoryHeart/herdr-world/releases/tag/v0.1.0-rc.6)
+> **Public preview:** [`v0.1.0-rc.7`](https://github.com/IvoryHeart/herdr-world/releases/tag/v0.1.0-rc.7)
 > provides native archives for Linux x86-64 and macOS on Apple Silicon and Intel. Herdr World
 > currently requires Herdr `v0.8.2` or newer reporting terminal protocol `20`.
 
@@ -113,8 +113,8 @@ Android development also needs a JDK and Android SDK. See [docs/android.md](docs
 
 | Platform | Status |
 | --- | --- |
-| Linux x86-64 | Available in [`v0.1.0-rc.6`](https://github.com/IvoryHeart/herdr-world/releases/tag/v0.1.0-rc.6) |
-| macOS ARM64 / x86-64 | Available unsigned in [`v0.1.0-rc.6`](https://github.com/IvoryHeart/herdr-world/releases/tag/v0.1.0-rc.6) |
+| Linux x86-64 | Available in [`v0.1.0-rc.7`](https://github.com/IvoryHeart/herdr-world/releases/tag/v0.1.0-rc.7) |
+| macOS ARM64 / x86-64 | Available unsigned in [`v0.1.0-rc.7`](https://github.com/IvoryHeart/herdr-world/releases/tag/v0.1.0-rc.7) |
 | Android | Source and debug build workflow are available; no signed public APK yet |
 
 ## Quick Start From Release
@@ -123,7 +123,7 @@ Choose `linux-x86_64`, `macos-arm64` (Apple Silicon), or `macos-x86_64` (Intel),
 verify the current release candidate:
 
 ```bash
-VERSION=v0.1.0-rc.6
+VERSION=v0.1.0-rc.7
 PLATFORM=linux-x86_64
 curl -fLO "https://github.com/IvoryHeart/herdr-world/releases/download/${VERSION}/herdr-world-${VERSION}-${PLATFORM}.tar.gz"
 curl -fLO "https://github.com/IvoryHeart/herdr-world/releases/download/${VERSION}/herdr-world-${VERSION}-${PLATFORM}.tar.gz.sha256"

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -1,6 +1,6 @@
 id = "ivoryheart.herdr-world"
 name = "Herdr World"
-version = "0.1.0-rc.6"
+version = "0.1.0-rc.7"
 min_herdr_version = "0.8.2"
 description = "Browser and mobile client for monitoring and controlling Herdr agents."
 platforms = ["linux", "macos"]

--- a/release.json
+++ b/release.json
@@ -1,3 +1,3 @@
 {
-  "current": "v0.1.0-rc.6"
+  "current": "v0.1.0-rc.7"
 }

--- a/scripts/herdr-world-plugin.test.mjs
+++ b/scripts/herdr-world-plugin.test.mjs
@@ -304,6 +304,7 @@ test("release workflow gates the three-platform plugin smoke on npm publication"
   assert.equal((workflow.match(/platform: linux-x86_64/g) ?? []).length >= 2, true);
   assert.match(workflow.slice(pluginJob), /platform: macos-arm64/);
   assert.match(workflow.slice(pluginJob), /platform: macos-x86_64/);
+  assert.match(workflow, /package_path="\$\{GITHUB_WORKSPACE\}\/npm-output\/herdr-world-\$\{VERSION\}\.tgz"/);
 });
 
 test("documents and tests the explicit stop-before-uninstall contract", () => {

--- a/site/index.html
+++ b/site/index.html
@@ -44,7 +44,7 @@
           <h1 id="hero-title">Your agents.<br /><em>One office.</em></h1>
           <p class="hero-intro">Herdr World turns live Herdr sessions into one visual workspace: terminal-first Spaces, a multi-host Pixel Office, and the controls to move between them without losing context.</p>
           <div class="hero-actions">
-            <a class="button button-primary" href="https://github.com/IvoryHeart/herdr-world/releases/tag/v0.1.0-rc.6">Download the RC <span aria-hidden="true">↓</span></a>
+            <a class="button button-primary" href="https://github.com/IvoryHeart/herdr-world/releases/tag/v0.1.0-rc.7">Download the RC <span aria-hidden="true">↓</span></a>
             <a class="button button-secondary" href="#install">View install</a>
           </div>
           <dl class="hero-facts">
@@ -133,7 +133,7 @@
             <span class="terminal-title">HERDR WORLD / INSTALL</span>
             <button class="copy-button" type="button" data-copy-install><span data-copy-label>Copy</span><span aria-hidden="true">⧉</span></button>
           </div>
-          <pre tabindex="0" aria-label="Herdr World installation commands"><code data-install-command><span class="prompt">$</span> VERSION=v0.1.0-rc.6
+          <pre tabindex="0" aria-label="Herdr World installation commands"><code data-install-command><span class="prompt">$</span> VERSION=v0.1.0-rc.7
 <span class="prompt">$</span> curl -fLO "https://github.com/IvoryHeart/herdr-world/releases/download/${VERSION}/herdr-world-${VERSION}-linux-x86_64.tar.gz"
 <span class="prompt">$</span> curl -fLO "https://github.com/IvoryHeart/herdr-world/releases/download/${VERSION}/herdr-world-${VERSION}-linux-x86_64.tar.gz.sha256"
 <span class="prompt">$</span> sha256sum --check "herdr-world-${VERSION}-linux-x86_64.tar.gz.sha256"
@@ -160,7 +160,7 @@
         <p class="eyebrow">The office is open</p>
         <h2 id="cta-title">Bring your agents<br /><em>into the room.</em></h2>
         <div class="hero-actions">
-          <a class="button button-primary" href="https://github.com/IvoryHeart/herdr-world/releases/tag/v0.1.0-rc.6">Download v0.1.0-rc.6</a>
+          <a class="button button-primary" href="https://github.com/IvoryHeart/herdr-world/releases/tag/v0.1.0-rc.7">Download v0.1.0-rc.7</a>
           <a class="button button-secondary" href="https://github.com/IvoryHeart/herdr-world/discussions">Join the discussion</a>
         </div>
       </section>

--- a/site/site.js
+++ b/site/site.js
@@ -1,4 +1,4 @@
-const installCommand = `VERSION=v0.1.0-rc.6
+const installCommand = `VERSION=v0.1.0-rc.7
 curl -fLO "https://github.com/IvoryHeart/herdr-world/releases/download/\${VERSION}/herdr-world-\${VERSION}-linux-x86_64.tar.gz"
 curl -fLO "https://github.com/IvoryHeart/herdr-world/releases/download/\${VERSION}/herdr-world-\${VERSION}-linux-x86_64.tar.gz.sha256"
 sha256sum --check "herdr-world-\${VERSION}-linux-x86_64.tar.gz.sha256"


### PR DESCRIPTION
## Summary

- advance the checked-in release references and public release notes to v0.1.0-rc.7
- fix npm publication to pass the downloaded tarball as an explicit filesystem path
- add a regression assertion for the release workflow path

RC6 published its GitHub and Homebrew artifacts, but its npm publication job failed because npm interpreted the relative tarball name as a Git target. RC7 is a new candidate per the release policy; it does not replace the existing RC6 tag or release.

## Validation

- npm run check
- npm run test:release
- npm run test:pages
- git diff --check