### PR TITLE
Release v0.1.0-rc.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@
 
 ### Removed
 
+## [0.1.0-rc.10] - 2026-08-29
+
+### Fixed
+
+- Accepted GitHub's squash-merge suffix on protected release commit subjects so the release
+  provenance gate matches the repository's PR merge strategy.
+  [Herdr World PR #47](https://github.com/IvoryHeart/herdr-world/pull/47)
+
 ## [0.1.0-rc.9] - 2026-08-29
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ navigation, multi-client viewing, mobile input controls, synchronized pane selec
 visualizations. The upstream relationship and synchronization record are documented in
 [`UPSTREAM.md`](UPSTREAM.md).
 
-> **Public preview:** [`v0.1.0-rc.9`](https://github.com/IvoryHeart/herdr-world/releases/tag/v0.1.0-rc.9)
+> **Public preview:** [`v0.1.0-rc.10`](https://github.com/IvoryHeart/herdr-world/releases/tag/v0.1.0-rc.10)
 > provides native archives for Linux x86-64 and macOS on Apple Silicon and Intel. Herdr World
 > currently requires Herdr `v0.8.2` or newer reporting terminal protocol `20`.
 
@@ -113,8 +113,8 @@ Android development also needs a JDK and Android SDK. See [docs/android.md](docs
 
 | Platform | Status |
 | --- | --- |
-| Linux x86-64 | Available in [`v0.1.0-rc.9`](https://github.com/IvoryHeart/herdr-world/releases/tag/v0.1.0-rc.9) |
-| macOS ARM64 / x86-64 | Available unsigned in [`v0.1.0-rc.9`](https://github.com/IvoryHeart/herdr-world/releases/tag/v0.1.0-rc.9) |
+| Linux x86-64 | Available in [`v0.1.0-rc.10`](https://github.com/IvoryHeart/herdr-world/releases/tag/v0.1.0-rc.10) |
+| macOS ARM64 / x86-64 | Available unsigned in [`v0.1.0-rc.10`](https://github.com/IvoryHeart/herdr-world/releases/tag/v0.1.0-rc.10) |
 | Android | Source and debug build workflow are available; no signed public APK yet |
 
 ## Quick Start From Release
@@ -123,7 +123,7 @@ Choose `linux-x86_64`, `macos-arm64` (Apple Silicon), or `macos-x86_64` (Intel),
 verify the current release candidate:
 
 ```bash
-VERSION=v0.1.0-rc.9
+VERSION=v0.1.0-rc.10
 PLATFORM=linux-x86_64
 curl -fLO "https://github.com/IvoryHeart/herdr-world/releases/download/${VERSION}/herdr-world-${VERSION}-${PLATFORM}.tar.gz"
 curl -fLO "https://github.com/IvoryHeart/herdr-world/releases/download/${VERSION}/herdr-world-${VERSION}-${PLATFORM}.tar.gz.sha256"

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -1,6 +1,6 @@
 id = "ivoryheart.herdr-world"
 name = "Herdr World"
-version = "0.1.0-rc.9"
+version = "0.1.0-rc.10"
 min_herdr_version = "0.8.2"
 description = "Browser and mobile client for monitoring and controlling Herdr agents."
 platforms = ["linux", "macos"]

--- a/release.json
+++ b/release.json
@@ -1,3 +1,3 @@
 {
-  "current": "v0.1.0-rc.9"
+  "current": "v0.1.0-rc.10"
 }

--- a/site/index.html
+++ b/site/index.html
@@ -44,7 +44,7 @@
           <h1 id="hero-title">Your agents.<br /><em>One office.</em></h1>
           <p class="hero-intro">Herdr World turns live Herdr sessions into one visual workspace: terminal-first Spaces, a multi-host Pixel Office, and the controls to move between them without losing context.</p>
           <div class="hero-actions">
-            <a class="button button-primary" href="https://github.com/IvoryHeart/herdr-world/releases/tag/v0.1.0-rc.9">Download the RC <span aria-hidden="true">↓</span></a>
+            <a class="button button-primary" href="https://github.com/IvoryHeart/herdr-world/releases/tag/v0.1.0-rc.10">Download the RC <span aria-hidden="true">↓</span></a>
             <a class="button button-secondary" href="#install">View install</a>
           </div>
           <dl class="hero-facts">
@@ -155,7 +155,7 @@
               <summary>Advanced npm options</summary>
               <div class="install-advanced-content">
                 <p class="install-panel-label">Pin a version or choose a session</p>
-                <pre tabindex="0" aria-label="Advanced npm commands"><code><span class="prompt">$</span> npm install --global @ivoryheart/herdr-world@0.1.0-rc.9
+                <pre tabindex="0" aria-label="Advanced npm commands"><code><span class="prompt">$</span> npm install --global @ivoryheart/herdr-world@0.1.0-rc.10
 <span class="prompt">$</span> herdr-world --session NAME
 <span class="prompt">$</span> herdr-world --port 8791</code></pre>
                 <p class="install-panel-note">Release candidates use npm’s <code>next</code> channel. Stable releases use <code>latest</code>; pin an exact version when you need a fixed build.</p>
@@ -182,7 +182,7 @@
 
           <section class="install-panel" id="install-panel-herdr" role="tabpanel" aria-labelledby="install-tab-herdr" data-install-panel="herdr" hidden>
             <p class="install-panel-label">Herdr-managed / Herdr 0.8.2+</p>
-            <pre tabindex="0" aria-label="Herdr plugin installation commands"><code data-install-command="herdr"><span class="prompt">$</span> herdr plugin install IvoryHeart/herdr-world --ref v0.1.0-rc.9
+            <pre tabindex="0" aria-label="Herdr plugin installation commands"><code data-install-command="herdr"><span class="prompt">$</span> herdr plugin install IvoryHeart/herdr-world --ref v0.1.0-rc.10
 <span class="prompt">$</span> herdr plugin action invoke open --plugin ivoryheart.herdr-world</code></pre>
             <p class="install-panel-note">Install registers and builds the plugin. The <code>open</code> action starts the bridge for an already-running Herdr server.</p>
             <details class="install-advanced">
@@ -201,14 +201,14 @@
 
           <section class="install-panel" id="install-panel-cli" role="tabpanel" aria-labelledby="install-tab-cli" data-install-panel="cli" hidden>
             <p class="install-panel-label">Manual release archive / Linux x86-64, macOS ARM64, or macOS Intel</p>
-            <pre tabindex="0" aria-label="CLI archive installation commands"><code data-install-command="cli">VERSION=v0.1.0-rc.9
+            <pre tabindex="0" aria-label="CLI archive installation commands"><code data-install-command="cli">VERSION=v0.1.0-rc.10
 PLATFORM=linux-x86_64 # or macos-arm64 / macos-x86_64
 <span class="prompt">$</span> curl -fLO "https://github.com/IvoryHeart/herdr-world/releases/download/${VERSION}/herdr-world-${VERSION}-${PLATFORM}.tar.gz"
 <span class="prompt">$</span> curl -fLO "https://github.com/IvoryHeart/herdr-world/releases/download/${VERSION}/herdr-world-${VERSION}-${PLATFORM}.tar.gz.sha256"
 <span class="prompt">$</span> tar -xzf "herdr-world-${VERSION}-${PLATFORM}.tar.gz"
 <span class="prompt">$</span> cd "herdr-world-${VERSION}-${PLATFORM}"
 <span class="prompt">$</span> bin/herdr-world</code></pre>
-            <p class="install-panel-note">Use <code>sha256sum --check</code> on Linux or <code>shasum -a 256 --check</code> on macOS before extracting. <a href="https://github.com/IvoryHeart/herdr-world/releases/tag/v0.1.0-rc.9">Download the current release candidate ↗</a></p>
+            <p class="install-panel-note">Use <code>sha256sum --check</code> on Linux or <code>shasum -a 256 --check</code> on macOS before extracting. <a href="https://github.com/IvoryHeart/herdr-world/releases/tag/v0.1.0-rc.10">Download the current release candidate ↗</a></p>
             <details class="install-advanced">
               <summary>Advanced CLI options</summary>
               <div class="install-advanced-content">
@@ -239,7 +239,7 @@ PLATFORM=linux-x86_64 # or macos-arm64 / macos-x86_64
         <p class="eyebrow">The office is open</p>
         <h2 id="cta-title">Bring your agents<br /><em>into the room.</em></h2>
         <div class="hero-actions">
-          <a class="button button-primary" href="https://github.com/IvoryHeart/herdr-world/releases/tag/v0.1.0-rc.9">Download v0.1.0-rc.9</a>
+          <a class="button button-primary" href="https://github.com/IvoryHeart/herdr-world/releases/tag/v0.1.0-rc.10">Download v0.1.0-rc.10</a>
           <a class="button button-secondary" href="https://github.com/IvoryHeart/herdr-world/discussions">Join the discussion</a>
         </div>
       </section>

--- a/site/site.js
+++ b/site/site.js
@@ -1,12 +1,12 @@
-// Current public preview: v0.1.0-rc.9
+// Current public preview: v0.1.0-rc.10
 const installCommands = {
   npm: `npm install --global @ivoryheart/herdr-world@next
 herdr-world`,
   brew: `brew install IvoryHeart/tap/herdr-world-rc
 herdr-world`,
-  herdr: `herdr plugin install IvoryHeart/herdr-world --ref v0.1.0-rc.9
+  herdr: `herdr plugin install IvoryHeart/herdr-world --ref v0.1.0-rc.10
 herdr plugin action invoke open --plugin ivoryheart.herdr-world`,
-  cli: `VERSION=v0.1.0-rc.9
+  cli: `VERSION=v0.1.0-rc.10
 PLATFORM=linux-x86_64
 curl -fLO "https://github.com/IvoryHeart/herdr-world/releases/download/\${VERSION}/herdr-world-\${VERSION}-\${PLATFORM}.tar.gz"
 curl -fLO "https://github.com/IvoryHeart/herdr-world/releases/download/\${VERSION}/herdr-world-\${VERSION}-\${PLATFORM}.tar.gz.sha256"


### PR DESCRIPTION
## Release candidate

- promote the current public references and plugin manifest to `v0.1.0-rc.10`
- publish the release provenance fix from PR #47
- carry the release notes for the protected release workflow correction

## Validation
- `npm run check`

RC9 remains an unpublished, immutable tag because its workflow stopped at provenance validation before any distribution publication.