### PR TITLE
fix: accept squash-merged release commits

### DIFF
--- a/scripts/release-version.mjs
+++ b/scripts/release-version.mjs
@@ -41,6 +41,11 @@ export function escapeRegex(value) {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
+export function isReleaseCommitSubject(subject, tag) {
+  const expected = `Release ${normalizeReleaseTag(tag)}`;
+  return subject === expected || new RegExp(`^${escapeRegex(expected)} \\(#\\d+\\)$`).test(subject);
+}
+
 export function releaseVersion(value) {
   return parseReleaseTag(value).tag.slice(1);
 }

--- a/scripts/release-version.test.mjs
+++ b/scripts/release-version.test.mjs
@@ -10,6 +10,7 @@ import {
   compareReleaseTags,
   escapeRegex,
   homebrewFormulaName,
+  isReleaseCommitSubject,
   npmDistributionTag,
   normalizeReleaseTag,
   parseReleaseTag,
@@ -56,6 +57,14 @@ test("maps release types to their public install channels", () => {
   assert.equal(npmDistributionTag("v1.2.3"), "latest");
   assert.equal(homebrewFormulaName("v1.2.3-rc.1"), "herdr-world-rc");
   assert.equal(homebrewFormulaName("v1.2.3"), "herdr-world");
+});
+
+test("accepts exact and GitHub squash-merged release commit subjects", () => {
+  assert.equal(isReleaseCommitSubject("Release v1.2.3", "v1.2.3"), true);
+  assert.equal(isReleaseCommitSubject("Release v1.2.3-rc.9 (#46)", "v1.2.3-rc.9"), true);
+  assert.equal(isReleaseCommitSubject("Release v1.2.3-rc.9 (#)", "v1.2.3-rc.9"), false);
+  assert.equal(isReleaseCommitSubject("Release v1.2.3-rc.9 (#46) extra", "v1.2.3-rc.9"), false);
+  assert.equal(isReleaseCommitSubject("Release v1.2.4 (#46)", "v1.2.3-rc.9"), false);
 });
 
 test("escapes release versions for literal changelog matching", () => {

--- a/scripts/validate-release.mjs
+++ b/scripts/validate-release.mjs
@@ -6,6 +6,7 @@ import { join } from "node:path";
 import {
   assertCurrentReleaseReferences,
   escapeRegex,
+  isReleaseCommitSubject,
   normalizeReleaseTag,
   releaseVersion,
 } from "./release-version.mjs";
@@ -57,8 +58,8 @@ try {
 }
 
 const subject = output("git", ["show", "-s", "--format=%s", tagSha]);
-if (subject !== `Release ${tag}`) {
-  fail(`tagged commit subject must be exactly Release ${tag}; found ${subject}`);
+if (!isReleaseCommitSubject(subject, tag)) {
+  fail(`tagged commit subject must be Release ${tag} or GitHub's squash-merge form Release ${tag} (#<number>); found ${subject}`);
 }
 
 try {


### PR DESCRIPTION
## Summary
- accept GitHub squash-merge release subjects such as `Release v0.1.0-rc.9 (#46)`
- retain strict tag/version matching and reject unrelated subjects
- add regression coverage

## Release context
The RC9 tag workflow was blocked because PR #46 was squash-merged and GitHub appended its PR number to the release commit subject. RC9 was not published.

## Validation
- `npm run test:release`