### PR TITLE
Release v0.1.0-rc.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@
 
 ### Changed
 
+### Fixed
+
+### Removed
+
+## [0.1.0-rc.15] - 2026-08-30
+
+### Changed
+
 - Made release publication fail closed behind the exact unpublished npm payload's full Herdr plugin
   lifecycle and the generated Homebrew Formula lifecycle on Linux x86-64, macOS ARM64, and macOS
   x86-64. The explicit distribution preflight now exercises those same gates before any tag is cut.
@@ -18,8 +26,6 @@
 - Kept release-smoke Herdr sockets below the macOS Unix-domain socket path limit instead of nesting
   them under the runner's long temporary directory.
   [Herdr World PR #57](https://github.com/IvoryHeart/herdr-world/pull/57)
-
-### Removed
 
 ## [0.1.0-rc.14] - 2026-08-30
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ navigation, multi-client viewing, mobile input controls, synchronized pane selec
 visualizations. The upstream relationship and synchronization record are documented in
 [`UPSTREAM.md`](UPSTREAM.md).
 
-> **Public preview:** [`v0.1.0-rc.14`](https://github.com/IvoryHeart/herdr-world/releases/tag/v0.1.0-rc.14)
+> **Public preview:** [`v0.1.0-rc.15`](https://github.com/IvoryHeart/herdr-world/releases/tag/v0.1.0-rc.15)
 > provides native archives for Linux x86-64 and macOS on Apple Silicon and Intel. Herdr World
 > currently requires Herdr `v0.8.2` or newer reporting terminal protocol `20`.
 
@@ -113,8 +113,8 @@ Android development also needs a JDK and Android SDK. See [docs/android.md](docs
 
 | Platform | Status |
 | --- | --- |
-| Linux x86-64 | Available in [`v0.1.0-rc.14`](https://github.com/IvoryHeart/herdr-world/releases/tag/v0.1.0-rc.14) |
-| macOS ARM64 / x86-64 | Available unsigned in [`v0.1.0-rc.14`](https://github.com/IvoryHeart/herdr-world/releases/tag/v0.1.0-rc.14) |
+| Linux x86-64 | Available in [`v0.1.0-rc.15`](https://github.com/IvoryHeart/herdr-world/releases/tag/v0.1.0-rc.15) |
+| macOS ARM64 / x86-64 | Available unsigned in [`v0.1.0-rc.15`](https://github.com/IvoryHeart/herdr-world/releases/tag/v0.1.0-rc.15) |
 | Android | Source and debug build workflow are available; no signed public APK yet |
 
 ## Quick Start From Release
@@ -123,7 +123,7 @@ Choose `linux-x86_64`, `macos-arm64` (Apple Silicon), or `macos-x86_64` (Intel),
 verify the current release candidate:
 
 ```bash
-VERSION=v0.1.0-rc.14
+VERSION=v0.1.0-rc.15
 PLATFORM=linux-x86_64
 curl -fLO "https://github.com/IvoryHeart/herdr-world/releases/download/${VERSION}/herdr-world-${VERSION}-${PLATFORM}.tar.gz"
 curl -fLO "https://github.com/IvoryHeart/herdr-world/releases/download/${VERSION}/herdr-world-${VERSION}-${PLATFORM}.tar.gz.sha256"

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -1,6 +1,6 @@
 id = "ivoryheart.herdr-world"
 name = "Herdr World"
-version = "0.1.0-rc.14"
+version = "0.1.0-rc.15"
 min_herdr_version = "0.8.2"
 description = "Browser and mobile client for monitoring and controlling Herdr agents."
 platforms = ["linux", "macos"]

--- a/release.json
+++ b/release.json
@@ -1,3 +1,3 @@
 {
-  "current": "v0.1.0-rc.14"
+  "current": "v0.1.0-rc.15"
 }

--- a/site/index.html
+++ b/site/index.html
@@ -44,7 +44,7 @@
           <h1 id="hero-title">Your agents.<br /><em>One office.</em></h1>
           <p class="hero-intro">Herdr World turns live Herdr sessions into one visual workspace: terminal-first Spaces, a multi-host Pixel Office, and the controls to move between them without losing context.</p>
           <div class="hero-actions">
-            <a class="button button-primary" href="https://github.com/IvoryHeart/herdr-world/releases/tag/v0.1.0-rc.14">Download the RC <span aria-hidden="true">↓</span></a>
+            <a class="button button-primary" href="https://github.com/IvoryHeart/herdr-world/releases/tag/v0.1.0-rc.15">Download the RC <span aria-hidden="true">↓</span></a>
             <a class="button button-secondary" href="#install">View install</a>
           </div>
           <dl class="hero-facts">
@@ -155,7 +155,7 @@
               <summary>Advanced npm options</summary>
               <div class="install-advanced-content">
                 <p class="install-panel-label">Pin a version or choose a session</p>
-                <pre tabindex="0" aria-label="Advanced npm commands"><code><span class="prompt">$</span> npm install --global @ivoryheart/herdr-world@0.1.0-rc.14
+                <pre tabindex="0" aria-label="Advanced npm commands"><code><span class="prompt">$</span> npm install --global @ivoryheart/herdr-world@0.1.0-rc.15
 <span class="prompt">$</span> herdr-world --session NAME
 <span class="prompt">$</span> herdr-world --port 8791</code></pre>
                 <p class="install-panel-note">Release candidates use npm’s <code>next</code> channel. Stable releases use <code>latest</code>; pin an exact version when you need a fixed build.</p>
@@ -182,7 +182,7 @@
 
           <section class="install-panel" id="install-panel-herdr" role="tabpanel" aria-labelledby="install-tab-herdr" data-install-panel="herdr" hidden>
             <p class="install-panel-label">Herdr-managed / Herdr 0.8.2+</p>
-            <pre tabindex="0" aria-label="Herdr plugin installation commands"><code data-install-command="herdr"><span class="prompt">$</span> herdr plugin install IvoryHeart/herdr-world --ref v0.1.0-rc.14
+            <pre tabindex="0" aria-label="Herdr plugin installation commands"><code data-install-command="herdr"><span class="prompt">$</span> herdr plugin install IvoryHeart/herdr-world --ref v0.1.0-rc.15
 <span class="prompt">$</span> herdr plugin action invoke open --plugin ivoryheart.herdr-world</code></pre>
             <p class="install-panel-note">Install registers and builds the plugin. The <code>open</code> action starts the bridge for an already-running Herdr server.</p>
             <details class="install-advanced">
@@ -201,14 +201,14 @@
 
           <section class="install-panel" id="install-panel-cli" role="tabpanel" aria-labelledby="install-tab-cli" data-install-panel="cli" hidden>
             <p class="install-panel-label">Manual release archive / Linux x86-64, macOS ARM64, or macOS Intel</p>
-            <pre tabindex="0" aria-label="CLI archive installation commands"><code data-install-command="cli">VERSION=v0.1.0-rc.14
+            <pre tabindex="0" aria-label="CLI archive installation commands"><code data-install-command="cli">VERSION=v0.1.0-rc.15
 PLATFORM=linux-x86_64 # or macos-arm64 / macos-x86_64
 <span class="prompt">$</span> curl -fLO "https://github.com/IvoryHeart/herdr-world/releases/download/${VERSION}/herdr-world-${VERSION}-${PLATFORM}.tar.gz"
 <span class="prompt">$</span> curl -fLO "https://github.com/IvoryHeart/herdr-world/releases/download/${VERSION}/herdr-world-${VERSION}-${PLATFORM}.tar.gz.sha256"
 <span class="prompt">$</span> tar -xzf "herdr-world-${VERSION}-${PLATFORM}.tar.gz"
 <span class="prompt">$</span> cd "herdr-world-${VERSION}-${PLATFORM}"
 <span class="prompt">$</span> bin/herdr-world</code></pre>
-            <p class="install-panel-note">Use <code>sha256sum --check</code> on Linux or <code>shasum -a 256 --check</code> on macOS before extracting. <a href="https://github.com/IvoryHeart/herdr-world/releases/tag/v0.1.0-rc.14">Download the current release candidate ↗</a></p>
+            <p class="install-panel-note">Use <code>sha256sum --check</code> on Linux or <code>shasum -a 256 --check</code> on macOS before extracting. <a href="https://github.com/IvoryHeart/herdr-world/releases/tag/v0.1.0-rc.15">Download the current release candidate ↗</a></p>
             <details class="install-advanced">
               <summary>Advanced CLI options</summary>
               <div class="install-advanced-content">
@@ -239,7 +239,7 @@ PLATFORM=linux-x86_64 # or macos-arm64 / macos-x86_64
         <p class="eyebrow">The office is open</p>
         <h2 id="cta-title">Bring your agents<br /><em>into the room.</em></h2>
         <div class="hero-actions">
-          <a class="button button-primary" href="https://github.com/IvoryHeart/herdr-world/releases/tag/v0.1.0-rc.14">Download v0.1.0-rc.14</a>
+          <a class="button button-primary" href="https://github.com/IvoryHeart/herdr-world/releases/tag/v0.1.0-rc.15">Download v0.1.0-rc.15</a>
           <a class="button button-secondary" href="https://github.com/IvoryHeart/herdr-world/discussions">Join the discussion</a>
         </div>
       </section>

--- a/site/site.js
+++ b/site/site.js
@@ -1,12 +1,12 @@
-// Current public preview: v0.1.0-rc.14
+// Current public preview: v0.1.0-rc.15
 const installCommands = {
   npm: `npm install --global @ivoryheart/herdr-world@next
 herdr-world`,
   brew: `brew install IvoryHeart/tap/herdr-world-rc
 herdr-world`,
-  herdr: `herdr plugin install IvoryHeart/herdr-world --ref v0.1.0-rc.14
+  herdr: `herdr plugin install IvoryHeart/herdr-world --ref v0.1.0-rc.15
 herdr plugin action invoke open --plugin ivoryheart.herdr-world`,
-  cli: `VERSION=v0.1.0-rc.14
+  cli: `VERSION=v0.1.0-rc.15
 PLATFORM=linux-x86_64
 curl -fLO "https://github.com/IvoryHeart/herdr-world/releases/download/\${VERSION}/herdr-world-\${VERSION}-\${PLATFORM}.tar.gz"
 curl -fLO "https://github.com/IvoryHeart/herdr-world/releases/download/\${VERSION}/herdr-world-\${VERSION}-\${PLATFORM}.tar.gz.sha256"


### PR DESCRIPTION
## Summary

- promote the release-gating and macOS plugin-smoke fixes as v0.1.0-rc.15
- update all public install and download references from rc.14 to rc.15
- preserve a fresh Unreleased changelog section in the tagged commit

## Validation

- `npm run test:release` (69 passing)
- `npm run test:pages` (1 passing)
- exact-main Release distribution preflight: https://github.com/IvoryHeart/herdr-world/actions/runs/33307250230
- hardening PR distribution preflight: https://github.com/IvoryHeart/herdr-world/actions/runs/33306634771

The rc.15 tag will be created only after this PR merges with every required check green.