### PR TITLE
test: wait for plugin startup completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- Synchronized the Herdr plugin release smoke with asynchronous startup-hook completion on macOS.
+
 ### Removed
 
 ## [0.1.0-rc.12] - 2026-08-29

--- a/scripts/herdr-world-plugin.test.mjs
+++ b/scripts/herdr-world-plugin.test.mjs
@@ -336,7 +336,9 @@ test("documents and tests the explicit stop-before-uninstall contract", () => {
   assert.match(packaging, /actions are asynchronous and target-scoped/);
   assert.match(smoke, /Installing .* while Herdr is stopped/);
   assert.match(smoke, /plugin install .*--ref/);
+  assert.match(smoke, /wait_for_startup/);
   assert.ok(smoke.indexOf('plugin install IvoryHeart/herdr-world') < smoke.indexOf('echo "Starting stock Herdr release smoke daemon and restoring the plugin service"'));
+  assert.ok(smoke.indexOf("wait_for_startup") < smoke.indexOf("wait_for_bridge http://127.0.0.1:8787"));
   assert.ok(smoke.indexOf("invoke_default stop") < smoke.indexOf('plugin uninstall "$PLUGIN_ID"'));
   assert.match(smoke, /no uninstall hook/);
 });

--- a/scripts/live-plugin-smoke.sh
+++ b/scripts/live-plugin-smoke.sh
@@ -163,6 +163,33 @@ process.stdin.on("end", () => {
   exit 1
 }
 
+wait_for_startup() {
+  local logs state
+  for _ in $(seq 1 100); do
+    logs="$(HERDR_SOCKET_PATH="$SOCKET_A" XDG_CONFIG_HOME="$CONFIG_HOME" XDG_DATA_HOME="$DATA_HOME" XDG_STATE_HOME="$STATE_HOME" \
+      "$HERDR_BIN" plugin log list --plugin "$PLUGIN_ID" --limit 100 2>/dev/null || true)"
+    state="$(node --input-type=module - "$logs" <<'NODE'
+try {
+  const value = JSON.parse(process.argv[2]);
+  const startup = value.result?.logs?.find((entry) => entry.event === "startup");
+  if (startup) process.stdout.write(JSON.stringify({ status: startup.status, stderr: startup.stderr ?? "" }));
+} catch {}
+NODE
+    )"
+    if [[ "$state" == *'"status":"succeeded"'* ]]; then return; fi
+    if [[ "$state" == *'"status":"failed"'* ]]; then
+      node --input-type=module - "$state" <<'NODE' >&2
+const value = JSON.parse(process.argv[2]);
+process.stderr.write(value.stderr || "Herdr plugin startup hook failed");
+NODE
+      return 1
+    fi
+    sleep 0.2
+  done
+  echo "Herdr plugin startup hook did not finish" >&2
+  exit 1
+}
+
 # Herdr runs startup hooks asynchronously after the ready message. Install while
 # it is stopped so the install test cannot race that one-shot startup dispatch.
 echo "Installing $PLUGIN_ID from GitHub at $VERSION while Herdr is stopped"
@@ -181,6 +208,7 @@ fi
 echo "Starting stock Herdr release smoke daemon and restoring the plugin service"
 start_default_herdr
 wait_for_herdr default
+wait_for_startup
 
 actions="$(HERDR_SOCKET_PATH="$SOCKET_A" XDG_CONFIG_HOME="$CONFIG_HOME" XDG_DATA_HOME="$DATA_HOME" XDG_STATE_HOME="$STATE_HOME" \
   "$HERDR_BIN" plugin action list --plugin "$PLUGIN_ID")"


### PR DESCRIPTION
## Summary
- wait for Herdr’s asynchronous startup hook to finish before exercising plugin lifecycle actions
- remove the macOS-only false port-conflict race from release smoke
- add regression assertions for the smoke ordering and changelog note

## Validation
- `npm run check`
- `bash -n scripts/live-plugin-smoke.sh`
- `node --test scripts/herdr-world-plugin.test.mjs`

RC12 published successfully except for this macOS smoke-harness race; no release tag is modified by this PR.