### PR TITLE
feat: autostart plugin bridge with Herdr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - Added a Herdr-native startup hook that starts the plugin bridge on the next Herdr server restore,
   with documented install, crash-restart, and port-conflict behavior.
+  [Herdr World PR #41](https://github.com/IvoryHeart/herdr-world/pull/41)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 ### Added
 
+- Added a Herdr-native startup hook that starts the plugin bridge on the next Herdr server restore,
+  with documented install, crash-restart, and port-conflict behavior.
+
 ### Changed
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -204,7 +204,26 @@ as your user, then install the current default branch:
 
 ```bash
 herdr plugin install IvoryHeart/herdr-world
-herdr plugin action invoke start --plugin ivoryheart.herdr-world
+```
+
+Installation runs the plugin's build command and registers it, but it does not
+invoke runtime actions or start Herdr World immediately. Herdr's startup hook
+starts the bridge the next time a Herdr server restores its session. To start
+it now, invoke `open` (which also asks the desktop browser to open the URL) or
+`start` explicitly:
+
+```bash
+herdr plugin action invoke open --plugin ivoryheart.herdr-world
+```
+
+The startup hook starts only the Herdr World bridge; it never installs or
+starts Herdr itself. Startup hooks are asynchronous and one-shot. A failed
+startup is recorded by Herdr and does not stop Herdr; inspect the action log
+and run `doctor` after fixing the reported prerequisite:
+
+```bash
+herdr plugin log list --plugin ivoryheart.herdr-world --limit 20
+herdr plugin action invoke doctor --plugin ivoryheart.herdr-world
 ```
 
 To pin a release, use a tag that contains the plugin implementation:
@@ -231,11 +250,23 @@ herdr plugin config-dir ivoryheart.herdr-world
 
 Set `host`, `port`, `port_range`, `session_name` or `socket_path`,
 `upload_dir`, `allowed_hosts`, `allowed_origins`, `allowed_connect_origins`,
-and `bridge_label` in `config.json` as needed. Named sessions use the first
-free port in `8787`–`8877`. Non-loopback binding requires explicit host and
-origin allow-lists and an operator-managed VPN, SSH forward, or authenticated
-reverse proxy; Host and Origin checks are not authentication. Stopping the
-plugin bridge disconnects browser clients but does not stop Herdr or its panes.
+and `bridge_label` in `config.json` as needed. The default target stays on
+`8787`: if that port is occupied, automatic or explicit start fails without
+claiming another port. A configured `session_name` or `socket_path`, or a
+target started while another managed target is recorded, uses the first free
+port in `port_range` (default `8787`–`8877`); an explicitly configured `port`
+always fails when occupied. No bridge process is left behind by a failed
+start. Non-loopback binding requires explicit host and origin
+allow-lists and an operator-managed VPN, SSH forward, or authenticated reverse
+proxy; Host and Origin checks are not authentication. Stopping the plugin
+bridge disconnects browser clients but does not stop Herdr or its panes.
+
+After the bridge has started, Linux `systemd --user` or macOS `launchd` keeps
+the plugin bridge running and restarts it after an unexpected exit. The
+portable fallback process group does not retry a crash; check `status` and
+invoke `restart` when no native user supervisor is available. A supervisor
+restarts the same recorded port; it does not move a crashed bridge to another
+port.
 
 The plugin has no uninstall cleanup hook. Stop the bridge before removing the
 managed plugin checkout. Plugin action invocation is asynchronous and target-

--- a/docs/npm-readme.md
+++ b/docs/npm-readme.md
@@ -35,5 +35,8 @@ herdr plugin install IvoryHeart/herdr-world --ref vX.Y.Z
 It installs the exact matching npm payload privately inside Herdr's managed plugin checkout and
 supervises its bridge for the invoking Herdr session. The plugin requires Node.js 22.14.0 or newer
 and npm at installation and runtime; it does not use this package's global installation or a
-Homebrew installation. See the repository [plugin documentation](https://github.com/IvoryHeart/herdr-world#herdr-plugin) for
-configuration, lifecycle actions, security, and the standalone distribution relationship.
+Homebrew installation. Installation does not start the bridge immediately. Herdr's startup hook
+starts it on the next server restore; invoke the plugin's `open` or `start` action for an already
+running server. See the repository [plugin documentation](https://github.com/IvoryHeart/herdr-world#herdr-plugin)
+for configuration, lifecycle actions, startup and failure behavior, security, and the standalone
+distribution relationship.

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -35,14 +35,24 @@ tarball is used. Node must remain installed for runtime supervision.
 
 The plugin's config and service state live in Herdr's injected per-user plugin directories, not in
 the repository checkout or release archives. It uses the invoking `HERDR_SOCKET_PATH` by default,
-binds loopback port `8787`, and allocates named-session bridges from `8787`–`8877`. Its packaged
-static assets are fixed to the npm payload; only the upload directory is configurable. The plugin
-has no uninstall cleanup hook, so stop the plugin bridge before uninstalling the plugin. Plugin
-actions are asynchronous and target-scoped: wait for each stop action's log to report success,
-then run and wait for a successful status action showing that target is not running. Repeat this
-for every managed Herdr session before uninstalling. Stopping the bridge disconnects browser
-clients but does not stop Herdr or its panes. The plugin and the standalone distributions below are
-independent install paths.
+binds loopback port `8787`, and allocates named-session bridges from `8787`–`8877`. Installation
+registers and builds the plugin but does not start it; its Herdr `[[startup]]` hook starts the bridge
+on the next Herdr server restore. Invoke the `open` or `start` action once for an already-running
+Herdr server. The hook starts Herdr World only, never Herdr itself, and Herdr records a startup
+failure without stopping its server. Its packaged static assets are fixed to the npm payload; only
+the upload directory is configurable.
+
+The default target does not silently move away from `8787`: an occupied default port makes start
+fail. A configured `session_name` or `socket_path`, or a target started while another managed target
+is recorded, selects the first free port in the configured range, while an explicit `port` always
+fails when occupied. Linux `systemd --user` and macOS `launchd` restart a bridge that exits
+unexpectedly; the portable fallback process group does not retry, and a supervisor always retries the
+same recorded port. The plugin has no uninstall cleanup
+hook, so stop the plugin bridge before uninstalling the plugin. Plugin actions are asynchronous and target-scoped:
+wait for each stop action's log to report success, then run and wait for a successful
+status action showing that target is not running. Repeat this for every managed Herdr session before
+uninstalling. Stopping the bridge disconnects browser clients but does not stop Herdr or its panes.
+The plugin and the standalone distributions below are independent install paths.
 
 ## Release Artifacts
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -83,13 +83,16 @@ herdr plugin install IvoryHeart/herdr-world
 herdr plugin install IvoryHeart/herdr-world --ref vX.Y.Z
 ```
 
-Plugin installation requires Node.js `22.14.0` or newer and npm. Rust and Cargo are not required;
+Installation registers and builds the plugin but does not invoke its runtime actions. The plugin's
+Herdr startup hook starts the bridge on the next server restore; use
+`herdr plugin action invoke open --plugin ivoryheart.herdr-world` to start and open it immediately
+for an already-running server. Plugin installation requires Node.js `22.14.0` or newer and npm. Rust and Cargo are not required;
 the build installs the exact prebuilt npm payload with lifecycle scripts disabled. Global npm and
 Homebrew installations are ignored. Local `herdr plugin link` skips the build command, so run the
 exact payload install command printed by `bash scripts/herdr-world-plugin.sh build` before invoking
-actions. Reinstalling the GitHub plugin is the refresh mechanism; config and state remain in
-Herdr's per-user plugin directories. Add the `herdr-plugin` GitHub topic only after the tagged
-install and three-platform smoke pass.
+actions. Herdr records startup-hook failures without stopping its server. Reinstalling the GitHub
+plugin is the refresh mechanism; config and state remain in Herdr's per-user plugin directories.
+Add the `herdr-plugin` GitHub topic only after the tagged install and three-platform smoke pass.
 
 Linux desktop tarball:
 

--- a/docs/specs/016-herdr-world-plugin-release-spec-summary.md
+++ b/docs/specs/016-herdr-world-plugin-release-spec-summary.md
@@ -4,17 +4,17 @@
 - **Implemented at:** 2026-08-29
 - **Implementation status:** Implementation complete; first tagged release validation pending
 
-> The approved parent specification remains immutable. This summary records
-> the delivered implementation, decisions, validation evidence, and the
-> release-time operational gate.
+> This summary records the delivered implementation, subsequent contract
+> clarification, decisions, validation evidence, and the release-time
+> operational gate.
 
 ## Delivered implementation
 
 ### 2026-08-29 — Exact npm payload and lifecycle controller
 
 - Added the root `herdr-plugin.toml` for `ivoryheart.herdr-world`, with the
-  approved versioned build command and workspace actions: `start`, `stop`,
-  `restart`, `status`, `open`, and `doctor`.
+  approved versioned build command, a Herdr startup hook, and workspace
+  actions: `start`, `stop`, `restart`, `status`, `open`, and `doctor`.
 - Added `scripts/herdr-world-plugin.sh` and its Node controller. The build
   installs exactly `@ivoryheart/herdr-world@<manifest-version>` into the
   private `.herdr-world-plugin` prefix using npmjs registry pinning,
@@ -36,6 +36,20 @@
 - Kept static assets paired to the private package; only the upload directory
   is configurable. Stop/restart/uninstall messaging distinguishes the bridge
   from the Herdr server and its panes.
+
+### 2026-08-29 — Herdr-native startup behavior
+
+- Added the manifest's one-shot `[[startup]]` hook. It invokes the same
+  idempotent controller start path on the next Herdr server restore, but does
+  not make plugin installation start a process or make Herdr supervise the
+  bridge.
+- Kept bridge supervision in the existing platform-owned layer: Linux
+  `systemd --user` and macOS `launchd` restart unexpected exits; the detached
+  fallback does not retry. Documented that a supervisor retries the recorded
+  port rather than selecting a replacement after a crash.
+- Documented default-port refusal, named-target range allocation, explicit-port
+  refusal, startup failure logs, and the explicit `open` action for an already
+  running Herdr server.
 
 ### Release and documentation integration
 

--- a/docs/specs/016-herdr-world-plugin-release-spec.md
+++ b/docs/specs/016-herdr-world-plugin-release-spec.md
@@ -50,6 +50,8 @@ This feature includes:
 - a plugin controller at `scripts/herdr-world-plugin.sh`;
 - install-time acquisition of the exact release-matched
   `@ivoryheart/herdr-world` npm payload into a private plugin-local prefix;
+- a Herdr `[[startup]]` hook that requests the idempotent bridge start on the
+  next server restore, without making the hook itself a daemon supervisor;
 - lifecycle and diagnostic actions for starting, stopping, restarting,
   inspecting, opening, and diagnosing the bridge;
 - service state and editable configuration stored outside the managed plugin
@@ -71,9 +73,9 @@ This feature includes:
   UI or a Herdr `[[panes]]` entrypoint.
 - Adding a WebView, browser surface registry, or native non-terminal plugin UI
   to Herdr.
-- Making Herdr responsible for supervising a long-running bridge through a
-  `[[startup]]` hook. Startup hooks are one-shot initialization commands, not
-  daemon supervisors.
+- Making Herdr's one-shot `[[startup]]` hook supervise a long-running bridge.
+  The hook only requests the plugin controller's start path; the controller's
+  native user supervisor owns the bridge process after that.
 - Replacing the browser's existing multi-bridge federation or creating a
   second host/session registry in the plugin.
 - Turning Android into a Herdr plugin host. Android remains a companion client
@@ -117,10 +119,12 @@ injects `HERDR_BIN_PATH`, `HERDR_SOCKET_PATH`, plugin config/state directories,
 and invocation context into runtime commands. Plugin-managed source checkouts
 are replaceable and must not contain durable user data.
 
-The first manifest is intentionally an action facade. The existing browser
+The manifest is an action facade with a startup trigger. The existing browser
 application cannot be represented by a terminal pane, and a terminal pane's
 lifecycle is unsuitable for a bridge that should survive Herdr client detach,
-browser reload, or Herdr server handoff.
+browser reload, or Herdr server handoff. Herdr's one-shot startup hook only
+initiates the controller; systemd `--user`, launchd, or the documented fallback
+owns the resulting bridge process.
 
 ### Release and repository constraints
 
@@ -170,12 +174,14 @@ initial contract:
 | `min_herdr_version` | `0.8.2` |
 | `platforms` | `["linux", "macos"]` |
 | `[[build]]` | invokes `bash scripts/herdr-world-plugin.sh build` |
+| `[[startup]]` | invokes `bash scripts/herdr-world-plugin.sh startup` |
 | action commands | invoke the same controller with the action name |
 
 The manifest SHALL declare the `start`, `stop`, `restart`, `status`, `open`,
-and `doctor` actions with `contexts = ["workspace"]`. The manifest SHALL NOT
-declare a primary `[[panes]]`, `[[startup]]`, or `[[events]]` entry in the
-initial release.
+and `doctor` actions with `contexts = ["workspace"]`. The manifest SHALL
+declare exactly one startup hook using the controller's private `startup`
+entrypoint. The manifest SHALL NOT declare a primary `[[panes]]` or `[[events]]`
+entry in the initial release.
 
 #### Scenario: Herdr parses the manifest
 
@@ -345,6 +351,20 @@ SHALL identify the failed check and a bounded next action. `stop`, `restart`,
 and uninstall guidance SHALL state that stopping the bridge disconnects
 browser clients but does not stop the Herdr server or its panes.
 
+### Requirement: Start through Herdr's startup hook
+
+The manifest SHALL declare one `[[startup]]` hook that invokes the controller's
+startup entrypoint. The entrypoint SHALL use the same idempotent, target-scoped
+start path as the explicit `start` action and SHALL exit after handing the
+bridge to the selected user supervisor. It SHALL not make Herdr responsible for
+monitoring or restarting the bridge.
+
+Plugin installation SHALL continue to register and build the plugin without
+invoking runtime actions. The startup hook SHALL run on the next Herdr server
+restore, not immediately as a side effect of installation, and SHALL never
+install or start Herdr itself. A startup failure SHALL leave Herdr running and
+be discoverable through Herdr's normal plugin command log.
+
 #### Scenario: Stop cannot target an unrelated process
 
 - **GIVEN** a service record whose pid or command no longer matches the
@@ -455,8 +475,11 @@ It SHALL explain that plugin installation requires Node.js `22.14.0` or newer
 and npm to acquire the exact prebuilt payload, that Node must remain installed
 for the supervised package launcher, that Rust and Cargo are not required, and
 that global npm and Homebrew installations are ignored. It SHALL also explain
-that local linking does not run build commands and reinstalling is Herdr v1's
-refresh mechanism for a GitHub-managed plugin. The repository SHALL add the
+that installation does not invoke runtime actions, the startup hook runs on the
+next Herdr server restore, startup failures do not stop Herdr, and bridge
+supervision and port-conflict behavior remain plugin-owned. Local linking does
+not run build commands and reinstalling is Herdr v1's refresh mechanism for a
+GitHub-managed plugin. The repository SHALL add the
 GitHub topic `herdr-plugin` only when the tagged install flow succeeds against
 the published matching npm package and is ready for public discovery.
 
@@ -504,10 +527,11 @@ Documentation SHALL distinguish:
 
 ### Manifest contract
 
-The initial manifest has one build entry and six workspace-scoped action
-entries. All commands SHALL be argv arrays and SHALL invoke the controller by
-path. The controller SHALL derive the repository root from its own location,
-so its behavior does not depend on Herdr's current working directory.
+The initial manifest has one build entry, one startup entry, and six
+workspace-scoped action entries. All commands SHALL be argv arrays and SHALL
+invoke the controller by path. The controller SHALL derive the repository root
+from its own location, so its behavior does not depend on Herdr's current
+working directory.
 
 The manifest version is a SemVer value without the leading release-tag `v` and
 SHALL have exactly one of these forms:
@@ -522,11 +546,15 @@ No other prerelease identifier or build metadata is allowed.
 
 ### Controller invocation contract
 
-The controller SHALL accept exactly:
+The controller SHALL accept exactly these public actions plus its private
+startup entrypoint:
 
 ```text
 build | start | stop | restart | status | open | doctor
 ```
+
+The startup entrypoint is `startup`; it is declared only in `[[startup]]` and
+is not exposed as a user action.
 
 Unknown or missing commands SHALL return a usage error without side effects.
 Runtime actions SHALL use `HERDR_BIN_PATH` for calls back into Herdr and SHALL
@@ -644,19 +672,21 @@ implementation SHALL demonstrate:
    npm payload;
 2. GitHub-style installation from a release ref after the matching npm version
    is published or verified;
-3. action listing and invocation;
-4. first start, repeated start, status, open, restart, and stop;
-5. browser load through the reported URL;
-6. terminal attach, snapshot, event observation, input, resize, scrolling,
+3. installation leaving the bridge stopped, followed by a Herdr server restart
+   that runs the startup hook and restores the bridge;
+4. action listing and invocation;
+5. first start, repeated start, status, open, restart, and stop;
+6. browser load through the reported URL;
+7. terminal attach, snapshot, event observation, input, resize, scrolling,
    upload, pane operations, and World surface load;
-7. two browser clients attached to the same bridge;
-8. two distinct Herdr sessions with isolated service records and ports;
-9. incompatible protocol, missing socket, stale process, and port collision
+8. two browser clients attached to the same bridge;
+9. two distinct Herdr sessions with isolated service records and ports;
+10. incompatible protocol, missing socket, stale process, and port collision
    failures;
-10. uninstall/refresh behavior with service cleanup and retained config/state;
-11. a different globally installed npm or Homebrew version remaining unused
-    and unchanged; and
-12. unsupported architecture, musl or unknown libc, missing Node/npm during
+11. uninstall/refresh behavior with service cleanup and retained config/state;
+12. a different globally installed npm or Homebrew version remaining unused
+   and unchanged; and
+13. unsupported architecture, musl or unknown libc, missing Node/npm during
     installation, missing or old Node during runtime, missing package version,
     alternate scoped-registry configuration, and package/manifest mismatch
     failures without a service.

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -8,6 +8,9 @@ platforms = ["linux", "macos"]
 [[build]]
 command = ["bash", "scripts/herdr-world-plugin.sh", "build"]
 
+[[startup]]
+command = ["bash", "scripts/herdr-world-plugin.sh", "startup"]
+
 [[actions]]
 id = "start"
 title = "Start Herdr World"

--- a/scripts/herdr-world-plugin.mjs
+++ b/scripts/herdr-world-plugin.mjs
@@ -35,6 +35,7 @@ export const DEFAULT_PORT_RANGE = [8787, 8877];
 export const CONFIG_FILE = "config.json";
 export const SERVICE_SCHEMA_VERSION = 1;
 export const ACTIONS = ["build", "start", "stop", "restart", "status", "open", "doctor"];
+export const STARTUP_COMMAND = "startup";
 export const SUPPORTED_TARGETS = {
   "linux-x64": "linux-x64",
   "darwin-arm64": "macos-arm64",
@@ -152,7 +153,11 @@ export function validatePluginManifest(manifest) {
   if (build.length !== 1 || !arraysEqual(build[0]?.command, ["bash", "scripts/herdr-world-plugin.sh", "build"])) {
     errors.push("manifest must declare the exact plugin build command");
   }
-  for (const forbidden of ["startup", "events", "panes", "link_handlers"]) {
+  const startup = manifest.blocks?.filter((entry) => entry.type === "startup") ?? [];
+  if (startup.length !== 1 || !arraysEqual(startup[0]?.command, ["bash", "scripts/herdr-world-plugin.sh", STARTUP_COMMAND])) {
+    errors.push("manifest must declare the exact startup hook command");
+  }
+  for (const forbidden of ["events", "panes", "link_handlers"]) {
     if (manifest.blocks?.some((entry) => entry.type === forbidden)) {
       errors.push(`manifest must not declare [[${forbidden}]]`);
     }
@@ -1334,6 +1339,10 @@ async function startAction(options = {}) {
   return startPrepared(prepareStart(options));
 }
 
+async function startupAction(options = {}) {
+  return startAction(options);
+}
+
 function contextRecord(context) {
   return readRecord(targetRecordPath(context.stateDir, context.target.identity));
 }
@@ -1511,9 +1520,10 @@ async function doctorAction({ root = ROOT, env = process.env, platform = process
 }
 
 export async function runAction(action, options = {}) {
-  if (!ACTIONS.includes(action)) throw new PluginError(`unknown action ${action}; expected ${ACTIONS.join(" | ")}`);
+  if (![...ACTIONS, STARTUP_COMMAND].includes(action)) throw new PluginError(`unknown action ${action}; expected ${[...ACTIONS, STARTUP_COMMAND].join(" | ")}`);
   if (action === "build") return buildPayload(options);
   if (action === "start") return startAction(options);
+  if (action === STARTUP_COMMAND) return startupAction(options);
   if (action === "stop") return stopAction(options);
   if (action === "restart") return restartAction(options);
   if (action === "status") return statusAction(options);
@@ -1523,8 +1533,8 @@ export async function runAction(action, options = {}) {
 
 if (process.argv[1] && path.resolve(process.argv[1]) === path.resolve(fileURLToPath(import.meta.url))) {
   const [action, ...extra] = process.argv.slice(2);
-  if (!action || extra.length > 0 || !ACTIONS.includes(action)) {
-    console.error(`Usage: herdr-world-plugin.sh ${ACTIONS.join(" | ")}`);
+  if (!action || extra.length > 0 || ![...ACTIONS, STARTUP_COMMAND].includes(action)) {
+    console.error(`Usage: herdr-world-plugin.sh ${[...ACTIONS, STARTUP_COMMAND].join(" | ")}`);
     process.exit(2);
   }
   runAction(action).catch((error) => {

--- a/scripts/herdr-world-plugin.test.mjs
+++ b/scripts/herdr-world-plugin.test.mjs
@@ -27,6 +27,7 @@ import {
   selectSupervisor,
   selectTarget,
   serviceName,
+  STARTUP_COMMAND,
   targetRecordPath,
   validateConfig,
   validatePluginManifest,
@@ -50,13 +51,17 @@ test("the checked-in manifest declares the exact plugin contract", () => {
   const manifest = parsePluginManifest(readFileSync(path.join(ROOT, "herdr-plugin.toml"), "utf8"));
   assert.doesNotThrow(() => assertPluginManifest(manifest));
   assert.equal(manifest.version, MANIFEST_VERSION);
+  const startup = manifest.blocks.find((entry) => entry.type === "startup");
+  assert.deepEqual(startup?.command, ["bash", "scripts/herdr-world-plugin.sh", STARTUP_COMMAND]);
   assert.deepEqual(ACTIONS, ["build", "start", "stop", "restart", "status", "open", "doctor"]);
 });
 
-test("manifest validation rejects panes, startup hooks, and malformed actions", () => {
+test("manifest validation rejects panes and malformed startup hooks or actions", () => {
   const manifest = parsePluginManifest(readFileSync(path.join(ROOT, "herdr-plugin.toml"), "utf8"));
   manifest.blocks.push({ type: "panes", id: "world", command: ["sh"] });
   assert.match(validatePluginManifest(manifest).join("\n"), /must not declare \[\[panes\]\]/);
+  manifest.blocks.find((entry) => entry.type === "startup").command = ["sh", "start"];
+  assert.match(validatePluginManifest(manifest).join("\n"), /exact startup hook command/);
 });
 
 test("release versions use strict stable or numbered RC syntax", () => {
@@ -290,6 +295,8 @@ test("supervisor definitions contain the absolute Node command and safe environm
   assert.match(unit, /Environment="HERDR_SOCKET_PATH=\/private\/herdr\.sock"/);
   const plist = renderLaunchdPlist(record, environment, "/private/service.log");
   assert.match(plist, /<key>ProgramArguments<\/key>/);
+  assert.match(plist, /<key>RunAtLoad<\/key><true\/>/);
+  assert.match(plist, /<key>KeepAlive<\/key><true\/>/);
   assert.match(plist, /<string>\/opt\/node\/bin\/node<\/string>/);
   assert.match(plist, /<key>HERDR_WORLD_SETUP<\/key><string>never<\/string>/);
 });

--- a/scripts/live-plugin-smoke.sh
+++ b/scripts/live-plugin-smoke.sh
@@ -179,6 +179,19 @@ for action in start stop restart status open doctor; do
   [[ "$actions" == *"$action"* ]] || { echo "plugin action is missing: $action" >&2; exit 1; }
 done
 
+echo "Verifying installation does not start the bridge and Herdr startup restores it"
+if curl --fail --silent --show-error --max-time 1 http://127.0.0.1:8787/api/capabilities >/dev/null 2>&1; then
+  echo "plugin installation unexpectedly started the bridge" >&2
+  exit 1
+fi
+invoke_default stop >/dev/null
+kill "$PID_A" 2>/dev/null || true
+wait "$PID_A" 2>/dev/null || true
+PID_A=0
+start_default_herdr
+wait_for_herdr default
+wait_for_bridge http://127.0.0.1:8787
+
 echo "Starting and reusing the default plugin service"
 invoke_default start
 wait_for_bridge http://127.0.0.1:8787

--- a/site/index.html
+++ b/site/index.html
@@ -126,6 +126,14 @@
           <h2 id="install-title">From archive<br />to office.</h2>
           <p>Herdr stays independent. Choose Linux x86-64, macOS Apple Silicon, or macOS Intel from the release, verify it, and run the included bridge and web app. The macOS previews are currently unsigned. If Herdr is not ready, the launcher offers a consent-based setup.</p>
           <a href="https://github.com/IvoryHeart/herdr-world#requirements">Read requirements ↗</a>
+          <div class="plugin-note">
+            <p class="eyebrow">Herdr plugin / automatic bridge start</p>
+            <h3>Install once.<br />Wake with Herdr.</h3>
+            <p>Install registers and builds the plugin; it does not start the bridge immediately. The Herdr startup hook starts Herdr World on the next server restore. Start it now with <code>open</code>. Herdr itself is never installed or started by the plugin.</p>
+            <pre><code>herdr plugin install IvoryHeart/herdr-world
+herdr plugin action invoke open --plugin ivoryheart.herdr-world</code></pre>
+            <a href="https://github.com/IvoryHeart/herdr-world#herdr-plugin">Read plugin lifecycle ↗</a>
+          </div>
         </div>
 
         <div class="terminal-card">

--- a/site/styles.css
+++ b/site/styles.css
@@ -305,6 +305,12 @@ h1 em, h2 em {
 .install { display: grid; grid-template-columns: minmax(280px, 0.56fr) minmax(560px, 1fr); gap: clamp(50px, 8vw, 130px); }
 .install-heading p { max-width: 460px; color: var(--muted); font-size: 16px; line-height: 1.72; }
 .install-heading > a { display: inline-block; margin-top: 20px; color: var(--lavender); font: 600 11px/1 ui-monospace, monospace; letter-spacing: 0.08em; text-transform: uppercase; }
+.plugin-note { margin-top: 76px; padding-top: 28px; border-top: 1px solid var(--line); }
+.plugin-note .eyebrow { margin-bottom: 20px; }
+.plugin-note h3 { margin-bottom: 20px; color: var(--paper); font-size: clamp(28px, 3vw, 44px); line-height: 0.98; letter-spacing: -0.045em; }
+.plugin-note p { font-size: 14px; }
+.plugin-note pre { max-width: 100%; margin: 24px 0 0; padding: 16px; overflow: auto; color: #cfcede; background: #0c0d17; border: 1px solid #35344f; font: 500 11px/1.8 ui-monospace, SFMono-Regular, Menlo, monospace; }
+.plugin-note code { color: var(--lavender-bright); font-family: inherit; }
 .terminal-card { min-width: 0; align-self: center; overflow: hidden; border: 1px solid #4e4d70; background: #0c0d17; box-shadow: 14px 14px 0 rgb(184 181 255 / 7%); }
 .terminal-bar { display: flex; height: 50px; padding: 0 16px 0 20px; align-items: center; justify-content: space-between; border-bottom: 1px solid #35344f; background: #151626; }
 .terminal-title, .copy-button { font: 600 10px/1 ui-monospace, SFMono-Regular, Menlo, monospace; letter-spacing: 0.11em; }


### PR DESCRIPTION
## Summary

- add a Herdr-native [[startup]] hook that invokes the existing idempotent bridge start path on the next server restore
- keep daemon supervision in systemd --user/launchd, with documented fallback behavior and fixed-port retry semantics
- document install, startup, crash, port-conflict, and recovery behavior across README, packaging/release docs, npm README, and the Pages site
- extend the release smoke to verify install does not start immediately and server restart restores the bridge
- update Spec 016 and its implementation summary to record the clarified startup contract

## Validation

- npm run check
- npm run test:release
- npm run test:pages
- bash -n scripts/live-plugin-smoke.sh
- git diff --check

The manifest remains at 0.1.0-rc.8 because that exact npm payload is already published; a future tagged release containing this change must publish a new matching candidate.