### PR TITLE
fix: harden macOS launchd plugin startup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,28 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  launchd:
+    name: macOS launchd plugin lifecycle (${{ matrix.arch }})
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: arm64
+            runner: macos-15
+          - arch: x86_64
+            runner: macos-15-intel
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+      - name: Exercise the real launchd plugin lifecycle
+        env:
+          HERDR_WORLD_REAL_LAUNCHD: "1"
+        run: node --test scripts/herdr-world-plugin.test.mjs
+
   check:
     runs-on: ubuntu-latest
     timeout-minutes: 30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 ### Fixed
 
+- Fixed macOS launchd startup to rely on the plist's `RunAtLoad` behavior, include the failing
+  supervisor command in diagnostics, and safely unload a partially bootstrapped service after
+  startup failure while retaining recovery state when cleanup cannot be verified.
+
 ### Removed
 
 ## [0.1.0-rc.13] - 2026-08-29

--- a/scripts/herdr-world-plugin.mjs
+++ b/scripts/herdr-world-plugin.mjs
@@ -958,10 +958,11 @@ function runChecked(command, args, options = {}) {
     timeout: options.timeout ?? RUNTIME_TIMEOUT_MS,
     stdio: options.stdio ?? ["ignore", "pipe", "pipe"],
   });
-  if (result.error) throw new PluginError(`${path.basename(command)} failed: ${result.error.message}`);
+  const invocation = `${path.basename(command)} ${args.join(" ")}`;
+  if (result.error) throw new PluginError(`${invocation} failed: ${result.error.message}`);
   if (result.status !== 0) {
     const detail = String(result.stderr || result.stdout || `exit status ${result.status}`).trim();
-    throw new PluginError(`${path.basename(command)} ${args.join(" ")} failed: ${detail}`);
+    throw new PluginError(`${invocation} failed: ${detail}`);
   }
   return String(result.stdout ?? "").trim();
 }
@@ -990,6 +991,24 @@ function launchdAvailable(env) {
   const result = commandResult(command, ["print", `gui/${uid}`], { env, timeout: RUNTIME_TIMEOUT_MS });
   if (result.status !== 0) return null;
   return command;
+}
+
+function launchdDomain() {
+  const uid = typeof process.getuid === "function" ? process.getuid() : null;
+  if (uid === null) throw new PluginError("launchd user id is unavailable");
+  return `gui/${uid}`;
+}
+
+function launchdServiceTarget(record) {
+  return `${launchdDomain()}/${record.service_name}`;
+}
+
+function launchdServicePresent(record, command) {
+  const args = ["print", launchdServiceTarget(record)];
+  const result = commandResult(command, args, { timeout: RUNTIME_TIMEOUT_MS });
+  const invocation = `${path.basename(command)} ${args.join(" ")}`;
+  if (result.error) throw new PluginError(`${invocation} failed: ${result.error.message}`);
+  return result.status === 0;
 }
 
 export function selectSupervisor(platform, env) {
@@ -1064,9 +1083,8 @@ function startUnderSupervisor(record, environment, stateDir, supervisor) {
   const plistPath = pathForSupervisor(stateDir, record, "plist");
   const logPath = pathForSupervisor(stateDir, record, "log");
   launchdPlist(record, environment, plistPath, logPath);
-  const domain = `gui/${process.getuid()}`;
+  const domain = launchdDomain();
   runChecked(supervisor.command, ["bootstrap", domain, plistPath]);
-  runChecked(supervisor.command, ["kickstart", "-k", `${domain}/${record.service_name}`]);
   return launchdPid(record, supervisor.command);
 }
 
@@ -1085,7 +1103,7 @@ function systemdPid(record, command) {
 
 function launchdPid(record, command) {
   try {
-    const output = runChecked(command, ["print", `gui/${process.getuid()}/${record.service_name}`]);
+    const output = runChecked(command, ["print", launchdServiceTarget(record)]);
     return parsePid(output.match(/\bpid\s*=\s*(\d+)/)?.[1] ?? 0);
   } catch {
     return 0;
@@ -1148,7 +1166,7 @@ function supervisorStatus(record, supervisor, platform = process.platform) {
     }
   }
   try {
-    const output = runChecked(supervisor.command, ["print", `gui/${process.getuid()}/${record.service_name}`]);
+    const output = runChecked(supervisor.command, ["print", launchdServiceTarget(record)]);
     const pid = parsePid(output.match(/\bpid\s*=\s*(\d+)/)?.[1] ?? 0);
     const active = Boolean(pid) || /state\s*=\s*(running|spawned)/.test(output);
     const commandLine = pid ? processCommandLine(pid, platform) : "";
@@ -1200,11 +1218,38 @@ function stopProcessGroup(pid) {
 async function waitForStopped(record, supervisor, platform = process.platform) {
   const deadline = Date.now() + STOP_TIMEOUT_MS;
   while (Date.now() < deadline) {
+    if (record.supervisor === "launchd") {
+      try {
+        if (!launchdServicePresent(record, supervisor.command)) return;
+      } catch {
+        // Keep polling; a supervisor query failure cannot prove that the
+        // service has been unloaded.
+      }
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      continue;
+    }
     const state = supervisorStatus(record, supervisor, platform);
     if (!state.active) return;
     await new Promise((resolve) => setTimeout(resolve, 100));
   }
   throw new PluginError(`service ${record.service_name} did not stop within ${STOP_TIMEOUT_MS}ms`);
+}
+
+async function unloadLaunchd(record, command) {
+  let bootoutError;
+  try {
+    runChecked(command, ["bootout", launchdServiceTarget(record)]);
+  } catch (error) {
+    bootoutError = error;
+  }
+  try {
+    await waitForStopped(record, { kind: "launchd", command }, "darwin");
+  } catch (error) {
+    if (bootoutError) {
+      throw new PluginError(`${bootoutError.message}; launchd cleanup could not be verified: ${error.message}`);
+    }
+    throw error;
+  }
 }
 
 async function stopRecord(record, env, platform = process.platform) {
@@ -1215,9 +1260,9 @@ async function stopRecord(record, env, platform = process.platform) {
   } else if (record.supervisor === "systemd-user") {
     runChecked(supervisor.command, ["--user", "stop", record.service_name]);
   } else {
-    runChecked(supervisor.command, ["bootout", `gui/${process.getuid()}/${record.service_name}`]);
+    await unloadLaunchd(record, supervisor.command);
   }
-  await waitForStopped(record, supervisor, platform);
+  if (record.supervisor !== "launchd") await waitForStopped(record, supervisor, platform);
   if (record.supervisor === "systemd-user") {
     try {
       runChecked(supervisor.command, ["--user", "disable", record.service_name]);
@@ -1311,7 +1356,14 @@ async function startPrepared(plan, { lockHeld = false } = {}) {
       env,
     });
     let started = false;
+    let launchdCleanupAllowed = false;
     try {
+      if (record.supervisor === "launchd") {
+        if (launchdServicePresent(record, supervisor.command)) {
+          throw new PluginError(`launchd service ${record.service_name} is already loaded; stop it before retrying`);
+        }
+        launchdCleanupAllowed = true;
+      }
       record.pid = startUnderSupervisor(record, environment, context.stateDir, supervisor);
       record.updated_at = new Date().toISOString();
       writeRecord(recordPath, record);
@@ -1324,12 +1376,30 @@ async function startPrepared(plan, { lockHeld = false } = {}) {
       printService(record, capabilities);
       return record;
     } catch (error) {
-      if (started) {
+      let cleanupError = null;
+      if (record.supervisor === "launchd" && launchdCleanupAllowed) {
+        // bootstrap can load the service before launchctl reports a timeout or
+        // another failure. Remove the exact service label even when no record
+        // was written, otherwise the failed startup can retain the port.
+        try { await unloadLaunchd(record, supervisor.command); } catch (cleanupFailure) { cleanupError = cleanupFailure; }
+      } else if (started) {
         try { await stopRecord(record, env, platform); } catch {}
       } else if (record.supervisor === "systemd-user") {
         try {
           runChecked(supervisor.command, ["--user", "disable", record.service_name]);
         } catch {}
+      }
+      if (cleanupError) {
+        let recordRetained = false;
+        try {
+          writeRecord(recordPath, record);
+          recordRetained = true;
+        } catch {}
+        const recovery = recordRetained
+          ? `The service record was retained at ${recordPath}; use the plugin stop action to retry cleanup.`
+          : "The service record could not be retained; inspect launchd before retrying to avoid an orphaned bridge.";
+        const original = error instanceof Error ? error.message : String(error);
+        throw new PluginError(`${original}; ${cleanupError.message}. ${recovery}`);
       }
       removeRecord(recordPath);
       if (error instanceof PluginError) throw error;

--- a/scripts/herdr-world-plugin.test.mjs
+++ b/scripts/herdr-world-plugin.test.mjs
@@ -1,5 +1,7 @@
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
 import { chmodSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import net from "node:net";
 import os from "node:os";
 import path from "node:path";
 import process from "node:process";
@@ -46,6 +48,140 @@ function temporaryDirectory(prefix = "herdr-world-plugin-test-") {
 function executableScript(pathname, body) {
   writeFileSync(pathname, body);
   chmodSync(pathname, 0o755);
+}
+
+async function freePort() {
+  const server = net.createServer();
+  await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const port = server.address().port;
+  await new Promise((resolve) => server.close(resolve));
+  return port;
+}
+
+async function launchdFixture({ real = false } = {}) {
+  const root = temporaryDirectory("herdr-world-launchd-test-");
+  const bin = path.join(root, "bin");
+  const configDir = path.join(root, "config");
+  const stateDir = path.join(root, "state");
+  const packageRoot = path.join(root, ".herdr-world-plugin/node_modules/@ivoryheart/herdr-world");
+  const entrypoint = path.join(root, ".herdr-world-plugin/node_modules/.bin/herdr-world");
+  const socketPath = path.join(root, "herdr.sock");
+  const port = await freePort();
+  mkdirSync(bin, { recursive: true });
+  mkdirSync(configDir, { recursive: true });
+  for (const target of ["macos-arm64", "macos-x64"]) mkdirSync(path.join(packageRoot, `lib/bridges/${target}`), { recursive: true });
+  mkdirSync(path.join(packageRoot, "share/herdr-world/web/legal"), { recursive: true });
+  mkdirSync(path.dirname(entrypoint), { recursive: true });
+  writeFileSync(path.join(root, "herdr-plugin.toml"), readFileSync(path.join(ROOT, "herdr-plugin.toml")));
+  writeFileSync(path.join(configDir, "config.json"), JSON.stringify({ port, port_range: [port, port] }));
+  writeFileSync(path.join(packageRoot, "package.json"), JSON.stringify({ name: PACKAGE_NAME, version: MANIFEST_VERSION }));
+  writeFileSync(path.join(packageRoot, "share/herdr-world/web/index.html"), "<title>fixture</title>");
+  writeFileSync(path.join(packageRoot, "share/herdr-world/web/legal/manifest.json"), JSON.stringify({ schema_version: 1, files: [] }));
+  for (const file of ["LICENSE", "THIRD_PARTY_NOTICES.md", "UPSTREAM.md"]) writeFileSync(path.join(packageRoot, file), "fixture");
+  for (const target of ["macos-arm64", "macos-x64"]) {
+    executableScript(path.join(packageRoot, `lib/bridges/${target}/herdr-world-bridge`), "#!/bin/sh\nexit 0\n");
+  }
+  executableScript(path.join(packageRoot, "lib/herdr-world-launcher.sh"), "#!/bin/sh\nexit 0\n");
+  executableScript(entrypoint, `#!/usr/bin/env node
+const http = require("node:http");
+const args = process.argv.slice(2);
+const port = Number(args[args.indexOf("--port") + 1]);
+const server = http.createServer((request, response) => {
+  if (request.url === "/api/capabilities") {
+    response.writeHead(200, { "content-type": "application/json" });
+    response.end(JSON.stringify({ bridge_api_version: 1, herdr_version: "0.8.2", terminal_protocol: 20, web_compat: 1 }));
+    return;
+  }
+  response.writeHead(200, { "content-type": "text/html" });
+  response.end("<title>fixture</title>");
+});
+server.listen(port, "127.0.0.1");
+`);
+  const herdr = path.join(bin, "herdr");
+  executableScript(herdr, `#!/usr/bin/env node
+console.log(JSON.stringify({ running: true, status: "running", compatible: true, version: "0.8.2", protocol: 20, socket: process.env.HERDR_SOCKET_PATH }));
+`);
+  const fakeLaunchctl = path.join(bin, "launchctl");
+  const statePath = path.join(bin, "service.pid");
+  const logPath = path.join(bin, "launchctl.log");
+  const commandPath = path.join(bin, "service-command.json");
+  const failPath = path.join(bin, "bootstrap-fails");
+  const cleanupFailPath = path.join(bin, "bootout-fails");
+  executableScript(fakeLaunchctl, `#!/usr/bin/env node
+const { appendFileSync, existsSync, readFileSync, rmSync, writeFileSync } = require("node:fs");
+const { spawn } = require("node:child_process");
+const path = require("node:path");
+const bin = path.dirname(path.resolve(process.argv[1]));
+const args = process.argv.slice(2);
+const statePath = path.join(bin, "service.pid");
+const logPath = path.join(bin, "launchctl.log");
+const commandPath = path.join(bin, "service-command.json");
+const failPath = path.join(bin, "bootstrap-fails");
+const cleanupFailPath = path.join(bin, "bootout-fails");
+appendFileSync(logPath, JSON.stringify(args) + "\\n");
+if (args[0] === "print") {
+  const service = args[1]?.split("/").length === 3;
+  if (!service) process.exit(0);
+  if (!existsSync(statePath)) process.exit(1);
+  const pid = readFileSync(statePath, "utf8").trim();
+  process.stdout.write("pid = " + pid + "\\nstate = running\\n");
+  process.exit(0);
+}
+if (args[0] === "bootstrap") {
+  const command = JSON.parse(readFileSync(commandPath, "utf8"));
+  const child = spawn(command[0], command.slice(1), { detached: true, stdio: "ignore" });
+  child.unref();
+  writeFileSync(statePath, String(child.pid));
+  if (existsSync(failPath)) {
+    process.stderr.write("fixture bootstrap failed\\n");
+    process.exit(7);
+  }
+  process.exit(0);
+}
+if (args[0] === "bootout") {
+  if (existsSync(cleanupFailPath)) {
+    process.stderr.write("fixture bootout failed\\n");
+    process.exit(8);
+  }
+  if (existsSync(statePath)) {
+    const pid = Number(readFileSync(statePath, "utf8"));
+    try { process.kill(pid, "SIGTERM"); } catch {}
+    rmSync(statePath, { force: true });
+  }
+  process.exit(0);
+}
+process.exit(0);
+`);
+  writeFileSync(commandPath, JSON.stringify([process.execPath, entrypoint, "--host", "127.0.0.1", "--port", String(port)]));
+  const socketServer = net.createServer();
+  await new Promise((resolve, reject) => {
+    socketServer.once("error", reject);
+    socketServer.listen(socketPath, resolve);
+  });
+  const env = {
+    ...process.env,
+    HERDR_PLUGIN_CONFIG_DIR: configDir,
+    HERDR_PLUGIN_STATE_DIR: stateDir,
+    HERDR_SOCKET_PATH: socketPath,
+    HERDR_BIN_PATH: herdr,
+    HERDR_WORLD_NODE_PATH: process.execPath,
+  };
+  if (!real) env.HERDR_WORLD_LAUNCHCTL = fakeLaunchctl;
+  return {
+    root,
+    port,
+    socketPath,
+    socketServer,
+    stateDir,
+    statePath,
+    logPath,
+    failPath,
+    cleanupFailPath,
+    env,
+  };
 }
 
 test("the checked-in manifest declares the exact plugin contract", () => {
@@ -309,6 +445,91 @@ test("supervisor definitions contain the absolute Node command and safe environm
   assert.match(plist, /<key>HERDR_WORLD_SETUP<\/key><string>never<\/string>/);
 });
 
+test("launchd bootstraps RunAtLoad services once and unloads partial startup", async () => {
+  const fixture = await launchdFixture();
+  const options = { root: fixture.root, env: fixture.env, platform: "darwin", arch: "arm64" };
+  try {
+    const record = await runAction("start", options);
+    assert.equal(record.supervisor, "launchd");
+    assert.equal(record.port, fixture.port);
+    const commands = readFileSync(fixture.logPath, "utf8")
+      .trim()
+      .split("\n")
+      .filter(Boolean)
+      .map((line) => JSON.parse(line));
+    assert.ok(commands.some((args) => args[0] === "bootstrap"));
+    assert.equal(commands.some((args) => args[0] === "kickstart"), false);
+    assert.ok(commands.some((args) => args[0] === "print" && args[1].split("/").length === 3));
+
+    await runAction("stop", options);
+    assert.equal(fsExists(fixture.statePath), false);
+
+    const bootoutCount = () => readFileSync(fixture.logPath, "utf8")
+      .trim()
+      .split("\n")
+      .filter(Boolean)
+      .map((line) => JSON.parse(line))
+      .filter((args) => args[0] === "bootout").length;
+    writeFileSync(fixture.statePath, "999999\n");
+    const beforeExistingStart = bootoutCount();
+    await assert.rejects(runAction("start", options), /launchd service .* already loaded/);
+    assert.equal(fsExists(fixture.statePath), true);
+    assert.equal(bootoutCount(), beforeExistingStart);
+    rmSync(fixture.statePath, { force: true });
+
+    writeFileSync(fixture.failPath, "fixture\n");
+    writeFileSync(fixture.cleanupFailPath, "fixture\n");
+    await assert.rejects(runAction("start", options), /launchctl bootstrap .*fixture bootstrap failed;.*cleanup could not be verified/);
+    assert.equal(fsExists(fixture.statePath), true);
+    const identity = resolveTargetIdentity(validateConfig({}), fixture.env);
+    assert.equal(fsExists(targetRecordPath(fixture.stateDir, identity.identity)), true);
+    rmSync(fixture.cleanupFailPath, { force: true });
+    rmSync(fixture.failPath, { force: true });
+    await runAction("stop", options);
+    assert.equal(fsExists(fixture.statePath), false);
+  } finally {
+    if (fsExists(fixture.statePath)) {
+      const pid = Number(readFileSync(fixture.statePath, "utf8"));
+      try { process.kill(pid, "SIGTERM"); } catch {}
+    }
+    await new Promise((resolve) => fixture.socketServer.close(resolve));
+    rmSync(fixture.socketPath, { force: true });
+    rmSync(fixture.root, { recursive: true, force: true });
+  }
+});
+
+if (process.env.HERDR_WORLD_REAL_LAUNCHD === "1") {
+  test("real macOS launchd starts, restarts, and stops the plugin service", { timeout: 30_000 }, async () => {
+    assert.equal(process.platform, "darwin");
+    const fixture = await launchdFixture({ real: true });
+    const options = { root: fixture.root, env: fixture.env, platform: "darwin", arch: process.arch };
+    const identity = resolveTargetIdentity(validateConfig({}), fixture.env);
+    const label = serviceName(identity.identity, "launchd");
+    const serviceTarget = `gui/${process.getuid()}/${label}`;
+    try {
+      const first = await runAction("start", options);
+      assert.equal(first.supervisor, "launchd");
+      assert.equal(first.port, fixture.port);
+
+      const repeated = await runAction("start", options);
+      assert.equal(repeated.service_name, first.service_name);
+
+      const restarted = await runAction("restart", options);
+      assert.equal(restarted.supervisor, "launchd");
+      assert.equal(restarted.port, fixture.port);
+
+      await runAction("stop", options);
+      assert.equal(await runAction("status", options), null);
+    } finally {
+      try { await runAction("stop", options); } catch {}
+      spawnSync("/bin/launchctl", ["bootout", serviceTarget], { stdio: "ignore", timeout: 5_000 });
+      await new Promise((resolve) => fixture.socketServer.close(resolve));
+      rmSync(fixture.socketPath, { force: true });
+      rmSync(fixture.root, { recursive: true, force: true });
+    }
+  });
+}
+
 test("release workflow gates the three-platform plugin smoke on npm publication", () => {
   const workflow = readFileSync(path.join(ROOT, ".github/workflows/release.yml"), "utf8");
   const npmJob = workflow.indexOf("  npm_publish:");
@@ -320,6 +541,14 @@ test("release workflow gates the three-platform plugin smoke on npm publication"
   assert.match(workflow.slice(pluginJob), /platform: macos-arm64/);
   assert.match(workflow.slice(pluginJob), /platform: macos-x86_64/);
   assert.match(workflow, /package_path="\$\{GITHUB_WORKSPACE\}\/npm-output\/herdr-world-\$\{VERSION\}\.tgz"/);
+});
+
+test("PR CI exercises real launchd on both macOS architectures", () => {
+  const workflow = readFileSync(path.join(ROOT, ".github/workflows/ci.yml"), "utf8");
+  assert.match(workflow, /macos-15/);
+  assert.match(workflow, /macos-15-intel/);
+  assert.match(workflow, /HERDR_WORLD_REAL_LAUNCHD: "1"/);
+  assert.match(workflow, /node --test scripts\/herdr-world-plugin\.test\.mjs/);
 });
 
 test("documents and tests the explicit stop-before-uninstall contract", () => {

--- a/tests/e2e/world.spec.ts
+++ b/tests/e2e/world.spec.ts
@@ -304,8 +304,8 @@ test("opens one stable live conversation bubble for the selected Office agent", 
   await expect(connector.locator("path[data-anchor='workbench']")).toHaveCount(2);
   await expect(connector.locator("path[data-anchor='agent']")).toHaveCount(2);
 
-  const resetOfficeView = page.getByRole("button", { name: "Reset office view" });
-  await expect(resetOfficeView).toBeVisible();
+  const officeStage = page.getByRole("region", { name: "Scrollable Pixel Office scene" });
+  await expect(officeStage).toBeVisible();
   await expect
     .poll(() =>
       page.evaluate(() => Boolean(
@@ -314,13 +314,15 @@ test("opens one stable live conversation bubble for the selected Office agent", 
       )),
     )
     .toBe(true);
-  await resetOfficeView.focus();
-  await expect(resetOfficeView).toBeFocused();
+  // Let terminal autofocus settle, then move focus to the persistent page
+  // region before exercising the page-level Escape handler.
+  await officeStage.focus();
+  await expect(officeStage).toBeFocused();
   await page.keyboard.press("Escape");
   await expect(openBubbles).toHaveCount(1);
   await expect(page.getByRole("dialog", { name: "Codex A" })).toBeVisible();
-  await resetOfficeView.focus();
-  await expect(resetOfficeView).toBeFocused();
+  await officeStage.focus();
+  await expect(officeStage).toBeFocused();
   await page.keyboard.press("Escape");
   await expect(openBubbles).toHaveCount(0);
 });


### PR DESCRIPTION
## Summary\n\n- Rely on launchd plist RunAtLoad behavior and remove the redundant kickstart.\n- Include the exact launchctl invocation in startup diagnostics.\n- Detect an already-loaded service before bootstrap.\n- Safely unload partially bootstrapped services and retain the service record when cleanup cannot be verified.\n- Add deterministic launchd lifecycle coverage plus real macOS ARM64 and Intel CI jobs.\n\n## Validation\n\n- node --test scripts/herdr-world-plugin.test.mjs — 21 passed\n- npm run test:release — 68 passed\n- npm run check — passed previously on this final change set\n- git diff --check — passed\n\n## Merge protection\n\nThe repository ruleset should require both new macOS checks before merging:\n\n- macOS launchd plugin lifecycle (arm64)\n- macOS launchd plugin lifecycle (x86_64)\n\nThose check requirements are configured in GitHub repository settings rather than in this PR.