### PR TITLE
fix: gate releases on unpublished lifecycle smoke

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -514,7 +514,7 @@ jobs:
   github_release:
     name: Assemble and publish GitHub release
     if: github.event_name == 'push' && github.ref_type == 'tag'
-    needs: [provenance, native, external_state]
+    needs: [provenance, native, external_state, npm_install_test, plugin_smoke, homebrew_test]
     outputs:
       publication_result: ${{ steps.publish.outputs.result }}
       publication_url: ${{ steps.publish.outputs.url }}
@@ -638,10 +638,8 @@ jobs:
 
   homebrew_test:
     name: Homebrew Formula test (${{ matrix.platform }})
-    needs: [formula, github_release]
-    if: >-
-      always() && needs.formula.result == 'success' &&
-      (github.event_name != 'push' || needs.github_release.result == 'success')
+    needs: [formula]
+    if: always() && needs.formula.result == 'success'
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 30
     strategy:
@@ -662,8 +660,7 @@ jobs:
           path: formula
           run-id: ${{ github.run_id }}
           github-token: ${{ github.token }}
-      - name: Download the local native archive for explicit preflight
-        if: github.event_name == 'workflow_dispatch'
+      - name: Download the local verified native archive
         uses: actions/download-artifact@v8
         with:
           name: desktop-${{ matrix.platform }}-${{ github.run_id }}
@@ -694,20 +691,16 @@ jobs:
           other_formula="herdr-world-rc"
           [[ "$formula_name" == "herdr-world-rc" ]] && other_formula="herdr-world"
           audit_args=()
-          if [[ "$GITHUB_EVENT_NAME" == "push" ]]; then
-            audit_args+=(--online)
-          fi
           if [[ ! -f "$tap_root/Formula/${other_formula}.rb" ]]; then
             # The first channel cannot resolve its declared peer until that peer is published.
             audit_args+=(--except=conflicts)
           fi
           brew audit "${audit_args[@]}" "$qualified_formula"
-          if [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]]; then
-            archive="$(find formula-native -maxdepth 1 -type f -name 'herdr-world-*.tar.gz' -print -quit)"
-            [[ -n "$archive" ]] || { echo "no native archive was downloaded for manual Formula validation" >&2; exit 1; }
-            archive="$(cd "$(dirname "$archive")" && pwd)/$(basename "$archive")"
-            FORMULA_ARCHIVE_URL="file://${archive}" FORMULA_PLATFORM="${{ matrix.platform }}" \
-              node --input-type=module - "$tap_root/Formula/${formula_name}.rb" <<'NODE'
+          archive="$(find formula-native -maxdepth 1 -type f -name 'herdr-world-*.tar.gz' -print -quit)"
+          [[ -n "$archive" ]] || { echo "no verified native archive was downloaded for Formula validation" >&2; exit 1; }
+          archive="$(cd "$(dirname "$archive")" && pwd)/$(basename "$archive")"
+          FORMULA_ARCHIVE_URL="file://${archive}" FORMULA_PLATFORM="${{ matrix.platform }}" \
+            node --input-type=module - "$tap_root/Formula/${formula_name}.rb" <<'NODE'
           import { readFileSync, writeFileSync } from 'node:fs';
           const formulaPath = process.argv[2];
           const platform = process.env.FORMULA_PLATFORM;
@@ -720,7 +713,6 @@ jobs:
           }
           writeFileSync(formulaPath, localFormula);
           NODE
-          fi
           brew install --formula "$qualified_formula"
           brew test "$qualified_formula"
           brew reinstall --formula "$qualified_formula"
@@ -891,11 +883,8 @@ jobs:
 
   plugin_smoke:
     name: Herdr plugin smoke (${{ matrix.platform }})
-    if: >-
-      github.event_name == 'push' && github.ref_type == 'tag' &&
-      needs.npm_publish.result == 'success' &&
-      needs.npm_publish.outputs.publication_result != 'action-required'
-    needs: [npm_publish]
+    if: always() && needs.npm_package.result == 'success'
+    needs: [npm_package]
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 35
     strategy:
@@ -922,6 +911,40 @@ jobs:
         with:
           node-version: 22.14.0
           package-manager-cache: false
+      - uses: actions/download-artifact@v8
+        with:
+          name: npm-package-${{ github.run_id }}
+          path: npm-output
+          run-id: ${{ github.run_id }}
+          github-token: ${{ github.token }}
+      - name: Stage the exact unpublished plugin candidate
+        id: candidate
+        shell: bash
+        run: |
+          if [[ "$GITHUB_EVENT_NAME" == "push" ]]; then
+            version="$GITHUB_REF_NAME"
+          else
+            version="v0.0.0-rc.${GITHUB_RUN_ID}"
+          fi
+          checkout="${RUNNER_TEMP}/herdr-world-plugin-candidate"
+          mkdir -p "$checkout"
+          git archive HEAD | tar -x -C "$checkout"
+          node --input-type=module - "$checkout/herdr-plugin.toml" "${version#v}" <<'NODE'
+          import { readFileSync, writeFileSync } from 'node:fs';
+          const [manifestPath, version] = process.argv.slice(2);
+          const manifest = readFileSync(manifestPath, 'utf8');
+          const matches = manifest.match(/^version = "[^"]+"$/gm) ?? [];
+          if (matches.length !== 1) {
+            console.error('plugin manifest must contain exactly one top-level version');
+            process.exit(1);
+          }
+          writeFileSync(manifestPath, manifest.replace(matches[0], `version = "${version}"`));
+          NODE
+          package="${GITHUB_WORKSPACE}/npm-output/herdr-world-${version}.tgz"
+          [[ -f "$package" ]] || { echo "exact npm candidate is missing: $package" >&2; exit 1; }
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "checkout=$checkout" >> "$GITHUB_OUTPUT"
+          echo "package=$package" >> "$GITHUB_OUTPUT"
       - name: Download verified stock Herdr v0.8.2
         env:
           HERDR_ASSET: ${{ matrix.herdr_asset }}
@@ -941,7 +964,9 @@ jobs:
       - name: Install and exercise the tagged Herdr plugin
         env:
           HERDR_BIN: ${{ runner.temp }}/herdr
-          VERSION: ${{ github.ref_name }}
+          VERSION: ${{ steps.candidate.outputs.version }}
+          PLUGIN_CHECKOUT: ${{ steps.candidate.outputs.checkout }}
+          PLUGIN_PACKAGE: ${{ steps.candidate.outputs.package }}
         run: scripts/live-plugin-smoke.sh
 
   homebrew_publish:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,13 @@
 - Made release publication fail closed behind the exact unpublished npm payload's full Herdr plugin
   lifecycle and the generated Homebrew Formula lifecycle on Linux x86-64, macOS ARM64, and macOS
   x86-64. The explicit distribution preflight now exercises those same gates before any tag is cut.
+  [Herdr World PR #57](https://github.com/IvoryHeart/herdr-world/pull/57)
 
 ### Fixed
 
 - Kept release-smoke Herdr sockets below the macOS Unix-domain socket path limit instead of nesting
   them under the runner's long temporary directory.
+  [Herdr World PR #57](https://github.com/IvoryHeart/herdr-world/pull/57)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,14 @@
 
 ### Changed
 
+- Made release publication fail closed behind the exact unpublished npm payload's full Herdr plugin
+  lifecycle and the generated Homebrew Formula lifecycle on Linux x86-64, macOS ARM64, and macOS
+  x86-64. The explicit distribution preflight now exercises those same gates before any tag is cut.
+
 ### Fixed
+
+- Kept release-smoke Herdr sockets below the macOS Unix-domain socket path limit instead of nesting
+  them under the runner's long temporary directory.
 
 ### Removed
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -48,8 +48,9 @@ gh workflow run release.yml --ref main
 ```
 
 Wait for the `Release distribution` run to pass before cutting the release. Rerun it if `main`
-advances before release preparation continues. The preflight builds and exercises synthetic
-artifacts but cannot publish.
+advances before release preparation continues. The preflight builds synthetic native, npm, and
+Homebrew artifacts; exercises the exact unpublished plugin and Formula on Linux x86-64, macOS
+ARM64, and macOS x86-64; and cannot publish.
 
 Do not cut a release without bridge test/build coverage.
 
@@ -60,21 +61,22 @@ Corrections use a new release-candidate number. For example, a correction after
 
 Desktop artifacts are built from the final tag by `.github/workflows/release.yml`; do not upload a
 locally built substitute. The explicit distribution preflight runs the same Linux, Apple-Silicon,
-and Intel matrix without publishing; ordinary pull requests rely on the normal CI workflow,
-including its release unit tests. Each native job checks the CPU format and bundle contents, then
-exercises the packaged bridge against two checksum-pinned stock Herdr v0.8.2 daemons. One required
-notice gate validates the complete cross-platform dependency closure before any native job starts,
-avoiding three redundant builds of the notice generator.
+and Intel artifact, Formula, and plugin lifecycle matrix without publishing; ordinary pull requests
+rely on the normal CI workflow, including its release unit tests. Each native job checks the CPU
+format and bundle contents, then exercises the packaged bridge against two checksum-pinned stock
+Herdr v0.8.2 daemons. One required notice gate validates the complete cross-platform dependency
+closure before any native job starts, avoiding three redundant builds of the notice generator.
+
 ## Herdr Plugin Release
 
 The plugin is released with the application tag but does not publish a second application artifact.
-After the exact npm package has been published or verified at the unprefixed tag version, the
-workflow installs `IvoryHeart/herdr-world --ref vX.Y.Z` and runs the plugin lifecycle smoke on all
-three supported targets: Linux x86-64/glibc 2.34+, macOS ARM64, and macOS x86-64. The smoke uses a
-checksum-pinned stock Herdr v0.8.2 daemon, checks action listing, first/repeated start, status,
-open, doctor, restart, browser readiness, a second session/port, and stop-before-uninstall. Its result
-and public repository URL appear in the common release summary. It does not publish, rebuild, or
-substitute the npm payload.
+Before any public channel is changed, the workflow installs the exact generated npm tarball into an
+isolated checkout and runs the plugin lifecycle smoke on all three supported targets: Linux
+x86-64/glibc 2.34+, macOS ARM64, and macOS x86-64. The smoke uses a checksum-pinned stock Herdr
+v0.8.2 daemon and checks the plugin build, action listing, startup restoration, first/repeated start,
+status, open, doctor, restart, browser readiness, a second session/port, and
+stop-before-uninstall. The explicit preflight and tagged workflow use the same unpublished-package
+path, so a failure prevents the GitHub release, npm channel, and Homebrew Formula from advancing.
 
 Install the plugin from the default branch or pin a release:
 
@@ -238,9 +240,10 @@ The script:
 - opens the next `## [Unreleased]` changelog section and pushes it
 
 The tag starts the release distribution workflow. It builds and verifies Linux x86-64, macOS ARM64,
-and macOS x86-64 archives, assembles a draft GitHub release, and publishes the enabled npm and
-Homebrew channels from the exact tested outputs. The release commit's site changes also trigger the
-Pages deployment. No separate desktop upload or documentation-edit step is required.
+and macOS x86-64 archives, npm package, plugin lifecycle, and Homebrew Formula before assembling the
+GitHub release or advancing a public package channel. It then publishes the enabled GitHub, npm, and
+Homebrew channels from those exact tested outputs. The release commit's site changes also trigger
+the Pages deployment. No separate desktop upload or documentation-edit step is required.
 
 ## Android Validation
 

--- a/scripts/herdr-world-plugin.mjs
+++ b/scripts/herdr-world-plugin.mjs
@@ -451,7 +451,11 @@ export function serviceName(identity, supervisor) {
   return supervisor === "launchd" ? `io.ivoryheart.herdr-world.${suffix}` : `herdr-world-${suffix}.service`;
 }
 
-export function npmInstallArgs(version, prefix = ".herdr-world-plugin") {
+export function npmInstallArgs(
+  version,
+  prefix = ".herdr-world-plugin",
+  packageSpec = `${PACKAGE_NAME}@${version}`,
+) {
   return [
     "install",
     `--registry=${REGISTRY}`,
@@ -464,7 +468,7 @@ export function npmInstallArgs(version, prefix = ".herdr-world-plugin") {
     "--no-audit",
     "--no-fund",
     "--omit=dev",
-    `${PACKAGE_NAME}@${version}`,
+    packageSpec,
   ];
 }
 
@@ -560,10 +564,22 @@ export function buildPayload({ root = ROOT, env = process.env, nodePath, npmPath
     throw new PluginError(`npm is unavailable: ${error.message}`);
   }
   const prefix = path.join(root, ".herdr-world-plugin");
+  let packageSpec = `${PACKAGE_NAME}@${manifest.version}`;
+  if (env.HERDR_WORLD_PLUGIN_PACKAGE) {
+    if (!path.isAbsolute(env.HERDR_WORLD_PLUGIN_PACKAGE)) {
+      throw new PluginError("HERDR_WORLD_PLUGIN_PACKAGE must be an absolute path");
+    }
+    try {
+      if (!statSync(env.HERDR_WORLD_PLUGIN_PACKAGE).isFile()) throw new Error("not a regular file");
+    } catch (error) {
+      throw new PluginError(`HERDR_WORLD_PLUGIN_PACKAGE is unavailable: ${error.message}`);
+    }
+    packageSpec = path.resolve(env.HERDR_WORLD_PLUGIN_PACKAGE);
+  }
   rmSync(prefix, { recursive: true, force: true });
   ensureDirectory(prefix);
   try {
-    const result = spawnSync(npm, npmInstallArgs(manifest.version, prefix), {
+    const result = spawnSync(npm, npmInstallArgs(manifest.version, prefix, packageSpec), {
       cwd: root,
       env: { ...env },
       stdio: "inherit",

--- a/scripts/herdr-world-plugin.test.mjs
+++ b/scripts/herdr-world-plugin.test.mjs
@@ -275,6 +275,8 @@ test("build installs and verifies the exact payload using a private prefix", () 
   mkdirSync(bin);
   writeFileSync(path.join(root, "herdr-plugin.toml"), readFileSync(path.join(ROOT, "herdr-plugin.toml")));
   const log = path.join(root, "npm-args.json");
+  const localPackage = path.join(root, `herdr-world-v${MANIFEST_VERSION}.tgz`);
+  writeFileSync(localPackage, "release candidate fixture");
   const fakeNpm = path.join(bin, "npm");
   const manifestVersion = JSON.stringify(MANIFEST_VERSION);
   executableScript(fakeNpm, `#!${process.execPath}
@@ -296,7 +298,12 @@ fs.writeFileSync(path.join(packageRoot, "package.json"), JSON.stringify({ name: 
   try {
     buildPayload({
       root,
-      env: { ...process.env, PATH: bin, FAKE_NPM_LOG: log },
+      env: {
+        ...process.env,
+        PATH: bin,
+        FAKE_NPM_LOG: log,
+        HERDR_WORLD_PLUGIN_PACKAGE: localPackage,
+      },
       nodePath: process.execPath,
       npmPath: fakeNpm,
       platform: "linux",
@@ -304,11 +311,32 @@ fs.writeFileSync(path.join(packageRoot, "package.json"), JSON.stringify({ name: 
       glibcVersion: "2.39",
     });
     const args = JSON.parse(readFileSync(log, "utf8"));
-    assert.equal(args.at(-1), `${PACKAGE_NAME}@${MANIFEST_VERSION}`);
+    assert.equal(args.at(-1), localPackage);
     assert.equal(args[args.indexOf("--ignore-scripts")], "--ignore-scripts");
     assert.equal(args[args.indexOf("--registry=https://registry.npmjs.org/")], "--registry=https://registry.npmjs.org/");
     assert.equal(args[args.indexOf("--@ivoryheart:registry=https://registry.npmjs.org/")], "--@ivoryheart:registry=https://registry.npmjs.org/");
     assert.equal(fsExists(path.join(root, ".herdr-world-plugin/node_modules/@ivoryheart/herdr-world/package.json")), true);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("build rejects a relative local release-candidate package path", () => {
+  const root = temporaryDirectory();
+  try {
+    writeFileSync(path.join(root, "herdr-plugin.toml"), readFileSync(path.join(ROOT, "herdr-plugin.toml")));
+    assert.throws(
+      () => buildPayload({
+        root,
+        env: { ...process.env, HERDR_WORLD_PLUGIN_PACKAGE: "candidate.tgz" },
+        nodePath: process.execPath,
+        npmPath: process.execPath,
+        platform: "linux",
+        arch: "x64",
+        glibcVersion: "2.39",
+      }),
+      /HERDR_WORLD_PLUGIN_PACKAGE must be an absolute path/,
+    );
   } finally {
     rmSync(root, { recursive: true, force: true });
   }
@@ -530,13 +558,19 @@ if (process.env.HERDR_WORLD_REAL_LAUNCHD === "1") {
   });
 }
 
-test("release workflow gates the three-platform plugin smoke on npm publication", () => {
+test("release workflow gates publication on the three-platform unpublished plugin smoke", () => {
   const workflow = readFileSync(path.join(ROOT, ".github/workflows/release.yml"), "utf8");
-  const npmJob = workflow.indexOf("  npm_publish:");
+  const packageJob = workflow.indexOf("  npm_package:");
+  const githubJob = workflow.indexOf("  github_release:");
   const pluginJob = workflow.indexOf("  plugin_smoke:");
-  assert.ok(npmJob >= 0 && pluginJob > npmJob);
-  assert.match(workflow.slice(pluginJob, workflow.indexOf("  homebrew_publish:", pluginJob)), /needs: \[npm_publish\]/);
-  assert.match(workflow.slice(pluginJob, workflow.indexOf("  homebrew_publish:", pluginJob)), /live-plugin-smoke\.sh/);
+  assert.ok(packageJob >= 0 && githubJob >= 0 && pluginJob >= 0);
+  const pluginSection = workflow.slice(pluginJob, workflow.indexOf("  homebrew_publish:", pluginJob));
+  const githubSection = workflow.slice(githubJob, workflow.indexOf("  homebrew_test:", githubJob));
+  assert.match(pluginSection, /needs: \[npm_package\]/);
+  assert.match(pluginSection, /PLUGIN_CHECKOUT:/);
+  assert.match(pluginSection, /PLUGIN_PACKAGE:/);
+  assert.match(pluginSection, /live-plugin-smoke\.sh/);
+  assert.match(githubSection, /needs: \[[^\]]*plugin_smoke[^\]]*homebrew_test[^\]]*\]/);
   assert.equal((workflow.match(/platform: linux-x86_64/g) ?? []).length >= 2, true);
   assert.match(workflow.slice(pluginJob), /platform: macos-arm64/);
   assert.match(workflow.slice(pluginJob), /platform: macos-x86_64/);
@@ -566,6 +600,9 @@ test("documents and tests the explicit stop-before-uninstall contract", () => {
   assert.match(smoke, /Installing .* while Herdr is stopped/);
   assert.match(smoke, /plugin install .*--ref/);
   assert.match(smoke, /wait_for_startup/);
+  assert.match(smoke, /mktemp -d \/tmp\/hwp\.XXXXXX/);
+  assert.match(smoke, /HERDR_WORLD_PLUGIN_PACKAGE="\$PLUGIN_PACKAGE"/);
+  assert.match(smoke, /plugin link "\$PLUGIN_CHECKOUT" --enabled/);
   assert.ok(smoke.indexOf('plugin install IvoryHeart/herdr-world') < smoke.indexOf('echo "Starting stock Herdr release smoke daemon and restoring the plugin service"'));
   assert.ok(smoke.indexOf("wait_for_startup") < smoke.indexOf("wait_for_bridge http://127.0.0.1:8787"));
   assert.ok(smoke.indexOf("invoke_default stop") < smoke.indexOf('plugin uninstall "$PLUGIN_ID"'));

--- a/scripts/live-plugin-smoke.sh
+++ b/scripts/live-plugin-smoke.sh
@@ -1,18 +1,35 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Release smoke for the GitHub-installed plugin. The caller supplies a stock
-# Herdr binary for the runner's platform; the plugin itself supplies the
-# published npm payload and its platform-specific bridge.
+# Release smoke for either a local, unpublished candidate or the GitHub-installed
+# plugin. The caller supplies a stock Herdr binary for the runner's platform.
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 HERDR_BIN="${HERDR_BIN:?set HERDR_BIN to the stock Herdr binary}"
 VERSION="${VERSION:?set VERSION to the release tag, including v}"
+PLUGIN_CHECKOUT="${PLUGIN_CHECKOUT:-}"
+PLUGIN_PACKAGE="${PLUGIN_PACKAGE:-}"
 PLUGIN_ID="ivoryheart.herdr-world"
 
 [[ -x "$HERDR_BIN" ]] || { echo "stock Herdr binary is not executable: $HERDR_BIN" >&2; exit 1; }
 [[ "$VERSION" == v* ]] || { echo "VERSION must be a v-prefixed release tag" >&2; exit 1; }
+if [[ -n "$PLUGIN_CHECKOUT" || -n "$PLUGIN_PACKAGE" ]]; then
+  [[ -n "$PLUGIN_CHECKOUT" && -n "$PLUGIN_PACKAGE" ]] || {
+    echo "PLUGIN_CHECKOUT and PLUGIN_PACKAGE must be supplied together" >&2
+    exit 1
+  }
+  [[ "$PLUGIN_CHECKOUT" == /* && -d "$PLUGIN_CHECKOUT" ]] || {
+    echo "PLUGIN_CHECKOUT must be an existing absolute directory" >&2
+    exit 1
+  }
+  [[ "$PLUGIN_PACKAGE" == /* && -f "$PLUGIN_PACKAGE" ]] || {
+    echo "PLUGIN_PACKAGE must be an existing absolute file" >&2
+    exit 1
+  }
+fi
 
-SMOKE_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/herdr-world-plugin-smoke.XXXXXX")"
+# Keep every Herdr socket below macOS's short sockaddr_un path limit. In
+# particular, do not inherit the much longer per-runner TMPDIR on macOS.
+SMOKE_ROOT="$(mktemp -d /tmp/hwp.XXXXXX)"
 CONFIG_HOME="$SMOKE_ROOT/config"
 DATA_HOME="$SMOKE_ROOT/data"
 STATE_HOME="$SMOKE_ROOT/state"
@@ -192,9 +209,17 @@ NODE
 
 # Herdr runs startup hooks asynchronously after the ready message. Install while
 # it is stopped so the install test cannot race that one-shot startup dispatch.
-echo "Installing $PLUGIN_ID from GitHub at $VERSION while Herdr is stopped"
-HERDR_SOCKET_PATH="$SOCKET_A" XDG_CONFIG_HOME="$CONFIG_HOME" XDG_DATA_HOME="$DATA_HOME" XDG_STATE_HOME="$STATE_HOME" \
-  "$HERDR_BIN" plugin install IvoryHeart/herdr-world --ref "$VERSION" --yes
+if [[ -n "$PLUGIN_CHECKOUT" ]]; then
+  echo "Installing $PLUGIN_ID from the local $VERSION candidate while Herdr is stopped"
+  HERDR_WORLD_PLUGIN_PACKAGE="$PLUGIN_PACKAGE" \
+    bash "$PLUGIN_CHECKOUT/scripts/herdr-world-plugin.sh" build
+  HERDR_SOCKET_PATH="$SOCKET_A" XDG_CONFIG_HOME="$CONFIG_HOME" XDG_DATA_HOME="$DATA_HOME" XDG_STATE_HOME="$STATE_HOME" \
+    "$HERDR_BIN" plugin link "$PLUGIN_CHECKOUT" --enabled
+else
+  echo "Installing $PLUGIN_ID from GitHub at $VERSION while Herdr is stopped"
+  HERDR_SOCKET_PATH="$SOCKET_A" XDG_CONFIG_HOME="$CONFIG_HOME" XDG_DATA_HOME="$DATA_HOME" XDG_STATE_HOME="$STATE_HOME" \
+    "$HERDR_BIN" plugin install IvoryHeart/herdr-world --ref "$VERSION" --yes
+fi
 PLUGIN_CONFIG_DIR="$(HERDR_SOCKET_PATH="$SOCKET_A" XDG_CONFIG_HOME="$CONFIG_HOME" XDG_DATA_HOME="$DATA_HOME" XDG_STATE_HOME="$STATE_HOME" \
   "$HERDR_BIN" plugin config-dir "$PLUGIN_ID")"
 [[ -d "$PLUGIN_CONFIG_DIR" ]] || { echo "plugin config directory was not retained" >&2; exit 1; }
@@ -248,7 +273,7 @@ NODE
 # Herdr has no uninstall hook; stop the controller-owned bridge first.
 invoke_default stop >/dev/null
 invoke_default status >/dev/null
-HERDR_SOCKET_PATH="$SOCKET_A" XDG_CONFIG_HOME="$CONFIG_HOME" XDG_STATE_HOME="$STATE_HOME" \
+HERDR_SOCKET_PATH="$SOCKET_A" XDG_CONFIG_HOME="$CONFIG_HOME" XDG_DATA_HOME="$DATA_HOME" XDG_STATE_HOME="$STATE_HOME" \
   "$HERDR_BIN" plugin uninstall "$PLUGIN_ID"
 [[ -d "$PLUGIN_CONFIG_DIR" ]] || { echo "uninstall removed plugin config/state unexpectedly" >&2; exit 1; }
 


### PR DESCRIPTION
## Summary

- run the exact unpublished npm candidate through the full Herdr plugin lifecycle on Linux and both macOS architectures before any public channel advances
- run Homebrew lifecycle tests against verified local archives before GitHub release publication
- keep release-smoke Unix sockets below the macOS path limit that broke v0.1.0-rc.14

## Validation

- `npm run check`
- local candidate build/install path using the exact v0.1.0-rc.14 npm artifact (full live lifecycle was intentionally not allowed to take over the existing local bridge on port 8787)