### PR TITLE
docs: simplify primary install commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
 - Updated the project site with tabbed npm, Homebrew, and Herdr plugin installation paths plus a
   concise CLI quick reference.
   [Herdr World PR #42](https://github.com/IvoryHeart/herdr-world/pull/42)
+- Kept the primary install tabs to the two commands users need and moved archive and lifecycle
+  commands into a collapsed advanced CLI section.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
   [Herdr World PR #42](https://github.com/IvoryHeart/herdr-world/pull/42)
 - Kept the primary install tabs to the two commands users need and moved archive and lifecycle
   commands into a collapsed advanced CLI section.
+  [Herdr World PR #43](https://github.com/IvoryHeart/herdr-world/pull/43)
 
 ### Fixed
 

--- a/scripts/pages.test.mjs
+++ b/scripts/pages.test.mjs
@@ -55,7 +55,10 @@ test("the Pages artifact is self-contained and release-accurate", () => {
   assert.match(html, /npm install --global @ivoryheart\/herdr-world@next/);
   assert.match(html, /brew install IvoryHeart\/tap\/herdr-world-rc/);
   assert.match(html, new RegExp("herdr plugin install IvoryHeart/herdr-world --ref " + currentRelease));
-  assert.match(html, /data-cli-command/);
+  assert.match(html, /<details class="cli-note">/);
+  assert.match(html, /data-cli-command>VERSION=v0\.1\.0-rc\.8/);
+  assert.match(html, /curl -fLO .*herdr-world-\$\{VERSION\}-linux-x86_64\.tar\.gz/);
+  assert.match(html, /tar -xzf .*herdr-world-\$\{VERSION\}-linux-x86_64\.tar\.gz/);
   assert.match(readFileSync(join(output, "site.js"), "utf8"), /data-install-tab/);
   assert.doesNotMatch(html, /(?:src|href)="\/(?!\/)/, "local references must be relative");
   assert.doesNotMatch(html, /file:\/\//, "local filesystem URLs must not ship");

--- a/site/index.html
+++ b/site/index.html
@@ -129,7 +129,7 @@
           <div class="plugin-note">
             <p class="eyebrow">Herdr plugin / native lifecycle</p>
             <h3>Install once.<br />Wake with Herdr.</h3>
-            <p>Herdr’s startup hook restores the bridge when the next Herdr server starts. It does not open a browser automatically. Use Herdr’s <strong>Open Herdr World</strong> action, or the CLI command shown below, when you want to open the web client now.</p>
+            <p>Herdr restores the bridge on startup. Use Herdr’s <strong>Open Herdr World</strong> action to open the web client now.</p>
             <a href="https://github.com/IvoryHeart/herdr-world#herdr-plugin">Read plugin lifecycle ↗</a>
           </div>
         </div>
@@ -148,18 +148,14 @@
           <section class="install-panel" id="install-panel-npm" role="tabpanel" aria-labelledby="install-tab-npm" data-install-panel="npm">
             <p class="install-panel-label">Standalone / Node.js 22.14+</p>
             <pre tabindex="0" aria-label="npm installation commands"><code data-install-command="npm"><span class="prompt">$</span> npm install --global @ivoryheart/herdr-world@next
-<span class="prompt">$</span> herdr-world
-
-<span class="success">→ open http://127.0.0.1:8787</span></code></pre>
+<span class="prompt">$</span> herdr-world</code></pre>
             <p class="install-panel-note">The npm package includes the tested Linux x64, macOS ARM64, and macOS Intel bridges.</p>
           </section>
 
           <section class="install-panel" id="install-panel-brew" role="tabpanel" aria-labelledby="install-tab-brew" data-install-panel="brew" hidden>
             <p class="install-panel-label">Standalone / macOS or Linux</p>
             <pre tabindex="0" aria-label="Homebrew installation commands"><code data-install-command="brew"><span class="prompt">$</span> brew install IvoryHeart/tap/herdr-world-rc
-<span class="prompt">$</span> herdr-world
-
-<span class="success">→ open http://127.0.0.1:8787</span></code></pre>
+<span class="prompt">$</span> herdr-world</code></pre>
             <p class="install-panel-note">For a stable release, use <code>IvoryHeart/tap/herdr-world</code>. Stable and RC Formulae cannot be installed together.</p>
           </section>
 
@@ -170,16 +166,28 @@
             <p class="install-panel-note">Install registers and builds the plugin. The startup hook starts the bridge on the next Herdr server restore; <code>open</code> starts it now and requests the browser. Herdr itself is never installed or started by the plugin.</p>
           </section>
 
-          <div class="cli-note">
-            <p class="install-panel-label">CLI / after installation</p>
-            <pre tabindex="0" aria-label="Herdr World CLI commands"><code data-cli-command><span class="prompt">$</span> herdr-world --help
+          <details class="cli-note">
+            <summary>CLI / advanced installation and lifecycle</summary>
+            <div class="cli-note-content">
+              <p class="install-panel-label">Manual release archive / Linux x86-64</p>
+              <pre tabindex="0" aria-label="CLI archive installation commands"><code data-cli-command>VERSION=v0.1.0-rc.8
+<span class="prompt">$</span> curl -fLO "https://github.com/IvoryHeart/herdr-world/releases/download/${VERSION}/herdr-world-${VERSION}-linux-x86_64.tar.gz"
+<span class="prompt">$</span> curl -fLO "https://github.com/IvoryHeart/herdr-world/releases/download/${VERSION}/herdr-world-${VERSION}-linux-x86_64.tar.gz.sha256"
+<span class="prompt">$</span> sha256sum --check "herdr-world-${VERSION}-linux-x86_64.tar.gz.sha256"
+<span class="prompt">$</span> tar -xzf "herdr-world-${VERSION}-linux-x86_64.tar.gz"
+<span class="prompt">$</span> cd "herdr-world-${VERSION}-linux-x86_64"
+<span class="prompt">$</span> bin/herdr-world</code></pre>
+
+              <p class="install-panel-label cli-runtime-label">Runtime and Herdr plugin commands</p>
+              <pre tabindex="0" aria-label="Herdr World CLI runtime commands"><code><span class="prompt">$</span> herdr-world --help
 <span class="prompt">$</span> herdr-world --port 8791
 
 <span class="comment"># Herdr plugin users:</span>
 <span class="prompt">$</span> herdr plugin action invoke status --plugin ivoryheart.herdr-world
 <span class="prompt">$</span> herdr plugin action invoke doctor --plugin ivoryheart.herdr-world</code></pre>
-            <p class="install-panel-note">The Herdr plugin intentionally uses Herdr’s action menu and CLI namespace; it does not install a second global <code>herdr-world</code> executable.</p>
-          </div>
+              <p class="install-panel-note">The Herdr plugin intentionally uses Herdr’s action menu and CLI namespace; it does not install a second global <code>herdr-world</code> executable.</p>
+            </div>
+          </details>
 
           <p class="archive-note">Prefer a manual desktop archive? <a href="https://github.com/IvoryHeart/herdr-world/releases/tag/v0.1.0-rc.8">Download the current release candidate ↗</a></p>
         </div>

--- a/site/styles.css
+++ b/site/styles.css
@@ -329,8 +329,14 @@ h1 em, h2 em {
 .install-panel pre, .cli-note pre { max-width: 100%; margin: 0; padding: 0; overflow: auto; color: #cfcede; font: 500 12px/1.85 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
 .install-panel-note { margin: 18px 0 0; color: var(--muted); font-size: 12px; line-height: 1.65; }
 .install-panel-note code { color: var(--lavender-bright); font-family: inherit; }
-.cli-note { margin: 28px; padding-top: 24px; border-top: 1px solid #35344f; }
+.cli-note { margin: 28px; border-top: 1px solid #35344f; }
+.cli-note summary { padding: 24px 0; color: var(--amber); cursor: pointer; font: 600 10px/1.4 ui-monospace, SFMono-Regular, Menlo, monospace; letter-spacing: 0.11em; text-transform: uppercase; }
+.cli-note summary::-webkit-details-marker { display: none; }
+.cli-note summary::after { float: right; color: var(--lavender); content: "+"; font-size: 16px; line-height: 0.75; }
+.cli-note[open] summary::after { content: "−"; }
+.cli-note-content { padding-bottom: 24px; }
 .cli-note .install-panel-label { margin-bottom: 17px; }
+.cli-runtime-label { margin-top: 28px; padding-top: 24px; border-top: 1px solid #35344f; }
 .cli-note .install-panel-note { margin-bottom: 0; }
 .archive-note { margin: 0; padding: 22px 28px 26px; color: #8b8a9f; border-top: 1px solid #35344f; font: 500 11px/1.6 ui-monospace, SFMono-Regular, Menlo, monospace; }
 .archive-note a { color: var(--lavender); }


### PR DESCRIPTION
Keep the npm, Homebrew, and Herdr install tabs focused on the two commands users need. Move the tar download/checksum/extract flow and runtime/plugin lifecycle commands into a collapsed Advanced CLI section. Shorten the Herdr lifecycle copy and extend Pages coverage for the advanced archive commands. Validation: npm run test:pages, node --check site/site.js, git diff --check.