### PR TITLE
fix: preserve Node metadata in plugin doctor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- Fixed the Herdr plugin doctor check to compare the active Node.js executable with the service record.
+
 ### Removed
 
 ## [0.1.0-rc.11] - 2026-08-29

--- a/scripts/herdr-world-plugin.mjs
+++ b/scripts/herdr-world-plugin.mjs
@@ -266,6 +266,10 @@ export function checkNode(nodePath, { runner = commandOutput } = {}) {
   return { path: path.resolve(nodePath), version: match[1] };
 }
 
+export function nodeMatchesRecord(record, node) {
+  return Boolean(record?.node_path && node?.path && record.node_path === node.path);
+}
+
 export function selectTarget({ platform = process.platform, arch = process.arch, glibcVersion } = {}) {
   const key = `${platform}-${arch}`;
   const target = SUPPORTED_TARGETS[key];
@@ -1454,8 +1458,9 @@ async function doctorAction({ root = ROOT, env = process.env, platform = process
   let config;
   if (directories) config = doctorCheck(checks, "configuration", () => loadConfig(directories.configDir));
   let node;
-  node = doctorCheck(checks, "Node.js version and absolute path", () => {
+  doctorCheck(checks, "Node.js version and absolute path", () => {
     const resolved = checkNode(resolveNode({ env }));
+    node = resolved;
     return `${resolved.version} at ${resolved.path}`;
   });
   doctorCheck(checks, "npm availability", () => {
@@ -1503,7 +1508,7 @@ async function doctorAction({ root = ROOT, env = process.env, platform = process
         const recorded = checkNode(record.node_path);
         return `${recorded.version} at ${recorded.path}`;
       });
-      if (node && record.node_path !== node.path) checks.push({ label: "current Node matches service", ok: false, detail: `record uses ${record.node_path}; current Node resolves to ${node.path}` });
+      if (node && !nodeMatchesRecord(record, node)) checks.push({ label: "current Node matches service", ok: false, detail: `record uses ${record.node_path}; current Node resolves to ${node.path}` });
       else if (node) checks.push({ label: "current Node matches service", ok: true, detail: node.path });
     }
   } else if (config) {

--- a/scripts/herdr-world-plugin.test.mjs
+++ b/scripts/herdr-world-plugin.test.mjs
@@ -16,6 +16,7 @@ import {
   choosePort,
   compareVersions,
   minimumVersionSatisfied,
+  nodeMatchesRecord,
   npmInstallArgs,
   parsePluginManifest,
   processMatchesRecord,
@@ -71,6 +72,13 @@ test("release versions use strict stable or numbered RC syntax", () => {
   assert.equal(minimumVersionSatisfied("22.13.9", MIN_NODE_VERSION), false);
   assert.equal(minimumVersionSatisfied("22.14.0-beta.1", MIN_NODE_VERSION), false);
   assert.throws(() => checkNode(process.execPath, { runner: () => "v22.13.9" }), /22.14.0 or newer/);
+});
+
+test("doctor compares the recorded service Node path with Node metadata", () => {
+  const record = { node_path: process.execPath };
+  assert.equal(nodeMatchesRecord(record, { path: process.execPath, version: "22.14.0" }), true);
+  assert.equal(nodeMatchesRecord(record, `${process.execPath}`), false);
+  assert.equal(nodeMatchesRecord(record, { path: "/missing/node", version: "22.14.0" }), false);
 });
 
 test("target selection enforces the published platform and libc matrix", () => {


### PR DESCRIPTION
## Summary
- preserve the structured Node.js metadata while rendering the doctor check
- make the recorded-service Node comparison pass for healthy installations
- add regression coverage and a changelog entry

## Validation
- `npm run check`

This fixes the Herdr plugin smoke failure observed in the published v0.1.0-rc.11 workflow; no release tag is modified.