### PR TITLE
Release v0.1.0-rc.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@
 
 ### Added
 
+### Changed
+
+### Fixed
+
+### Removed
+
+## [0.1.0-rc.9] - 2026-08-29
+
+### Added
+
 - Added a Herdr-native startup hook that starts the plugin bridge on the next Herdr server restore,
   with documented install, crash-restart, and port-conflict behavior.
   [Herdr World PR #41](https://github.com/IvoryHeart/herdr-world/pull/41)
@@ -23,10 +33,6 @@
   [Herdr World PR #44](https://github.com/IvoryHeart/herdr-world/pull/44)
 - Renamed the user-facing archive tab to `CLI` while keeping archive details in the CLI panel.
   [Herdr World PR #45](https://github.com/IvoryHeart/herdr-world/pull/45)
-
-### Fixed
-
-### Removed
 
 ## [0.1.0-rc.8] - 2026-08-29
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ navigation, multi-client viewing, mobile input controls, synchronized pane selec
 visualizations. The upstream relationship and synchronization record are documented in
 [`UPSTREAM.md`](UPSTREAM.md).
 
-> **Public preview:** [`v0.1.0-rc.8`](https://github.com/IvoryHeart/herdr-world/releases/tag/v0.1.0-rc.8)
+> **Public preview:** [`v0.1.0-rc.9`](https://github.com/IvoryHeart/herdr-world/releases/tag/v0.1.0-rc.9)
 > provides native archives for Linux x86-64 and macOS on Apple Silicon and Intel. Herdr World
 > currently requires Herdr `v0.8.2` or newer reporting terminal protocol `20`.
 
@@ -113,8 +113,8 @@ Android development also needs a JDK and Android SDK. See [docs/android.md](docs
 
 | Platform | Status |
 | --- | --- |
-| Linux x86-64 | Available in [`v0.1.0-rc.8`](https://github.com/IvoryHeart/herdr-world/releases/tag/v0.1.0-rc.8) |
-| macOS ARM64 / x86-64 | Available unsigned in [`v0.1.0-rc.8`](https://github.com/IvoryHeart/herdr-world/releases/tag/v0.1.0-rc.8) |
+| Linux x86-64 | Available in [`v0.1.0-rc.9`](https://github.com/IvoryHeart/herdr-world/releases/tag/v0.1.0-rc.9) |
+| macOS ARM64 / x86-64 | Available unsigned in [`v0.1.0-rc.9`](https://github.com/IvoryHeart/herdr-world/releases/tag/v0.1.0-rc.9) |
 | Android | Source and debug build workflow are available; no signed public APK yet |
 
 ## Quick Start From Release
@@ -123,7 +123,7 @@ Choose `linux-x86_64`, `macos-arm64` (Apple Silicon), or `macos-x86_64` (Intel),
 verify the current release candidate:
 
 ```bash
-VERSION=v0.1.0-rc.8
+VERSION=v0.1.0-rc.9
 PLATFORM=linux-x86_64
 curl -fLO "https://github.com/IvoryHeart/herdr-world/releases/download/${VERSION}/herdr-world-${VERSION}-${PLATFORM}.tar.gz"
 curl -fLO "https://github.com/IvoryHeart/herdr-world/releases/download/${VERSION}/herdr-world-${VERSION}-${PLATFORM}.tar.gz.sha256"

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -1,6 +1,6 @@
 id = "ivoryheart.herdr-world"
 name = "Herdr World"
-version = "0.1.0-rc.8"
+version = "0.1.0-rc.9"
 min_herdr_version = "0.8.2"
 description = "Browser and mobile client for monitoring and controlling Herdr agents."
 platforms = ["linux", "macos"]

--- a/release.json
+++ b/release.json
@@ -1,3 +1,3 @@
 {
-  "current": "v0.1.0-rc.8"
+  "current": "v0.1.0-rc.9"
 }

--- a/scripts/release-version.mjs
+++ b/scripts/release-version.mjs
@@ -128,6 +128,10 @@ export function stampCurrentRelease(
       updated = updated
         .replaceAll(`@${npmDistributionTag(current)}`, `@${npmDistributionTag(newTag)}`)
         .replaceAll(
+          `@${releaseVersion(current)}`,
+          `@${releaseVersion(newTag)}`,
+        )
+        .replaceAll(
           `tap/${homebrewFormulaName(current)}`,
           `tap/${homebrewFormulaName(newTag)}`,
         )

--- a/scripts/release-version.test.mjs
+++ b/scripts/release-version.test.mjs
@@ -117,17 +117,18 @@ test("switches site install channels when moving from an RC to stable", () => {
     writeFileSync(join(root, "README.md"), "v1.2.3-rc.1\n");
     writeFileSync(
       join(root, "site", "index.html"),
-      "v1.2.3-rc.1 @next tap/herdr-world-rc upgrade herdr-world-rc uninstall herdr-world-rc\n",
+      "v1.2.3-rc.1 @1.2.3-rc.1 @next tap/herdr-world-rc upgrade herdr-world-rc uninstall herdr-world-rc\n",
     );
     writeFileSync(
       join(root, "site", "site.js"),
-      "v1.2.3-rc.1 @next tap/herdr-world-rc upgrade herdr-world-rc uninstall herdr-world-rc\n",
+      "v1.2.3-rc.1 @1.2.3-rc.1 @next tap/herdr-world-rc upgrade herdr-world-rc uninstall herdr-world-rc\n",
     );
 
     stampCurrentRelease("v1.2.3", root);
 
     for (const relativePath of ["site/index.html", "site/site.js"]) {
       const contents = readFileSync(join(root, relativePath), "utf8");
+      assert.match(contents, /@1\.2\.3/);
       assert.match(contents, /@latest/);
       assert.match(contents, /tap\/herdr-world/);
       assert.match(contents, /upgrade herdr-world/);

--- a/site/index.html
+++ b/site/index.html
@@ -44,7 +44,7 @@
           <h1 id="hero-title">Your agents.<br /><em>One office.</em></h1>
           <p class="hero-intro">Herdr World turns live Herdr sessions into one visual workspace: terminal-first Spaces, a multi-host Pixel Office, and the controls to move between them without losing context.</p>
           <div class="hero-actions">
-            <a class="button button-primary" href="https://github.com/IvoryHeart/herdr-world/releases/tag/v0.1.0-rc.8">Download the RC <span aria-hidden="true">↓</span></a>
+            <a class="button button-primary" href="https://github.com/IvoryHeart/herdr-world/releases/tag/v0.1.0-rc.9">Download the RC <span aria-hidden="true">↓</span></a>
             <a class="button button-secondary" href="#install">View install</a>
           </div>
           <dl class="hero-facts">
@@ -155,7 +155,7 @@
               <summary>Advanced npm options</summary>
               <div class="install-advanced-content">
                 <p class="install-panel-label">Pin a version or choose a session</p>
-                <pre tabindex="0" aria-label="Advanced npm commands"><code><span class="prompt">$</span> npm install --global @ivoryheart/herdr-world@0.1.0-rc.8
+                <pre tabindex="0" aria-label="Advanced npm commands"><code><span class="prompt">$</span> npm install --global @ivoryheart/herdr-world@0.1.0-rc.9
 <span class="prompt">$</span> herdr-world --session NAME
 <span class="prompt">$</span> herdr-world --port 8791</code></pre>
                 <p class="install-panel-note">Release candidates use npm’s <code>next</code> channel. Stable releases use <code>latest</code>; pin an exact version when you need a fixed build.</p>
@@ -182,7 +182,7 @@
 
           <section class="install-panel" id="install-panel-herdr" role="tabpanel" aria-labelledby="install-tab-herdr" data-install-panel="herdr" hidden>
             <p class="install-panel-label">Herdr-managed / Herdr 0.8.2+</p>
-            <pre tabindex="0" aria-label="Herdr plugin installation commands"><code data-install-command="herdr"><span class="prompt">$</span> herdr plugin install IvoryHeart/herdr-world --ref v0.1.0-rc.8
+            <pre tabindex="0" aria-label="Herdr plugin installation commands"><code data-install-command="herdr"><span class="prompt">$</span> herdr plugin install IvoryHeart/herdr-world --ref v0.1.0-rc.9
 <span class="prompt">$</span> herdr plugin action invoke open --plugin ivoryheart.herdr-world</code></pre>
             <p class="install-panel-note">Install registers and builds the plugin. The <code>open</code> action starts the bridge for an already-running Herdr server.</p>
             <details class="install-advanced">
@@ -201,14 +201,14 @@
 
           <section class="install-panel" id="install-panel-cli" role="tabpanel" aria-labelledby="install-tab-cli" data-install-panel="cli" hidden>
             <p class="install-panel-label">Manual release archive / Linux x86-64, macOS ARM64, or macOS Intel</p>
-            <pre tabindex="0" aria-label="CLI archive installation commands"><code data-install-command="cli">VERSION=v0.1.0-rc.8
+            <pre tabindex="0" aria-label="CLI archive installation commands"><code data-install-command="cli">VERSION=v0.1.0-rc.9
 PLATFORM=linux-x86_64 # or macos-arm64 / macos-x86_64
 <span class="prompt">$</span> curl -fLO "https://github.com/IvoryHeart/herdr-world/releases/download/${VERSION}/herdr-world-${VERSION}-${PLATFORM}.tar.gz"
 <span class="prompt">$</span> curl -fLO "https://github.com/IvoryHeart/herdr-world/releases/download/${VERSION}/herdr-world-${VERSION}-${PLATFORM}.tar.gz.sha256"
 <span class="prompt">$</span> tar -xzf "herdr-world-${VERSION}-${PLATFORM}.tar.gz"
 <span class="prompt">$</span> cd "herdr-world-${VERSION}-${PLATFORM}"
 <span class="prompt">$</span> bin/herdr-world</code></pre>
-            <p class="install-panel-note">Use <code>sha256sum --check</code> on Linux or <code>shasum -a 256 --check</code> on macOS before extracting. <a href="https://github.com/IvoryHeart/herdr-world/releases/tag/v0.1.0-rc.8">Download the current release candidate ↗</a></p>
+            <p class="install-panel-note">Use <code>sha256sum --check</code> on Linux or <code>shasum -a 256 --check</code> on macOS before extracting. <a href="https://github.com/IvoryHeart/herdr-world/releases/tag/v0.1.0-rc.9">Download the current release candidate ↗</a></p>
             <details class="install-advanced">
               <summary>Advanced CLI options</summary>
               <div class="install-advanced-content">
@@ -239,7 +239,7 @@ PLATFORM=linux-x86_64 # or macos-arm64 / macos-x86_64
         <p class="eyebrow">The office is open</p>
         <h2 id="cta-title">Bring your agents<br /><em>into the room.</em></h2>
         <div class="hero-actions">
-          <a class="button button-primary" href="https://github.com/IvoryHeart/herdr-world/releases/tag/v0.1.0-rc.8">Download v0.1.0-rc.8</a>
+          <a class="button button-primary" href="https://github.com/IvoryHeart/herdr-world/releases/tag/v0.1.0-rc.9">Download v0.1.0-rc.9</a>
           <a class="button button-secondary" href="https://github.com/IvoryHeart/herdr-world/discussions">Join the discussion</a>
         </div>
       </section>

--- a/site/site.js
+++ b/site/site.js
@@ -1,12 +1,12 @@
-// Current public preview: v0.1.0-rc.8
+// Current public preview: v0.1.0-rc.9
 const installCommands = {
   npm: `npm install --global @ivoryheart/herdr-world@next
 herdr-world`,
   brew: `brew install IvoryHeart/tap/herdr-world-rc
 herdr-world`,
-  herdr: `herdr plugin install IvoryHeart/herdr-world --ref v0.1.0-rc.8
+  herdr: `herdr plugin install IvoryHeart/herdr-world --ref v0.1.0-rc.9
 herdr plugin action invoke open --plugin ivoryheart.herdr-world`,
-  cli: `VERSION=v0.1.0-rc.8
+  cli: `VERSION=v0.1.0-rc.9
 PLATFORM=linux-x86_64
 curl -fLO "https://github.com/IvoryHeart/herdr-world/releases/download/\${VERSION}/herdr-world-\${VERSION}-\${PLATFORM}.tar.gz"
 curl -fLO "https://github.com/IvoryHeart/herdr-world/releases/download/\${VERSION}/herdr-world-\${VERSION}-\${PLATFORM}.tar.gz.sha256"


### PR DESCRIPTION
## Release candidate

This PR prepares `v0.1.0-rc.9` from the latest `main`.

Included release-facing updates:
- stamps README, Pages, plugin manifest, and release metadata to `v0.1.0-rc.9`
- stamps the exact npm version in the Pages advanced instructions
- publishes the RC9 changelog section while retaining a fresh Unreleased section
- fixes release stamping so exact npm pins follow future stable/RC transitions

## Validation
- Full `npm run check` passed locally.
- Three-platform preflight passed on the parent `main` commit before the final tab-label merge; the only delta since then is the CLI tab label and this release metadata.

After merge, push only tag `v0.1.0-rc.9` to trigger the publication workflow.
