### PR TITLE
docs: call the install tab CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@
 - Split the installation card into npm, Homebrew, Herdr plugin, and CLI archive tabs, with
   method-specific advanced instructions and preview/stable channel guidance.
   [Herdr World PR #44](https://github.com/IvoryHeart/herdr-world/pull/44)
+- Renamed the user-facing archive tab to `CLI` while keeping archive details in the CLI panel.
+  [Herdr World PR #45](https://github.com/IvoryHeart/herdr-world/pull/45)
 
 ### Fixed
 

--- a/scripts/pages.test.mjs
+++ b/scripts/pages.test.mjs
@@ -53,6 +53,7 @@ test("the Pages artifact is self-contained and release-accurate", () => {
   assert.match(html, /data-install-tab="brew"/);
   assert.match(html, /data-install-tab="herdr"/);
   assert.match(html, /data-install-tab="cli"/);
+  assert.match(html, /data-install-tab="cli">CLI<\/button>/);
   assert.match(html, /npm install --global @ivoryheart\/herdr-world@next/);
   assert.ok(html.includes(`@ivoryheart/herdr-world@${currentRelease.slice(1)}`));
   assert.match(html, /brew install IvoryHeart\/tap\/herdr-world-rc/);

--- a/site/index.html
+++ b/site/index.html
@@ -143,7 +143,7 @@
             <button class="install-tab" type="button" role="tab" id="install-tab-npm" aria-controls="install-panel-npm" aria-selected="true" tabindex="0" data-install-tab="npm">npm</button>
             <button class="install-tab" type="button" role="tab" id="install-tab-brew" aria-controls="install-panel-brew" aria-selected="false" tabindex="-1" data-install-tab="brew">Homebrew</button>
             <button class="install-tab" type="button" role="tab" id="install-tab-herdr" aria-controls="install-panel-herdr" aria-selected="false" tabindex="-1" data-install-tab="herdr">Herdr plugin</button>
-            <button class="install-tab" type="button" role="tab" id="install-tab-cli" aria-controls="install-panel-cli" aria-selected="false" tabindex="-1" data-install-tab="cli">CLI archive</button>
+            <button class="install-tab" type="button" role="tab" id="install-tab-cli" aria-controls="install-panel-cli" aria-selected="false" tabindex="-1" data-install-tab="cli">CLI</button>
           </div>
 
           <section class="install-panel" id="install-panel-npm" role="tabpanel" aria-labelledby="install-tab-npm" data-install-panel="npm">


### PR DESCRIPTION
## Summary
- rename the installation tab from `CLI archive` to `CLI`
- keep the manual release archive wording inside the CLI panel where it explains the implementation

## Validation
- `npm run test:pages`
