### PR TITLE
docs: simplify installation paths on project site

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@
 
 ### Changed
 
+- Updated the project site with tabbed npm, Homebrew, and Herdr plugin installation paths plus a
+  concise CLI quick reference.
+
 ### Fixed
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 - Updated the project site with tabbed npm, Homebrew, and Herdr plugin installation paths plus a
   concise CLI quick reference.
+  [Herdr World PR #42](https://github.com/IvoryHeart/herdr-world/pull/42)
 
 ### Fixed
 

--- a/scripts/pages.test.mjs
+++ b/scripts/pages.test.mjs
@@ -48,6 +48,15 @@ test("the Pages artifact is self-contained and release-accurate", () => {
   assert.match(html, /assets\/pixel-office-desktop\.png/);
   assert.match(html, /assets\/pixel-office-mobile\.png/);
   assert.match(html, /property="og:image"[^>]+social-preview\.png/);
+  assert.match(html, /role="tablist"[^>]+aria-label="Herdr World installation methods"/);
+  assert.match(html, /data-install-tab="npm"/);
+  assert.match(html, /data-install-tab="brew"/);
+  assert.match(html, /data-install-tab="herdr"/);
+  assert.match(html, /npm install --global @ivoryheart\/herdr-world@next/);
+  assert.match(html, /brew install IvoryHeart\/tap\/herdr-world-rc/);
+  assert.match(html, new RegExp("herdr plugin install IvoryHeart/herdr-world --ref " + currentRelease));
+  assert.match(html, /data-cli-command/);
+  assert.match(readFileSync(join(output, "site.js"), "utf8"), /data-install-tab/);
   assert.doesNotMatch(html, /(?:src|href)="\/(?!\/)/, "local references must be relative");
   assert.doesNotMatch(html, /file:\/\//, "local filesystem URLs must not ship");
 

--- a/site/index.html
+++ b/site/index.html
@@ -122,16 +122,14 @@
       <section class="install" id="install" aria-labelledby="install-title">
         <div class="section-index" aria-hidden="true">02 / ENTER</div>
         <div class="install-heading">
-          <p class="eyebrow">Desktop public preview</p>
-          <h2 id="install-title">From archive<br />to office.</h2>
-          <p>Herdr stays independent. Choose Linux x86-64, macOS Apple Silicon, or macOS Intel from the release, verify it, and run the included bridge and web app. The macOS previews are currently unsigned. If Herdr is not ready, the launcher offers a consent-based setup.</p>
+          <p class="eyebrow">Three ways in</p>
+          <h2 id="install-title">Choose your<br /><em>path.</em></h2>
+          <p>Use npm or Homebrew for the standalone <code>herdr-world</code> command, or let Herdr manage the bridge as a native plugin. The Herdr route keeps its runtime inside Herdr’s plugin system and never writes a new command into your shell. The macOS previews are currently unsigned.</p>
           <a href="https://github.com/IvoryHeart/herdr-world#requirements">Read requirements ↗</a>
           <div class="plugin-note">
-            <p class="eyebrow">Herdr plugin / automatic bridge start</p>
+            <p class="eyebrow">Herdr plugin / native lifecycle</p>
             <h3>Install once.<br />Wake with Herdr.</h3>
-            <p>Install registers and builds the plugin; it does not start the bridge immediately. The Herdr startup hook starts Herdr World on the next server restore. Start it now with <code>open</code>. Herdr itself is never installed or started by the plugin.</p>
-            <pre><code>herdr plugin install IvoryHeart/herdr-world
-herdr plugin action invoke open --plugin ivoryheart.herdr-world</code></pre>
+            <p>Herdr’s startup hook restores the bridge when the next Herdr server starts. It does not open a browser automatically. Use Herdr’s <strong>Open Herdr World</strong> action, or the CLI command shown below, when you want to open the web client now.</p>
             <a href="https://github.com/IvoryHeart/herdr-world#herdr-plugin">Read plugin lifecycle ↗</a>
           </div>
         </div>
@@ -141,15 +139,49 @@ herdr plugin action invoke open --plugin ivoryheart.herdr-world</code></pre>
             <span class="terminal-title">HERDR WORLD / INSTALL</span>
             <button class="copy-button" type="button" data-copy-install><span data-copy-label>Copy</span><span aria-hidden="true">⧉</span></button>
           </div>
-          <pre tabindex="0" aria-label="Herdr World installation commands"><code data-install-command><span class="prompt">$</span> VERSION=v0.1.0-rc.8
-<span class="prompt">$</span> curl -fLO "https://github.com/IvoryHeart/herdr-world/releases/download/${VERSION}/herdr-world-${VERSION}-linux-x86_64.tar.gz"
-<span class="prompt">$</span> curl -fLO "https://github.com/IvoryHeart/herdr-world/releases/download/${VERSION}/herdr-world-${VERSION}-linux-x86_64.tar.gz.sha256"
-<span class="prompt">$</span> sha256sum --check "herdr-world-${VERSION}-linux-x86_64.tar.gz.sha256"
-<span class="prompt">$</span> tar -xzf "herdr-world-${VERSION}-linux-x86_64.tar.gz"
-<span class="prompt">$</span> cd "herdr-world-${VERSION}-linux-x86_64"
-<span class="prompt">$</span> bin/herdr-world
+          <div class="install-tabs" role="tablist" aria-label="Herdr World installation methods">
+            <button class="install-tab" type="button" role="tab" id="install-tab-npm" aria-controls="install-panel-npm" aria-selected="true" tabindex="0" data-install-tab="npm">npm</button>
+            <button class="install-tab" type="button" role="tab" id="install-tab-brew" aria-controls="install-panel-brew" aria-selected="false" tabindex="-1" data-install-tab="brew">Homebrew</button>
+            <button class="install-tab" type="button" role="tab" id="install-tab-herdr" aria-controls="install-panel-herdr" aria-selected="false" tabindex="-1" data-install-tab="herdr">Herdr plugin</button>
+          </div>
+
+          <section class="install-panel" id="install-panel-npm" role="tabpanel" aria-labelledby="install-tab-npm" data-install-panel="npm">
+            <p class="install-panel-label">Standalone / Node.js 22.14+</p>
+            <pre tabindex="0" aria-label="npm installation commands"><code data-install-command="npm"><span class="prompt">$</span> npm install --global @ivoryheart/herdr-world@next
+<span class="prompt">$</span> herdr-world
 
 <span class="success">→ open http://127.0.0.1:8787</span></code></pre>
+            <p class="install-panel-note">The npm package includes the tested Linux x64, macOS ARM64, and macOS Intel bridges.</p>
+          </section>
+
+          <section class="install-panel" id="install-panel-brew" role="tabpanel" aria-labelledby="install-tab-brew" data-install-panel="brew" hidden>
+            <p class="install-panel-label">Standalone / macOS or Linux</p>
+            <pre tabindex="0" aria-label="Homebrew installation commands"><code data-install-command="brew"><span class="prompt">$</span> brew install IvoryHeart/tap/herdr-world-rc
+<span class="prompt">$</span> herdr-world
+
+<span class="success">→ open http://127.0.0.1:8787</span></code></pre>
+            <p class="install-panel-note">For a stable release, use <code>IvoryHeart/tap/herdr-world</code>. Stable and RC Formulae cannot be installed together.</p>
+          </section>
+
+          <section class="install-panel" id="install-panel-herdr" role="tabpanel" aria-labelledby="install-tab-herdr" data-install-panel="herdr" hidden>
+            <p class="install-panel-label">Herdr-managed / Herdr 0.8.2+</p>
+            <pre tabindex="0" aria-label="Herdr plugin installation commands"><code data-install-command="herdr"><span class="prompt">$</span> herdr plugin install IvoryHeart/herdr-world --ref v0.1.0-rc.8
+<span class="prompt">$</span> herdr plugin action invoke open --plugin ivoryheart.herdr-world</code></pre>
+            <p class="install-panel-note">Install registers and builds the plugin. The startup hook starts the bridge on the next Herdr server restore; <code>open</code> starts it now and requests the browser. Herdr itself is never installed or started by the plugin.</p>
+          </section>
+
+          <div class="cli-note">
+            <p class="install-panel-label">CLI / after installation</p>
+            <pre tabindex="0" aria-label="Herdr World CLI commands"><code data-cli-command><span class="prompt">$</span> herdr-world --help
+<span class="prompt">$</span> herdr-world --port 8791
+
+<span class="comment"># Herdr plugin users:</span>
+<span class="prompt">$</span> herdr plugin action invoke status --plugin ivoryheart.herdr-world
+<span class="prompt">$</span> herdr plugin action invoke doctor --plugin ivoryheart.herdr-world</code></pre>
+            <p class="install-panel-note">The Herdr plugin intentionally uses Herdr’s action menu and CLI namespace; it does not install a second global <code>herdr-world</code> executable.</p>
+          </div>
+
+          <p class="archive-note">Prefer a manual desktop archive? <a href="https://github.com/IvoryHeart/herdr-world/releases/tag/v0.1.0-rc.8">Download the current release candidate ↗</a></p>
         </div>
       </section>
 

--- a/site/site.js
+++ b/site/site.js
@@ -1,17 +1,52 @@
-const installCommand = `VERSION=v0.1.0-rc.8
-curl -fLO "https://github.com/IvoryHeart/herdr-world/releases/download/\${VERSION}/herdr-world-\${VERSION}-linux-x86_64.tar.gz"
-curl -fLO "https://github.com/IvoryHeart/herdr-world/releases/download/\${VERSION}/herdr-world-\${VERSION}-linux-x86_64.tar.gz.sha256"
-sha256sum --check "herdr-world-\${VERSION}-linux-x86_64.tar.gz.sha256"
-tar -xzf "herdr-world-\${VERSION}-linux-x86_64.tar.gz"
-cd "herdr-world-\${VERSION}-linux-x86_64"
-bin/herdr-world`;
+// Current public preview: v0.1.0-rc.8
+const installCommands = {
+  npm: `npm install --global @ivoryheart/herdr-world@next
+herdr-world`,
+  brew: `brew install IvoryHeart/tap/herdr-world-rc
+herdr-world`,
+  herdr: `herdr plugin install IvoryHeart/herdr-world --ref v0.1.0-rc.8
+herdr plugin action invoke open --plugin ivoryheart.herdr-world`,
+};
 
+const installTabs = [...document.querySelectorAll("[data-install-tab]")];
+const installPanels = [...document.querySelectorAll("[data-install-panel]")];
 const copyButton = document.querySelector("[data-copy-install]");
 const copyLabel = document.querySelector("[data-copy-label]");
 
+function selectInstallTab(name, shouldFocus = false) {
+  for (const tab of installTabs) {
+    const selected = tab.dataset.installTab === name;
+    tab.setAttribute("aria-selected", String(selected));
+    tab.tabIndex = selected ? 0 : -1;
+    if (selected && shouldFocus) tab.focus();
+  }
+
+  for (const panel of installPanels) {
+    panel.hidden = panel.dataset.installPanel !== name;
+  }
+}
+
+for (const [index, tab] of installTabs.entries()) {
+  tab.addEventListener("click", () => selectInstallTab(tab.dataset.installTab));
+  tab.addEventListener("keydown", (event) => {
+    if (!["ArrowLeft", "ArrowRight", "Home", "End"].includes(event.key)) return;
+    event.preventDefault();
+    const nextIndex = event.key === "Home"
+      ? 0
+      : event.key === "End"
+        ? installTabs.length - 1
+        : (index + (event.key === "ArrowRight" ? 1 : -1) + installTabs.length) % installTabs.length;
+    selectInstallTab(installTabs[nextIndex].dataset.installTab, true);
+  });
+}
+
 copyButton?.addEventListener("click", async () => {
+  const selectedTab = installTabs.find((tab) => tab.getAttribute("aria-selected") === "true");
+  const command = selectedTab ? installCommands[selectedTab.dataset.installTab] : null;
+  if (!command) return;
+
   try {
-    await navigator.clipboard.writeText(installCommand);
+    await navigator.clipboard.writeText(command);
     if (copyLabel) copyLabel.textContent = "Copied";
   } catch {
     if (copyLabel) copyLabel.textContent = "Select text";

--- a/site/styles.css
+++ b/site/styles.css
@@ -304,11 +304,13 @@ h1 em, h2 em {
 
 .install { display: grid; grid-template-columns: minmax(280px, 0.56fr) minmax(560px, 1fr); gap: clamp(50px, 8vw, 130px); }
 .install-heading p { max-width: 460px; color: var(--muted); font-size: 16px; line-height: 1.72; }
+.install-heading code { color: var(--lavender-bright); font: inherit; }
 .install-heading > a { display: inline-block; margin-top: 20px; color: var(--lavender); font: 600 11px/1 ui-monospace, monospace; letter-spacing: 0.08em; text-transform: uppercase; }
 .plugin-note { margin-top: 76px; padding-top: 28px; border-top: 1px solid var(--line); }
 .plugin-note .eyebrow { margin-bottom: 20px; }
 .plugin-note h3 { margin-bottom: 20px; color: var(--paper); font-size: clamp(28px, 3vw, 44px); line-height: 0.98; letter-spacing: -0.045em; }
 .plugin-note p { font-size: 14px; }
+.plugin-note strong { color: var(--paper); }
 .plugin-note pre { max-width: 100%; margin: 24px 0 0; padding: 16px; overflow: auto; color: #cfcede; background: #0c0d17; border: 1px solid #35344f; font: 500 11px/1.8 ui-monospace, SFMono-Regular, Menlo, monospace; }
 .plugin-note code { color: var(--lavender-bright); font-family: inherit; }
 .terminal-card { min-width: 0; align-self: center; overflow: hidden; border: 1px solid #4e4d70; background: #0c0d17; box-shadow: 14px 14px 0 rgb(184 181 255 / 7%); }
@@ -316,7 +318,23 @@ h1 em, h2 em {
 .terminal-title, .copy-button { font: 600 10px/1 ui-monospace, SFMono-Regular, Menlo, monospace; letter-spacing: 0.11em; }
 .copy-button { display: inline-flex; gap: 8px; padding: 8px 10px; color: var(--muted); border: 1px solid #454464; background: transparent; cursor: pointer; }
 .copy-button:hover, .copy-button:focus-visible { color: var(--paper); border-color: var(--lavender); }
-.terminal-card pre { max-width: 100%; margin: 0; padding: 28px; overflow: auto; color: #cfcede; font: 500 12px/1.85 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+.install-tabs { display: flex; overflow-x: auto; border-bottom: 1px solid #35344f; background: #111221; }
+.install-tab { flex: 1 0 auto; min-height: 48px; padding: 0 18px; color: var(--muted); border: 0; border-right: 1px solid #292940; background: transparent; cursor: pointer; font: 600 10px/1 ui-monospace, SFMono-Regular, Menlo, monospace; letter-spacing: 0.08em; text-transform: uppercase; }
+.install-tab:last-child { border-right: 0; }
+.install-tab:hover, .install-tab:focus-visible { color: var(--paper); background: rgb(184 181 255 / 7%); }
+.install-tab[aria-selected="true"] { color: var(--ink); background: var(--lavender); }
+.install-panel { padding: 25px 28px 0; }
+.install-panel[hidden] { display: none; }
+.install-panel-label { margin: 0 0 17px; color: var(--amber); font: 600 10px/1.4 ui-monospace, SFMono-Regular, Menlo, monospace; letter-spacing: 0.11em; text-transform: uppercase; }
+.install-panel pre, .cli-note pre { max-width: 100%; margin: 0; padding: 0; overflow: auto; color: #cfcede; font: 500 12px/1.85 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+.install-panel-note { margin: 18px 0 0; color: var(--muted); font-size: 12px; line-height: 1.65; }
+.install-panel-note code { color: var(--lavender-bright); font-family: inherit; }
+.cli-note { margin: 28px; padding-top: 24px; border-top: 1px solid #35344f; }
+.cli-note .install-panel-label { margin-bottom: 17px; }
+.cli-note .install-panel-note { margin-bottom: 0; }
+.archive-note { margin: 0; padding: 22px 28px 26px; color: #8b8a9f; border-top: 1px solid #35344f; font: 500 11px/1.6 ui-monospace, SFMono-Regular, Menlo, monospace; }
+.archive-note a { color: var(--lavender); }
+.archive-note a:hover, .archive-note a:focus-visible { color: var(--paper); }
 .prompt { color: var(--pink); }
 .command { color: var(--lavender-bright); }
 .comment { color: #8b8a9f; }
@@ -376,7 +394,10 @@ footer p { max-width: 550px; margin: 0; }
   .office-strip { grid-template-columns: 1fr; padding: 90px 24px; }
   .phone-frame { width: min(270px, 88%); margin-top: 20px; }
   .install h2, .manifesto h2, .principles h2, .office-strip h2 { font-size: clamp(42px, 13vw, 68px); }
-  .terminal-card pre { padding: 22px 18px; font-size: 11px; }
+  .install-panel { padding-inline: 18px; }
+  .install-panel pre, .cli-note pre { font-size: 11px; }
+  .cli-note { margin-inline: 18px; }
+  .archive-note { padding-inline: 18px; }
   .principle-list article { min-height: 250px; }
   .principle-list article > span { margin-bottom: 54px; }
   .final-cta { min-height: 620px; padding-inline: 10px; }


### PR DESCRIPTION
Summary: replace the archive-first site install block with npm, Homebrew, and Herdr plugin tabs; add post-install CLI commands and a manual archive fallback; make tabs keyboard accessible and copy selected commands; document Herdr's native action/CLI model. The herdr-plugin GitHub topic was also added. Validation: npm run check, npm run test:pages, node --check site/site.js, git diff --check.