### PR TITLE
Release v0.1.0-rc.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,13 @@
 
 ### Fixed
 
-- Made the Herdr plugin release smoke deterministic across asynchronous startup-hook execution.
-
 ### Removed
+
+## [0.1.0-rc.11] - 2026-08-29
+
+### Fixed
+
+- Made the Herdr plugin release smoke deterministic across asynchronous startup-hook execution.
 
 ## [0.1.0-rc.10] - 2026-08-29
 


### PR DESCRIPTION
## Summary
- promote the RC11 changelog entry into the released section required by protected release provenance

This is a release bookkeeping correction for the already merged RC11 metadata PR; no product code changes are included. After merge, the immutable RC11 tag will be created at the corrected release commit.