### PR TITLE
fix: stabilize Office renderer lifecycle

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,7 @@ minimal effort.
 # Repository delivery workflow
 
 - Never commit or push directly to `main`. Make all repository changes, including release preparation and fixes, on a branch and deliver them through a pull request. Do not run automation that pushes `main` directly; stop and use a PR-based workflow or ask for direction if the automation cannot do that.
+- Treat opening the pull request as the delivery stopping point. Do not merge it unless the repository owner explicitly asks you to merge. Pull requests require independent review before merging unless the repository owner explicitly states that review is not required.
 
 Specifications are decision aids, not a gate on ordinary engineering work.
 Use one only when the repository owner asks for one or when a genuinely new

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,8 +29,10 @@
 
 - Stopped Office anchor updates from recursively rebuilding the Pixi scene while idle or resizing,
   keeping the interface responsive without increasing terminal resize traffic.
+  [Herdr World PR #62](https://github.com/IvoryHeart/herdr-world/pull/62)
 - Released scene-owned Pixi graphics contexts and text styles after each Office redraw so
   long-running sessions do not retain every discarded scene until the tab crashes.
+  [Herdr World PR #62](https://github.com/IvoryHeart/herdr-world/pull/62)
 - Preserved external Office focus across terminal connection retries so a late
   terminal autofocus cannot consume Escape instead of closing the topmost
   conversation window.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@
 
 ### Fixed
 
+- Stopped Office anchor updates from recursively rebuilding the Pixi scene while idle or resizing,
+  keeping the interface responsive without increasing terminal resize traffic.
+- Released scene-owned Pixi graphics contexts and text styles after each Office redraw so
+  long-running sessions do not retain every discarded scene until the tab crashes.
 - Preserved external Office focus across terminal connection retries so a late
   terminal autofocus cannot consume Escape instead of closing the topmost
   conversation window.

--- a/tests/e2e/world.spec.ts
+++ b/tests/e2e/world.spec.ts
@@ -678,18 +678,7 @@ test("moves and resizes the Office conversation bubble without losing its live a
   expect(afterResize.width).toBeGreaterThan(960);
   expect(afterResize.height).toBeGreaterThanOrEqual(beforeResize?.height ?? 0);
   await expect(slot).toHaveAttribute("data-positioned", "true");
-  await page.evaluate(() => new Promise<void>((resolve) => {
-    window.requestAnimationFrame(() => window.requestAnimationFrame(() => resolve()));
-  }));
-  const rendererAfterResize = await page.evaluate(() => ({
-    sceneRenders: window.__HERDR_WORLD_RENDERER__?.sceneRenders ?? 0,
-    sceneSkips: window.__HERDR_WORLD_RENDERER__?.sceneSkips ?? 0,
-  }));
-  await page.waitForTimeout(500);
-  expect(await page.evaluate(() => ({
-    sceneRenders: window.__HERDR_WORLD_RENDERER__?.sceneRenders ?? 0,
-    sceneSkips: window.__HERDR_WORLD_RENDERER__?.sceneSkips ?? 0,
-  }))).toEqual(rendererAfterResize);
+  await waitForOfficeRendererIdle(page);
 
   await page.locator(".agent-row").filter({ hasText: "Codex B" }).click();
   await expect(page.getByRole("dialog", { name: "Codex B" })).toBeVisible();
@@ -857,11 +846,7 @@ test("keeps the Office renderer idle and responsive through rapid viewport resiz
 }) => {
   await page.goto("/world");
   await waitForOffice(page);
-  await page.waitForTimeout(500);
-  const idleStart = await page.evaluate(() => window.__HERDR_WORLD_RENDERER__?.sceneSkips ?? 0);
-  await page.waitForTimeout(500);
-  expect(await page.evaluate(() => window.__HERDR_WORLD_RENDERER__?.sceneSkips ?? 0))
-    .toBe(idleStart);
+  await waitForOfficeRendererIdle(page);
 
   for (let cycle = 0; cycle < 4; cycle += 1) {
     for (const width of [1180, 960, 1240, 820, 1100, 760, 1320, 700]) {
@@ -873,6 +858,7 @@ test("keeps the Office renderer idle and responsive through rapid viewport resiz
   expect(await page.evaluate(() => new Promise<boolean>((resolve) => {
     window.requestAnimationFrame(() => resolve(true));
   }))).toBe(true);
+  await waitForOfficeRendererIdle(page);
 });
 
 test("does not rebuild the Pixi scene for an unchanged periodic snapshot", async ({
@@ -1345,6 +1331,42 @@ function rectanglesIntersect(first: Rectangle, second: Rectangle) {
 async function waitForLiveOffice(page: import("@playwright/test").Page) {
   await expect(page.locator(".agent-row").filter({ hasText: "Codex A" })).toBeVisible();
   await expect(page.locator(".agent-row").filter({ hasText: "Codex B" })).toBeVisible();
+}
+
+async function waitForOfficeRendererIdle(
+  page: Page,
+  quietForMs = 500,
+  timeoutMs = 10_000,
+) {
+  await page.evaluate(({ quietForMs: quietFor, timeoutMs: timeout }) =>
+    new Promise<void>((resolve, reject) => {
+      const rendererUpdates = () => {
+        const diagnostics = window.__HERDR_WORLD_RENDERER__;
+        return (diagnostics?.sceneRenders ?? 0) + (diagnostics?.sceneSkips ?? 0);
+      };
+      const startedAt = window.performance.now();
+      let lastChangeAt = startedAt;
+      let lastUpdates = rendererUpdates();
+      const sample = () => {
+        const now = window.performance.now();
+        const updates = rendererUpdates();
+        if (updates !== lastUpdates) {
+          lastUpdates = updates;
+          lastChangeAt = now;
+        }
+        if (now - lastChangeAt >= quietFor) {
+          resolve();
+          return;
+        }
+        if (now - startedAt >= timeout) {
+          reject(new Error(`Office renderer did not become idle after ${timeout}ms`));
+          return;
+        }
+        window.setTimeout(sample, 50);
+      };
+      sample();
+    }),
+  { quietForMs, timeoutMs });
 }
 
 function coreSocketUrls(urls: readonly string[]) {

--- a/tests/e2e/world.spec.ts
+++ b/tests/e2e/world.spec.ts
@@ -649,9 +649,17 @@ test("moves and resizes the Office conversation bubble without losing its live a
   const resizeBox = await resizeHandle.boundingBox();
   expect(beforeResize).not.toBeNull();
   expect(resizeBox).not.toBeNull();
+  const rendererBeforeResize = await page.evaluate(() => ({
+    sceneRenders: window.__HERDR_WORLD_RENDERER__?.sceneRenders ?? 0,
+    sceneSkips: window.__HERDR_WORLD_RENDERER__?.sceneSkips ?? 0,
+  }));
   await page.mouse.move((resizeBox?.x ?? 0) + 12, (resizeBox?.y ?? 0) + 12);
   await page.mouse.down();
-  await page.mouse.move((resizeBox?.x ?? 0) + 52, (resizeBox?.y ?? 0) + 20);
+  await page.mouse.move(
+    (resizeBox?.x ?? 0) + 52,
+    (resizeBox?.y ?? 0) + 20,
+    { steps: 30 },
+  );
   await page.mouse.up();
 
   await expect.poll(async () => (await slot.boundingBox())?.width ?? 0).toBeGreaterThan(
@@ -674,6 +682,14 @@ test("moves and resizes the Office conversation bubble without losing its live a
   expect(afterResize.width).toBeGreaterThan(960);
   expect(afterResize.height).toBeGreaterThanOrEqual(beforeResize?.height ?? 0);
   await expect(slot).toHaveAttribute("data-positioned", "true");
+  const rendererAfterResize = await page.evaluate(() => ({
+    sceneRenders: window.__HERDR_WORLD_RENDERER__?.sceneRenders ?? 0,
+    sceneSkips: window.__HERDR_WORLD_RENDERER__?.sceneSkips ?? 0,
+  }));
+  expect(
+    rendererAfterResize.sceneRenders - rendererBeforeResize.sceneRenders +
+      rendererAfterResize.sceneSkips - rendererBeforeResize.sceneSkips,
+  ).toBeLessThanOrEqual(12);
 
   await page.locator(".agent-row").filter({ hasText: "Codex B" }).click();
   await expect(page.getByRole("dialog", { name: "Codex B" })).toBeVisible();
@@ -834,6 +850,29 @@ test("shows perceptible working animation when motion is allowed", async ({ page
   expect(diagnostics?.reducedMotion).toBe(false);
   expect(diagnostics?.animation).toEqual({ characters: 1, monitors: 1, statuses: 1 });
   expect((diagnostics?.frames ?? 0) - start).toBeGreaterThan(2);
+});
+
+test("keeps the Office renderer idle and responsive through rapid viewport resizing", async ({
+  page,
+}) => {
+  await page.goto("/world");
+  await waitForOffice(page);
+  await page.waitForTimeout(500);
+  const idleStart = await page.evaluate(() => window.__HERDR_WORLD_RENDERER__?.sceneSkips ?? 0);
+  await page.waitForTimeout(500);
+  expect(await page.evaluate(() => window.__HERDR_WORLD_RENDERER__?.sceneSkips ?? 0))
+    .toBe(idleStart);
+
+  for (let cycle = 0; cycle < 4; cycle += 1) {
+    for (const width of [1180, 960, 1240, 820, 1100, 760, 1320, 700]) {
+      await page.setViewportSize({ width, height: 900 });
+    }
+  }
+  await expect(page.getByRole("region", { name: "Scrollable Pixel Office scene" }))
+    .toBeVisible();
+  expect(await page.evaluate(() => new Promise<boolean>((resolve) => {
+    window.requestAnimationFrame(() => resolve(true));
+  }))).toBe(true);
 });
 
 test("does not rebuild the Pixi scene for an unchanged periodic snapshot", async ({

--- a/tests/e2e/world.spec.ts
+++ b/tests/e2e/world.spec.ts
@@ -649,10 +649,6 @@ test("moves and resizes the Office conversation bubble without losing its live a
   const resizeBox = await resizeHandle.boundingBox();
   expect(beforeResize).not.toBeNull();
   expect(resizeBox).not.toBeNull();
-  const rendererBeforeResize = await page.evaluate(() => ({
-    sceneRenders: window.__HERDR_WORLD_RENDERER__?.sceneRenders ?? 0,
-    sceneSkips: window.__HERDR_WORLD_RENDERER__?.sceneSkips ?? 0,
-  }));
   await page.mouse.move((resizeBox?.x ?? 0) + 12, (resizeBox?.y ?? 0) + 12);
   await page.mouse.down();
   await page.mouse.move(
@@ -682,14 +678,18 @@ test("moves and resizes the Office conversation bubble without losing its live a
   expect(afterResize.width).toBeGreaterThan(960);
   expect(afterResize.height).toBeGreaterThanOrEqual(beforeResize?.height ?? 0);
   await expect(slot).toHaveAttribute("data-positioned", "true");
+  await page.evaluate(() => new Promise<void>((resolve) => {
+    window.requestAnimationFrame(() => window.requestAnimationFrame(() => resolve()));
+  }));
   const rendererAfterResize = await page.evaluate(() => ({
     sceneRenders: window.__HERDR_WORLD_RENDERER__?.sceneRenders ?? 0,
     sceneSkips: window.__HERDR_WORLD_RENDERER__?.sceneSkips ?? 0,
   }));
-  expect(
-    rendererAfterResize.sceneRenders - rendererBeforeResize.sceneRenders +
-      rendererAfterResize.sceneSkips - rendererBeforeResize.sceneSkips,
-  ).toBeLessThanOrEqual(12);
+  await page.waitForTimeout(500);
+  expect(await page.evaluate(() => ({
+    sceneRenders: window.__HERDR_WORLD_RENDERER__?.sceneRenders ?? 0,
+    sceneSkips: window.__HERDR_WORLD_RENDERER__?.sceneSkips ?? 0,
+  }))).toEqual(rendererAfterResize);
 
   await page.locator(".agent-row").filter({ hasText: "Codex B" }).click();
   await expect(page.getByRole("dialog", { name: "Codex B" })).toBeVisible();

--- a/web/src/world/PixelOfficeCanvas.tsx
+++ b/web/src/world/PixelOfficeCanvas.tsx
@@ -192,6 +192,25 @@ export function PixelOfficeCanvas({
   };
   const reportAnchorsRef = useRef(reportAnchors);
   reportAnchorsRef.current = reportAnchors;
+  const anchorFrameRef = useRef<number | null>(null);
+  const scheduleAnchorReport = () => {
+    if (anchorFrameRef.current !== null) {
+      return;
+    }
+    anchorFrameRef.current = window.requestAnimationFrame(() => {
+      anchorFrameRef.current = null;
+      reportAnchorsRef.current();
+    });
+  };
+  const scheduleAnchorReportRef = useRef(scheduleAnchorReport);
+  scheduleAnchorReportRef.current = scheduleAnchorReport;
+
+  useEffect(() => () => {
+    if (anchorFrameRef.current !== null) {
+      window.cancelAnimationFrame(anchorFrameRef.current);
+      anchorFrameRef.current = null;
+    }
+  }, []);
 
   useEffect(() => {
     const element = hostRef.current;
@@ -241,7 +260,7 @@ export function PixelOfficeCanvas({
           latest.roomAlignment,
           latest.longRoomTitleMode,
         );
-        window.requestAnimationFrame(() => reportAnchorsRef.current());
+        scheduleAnchorReportRef.current();
       })
       .catch((error: unknown) => {
         if (!disposed) {
@@ -272,10 +291,9 @@ export function PixelOfficeCanvas({
       roomAlignment,
       longRoomTitleMode,
     );
-    window.requestAnimationFrame(() => reportAnchorsRef.current());
+    scheduleAnchorReportRef.current();
   }, [
     completionSeenKeys,
-    conversationTargets,
     longRoomTitleMode,
     observability,
     projection,
@@ -284,12 +302,16 @@ export function PixelOfficeCanvas({
   ]);
 
   useEffect(() => {
+    scheduleAnchorReportRef.current();
+  }, [conversationTargets]);
+
+  useEffect(() => {
     const host = hostRef.current;
     const scroll = host?.closest<HTMLElement>(".world-stage-scroll");
     if (!scroll) {
       return;
     }
-    const scheduleReport = () => window.requestAnimationFrame(() => reportAnchorsRef.current());
+    const scheduleReport = () => scheduleAnchorReportRef.current();
     scroll.addEventListener("scroll", scheduleReport, { passive: true });
     window.addEventListener("resize", scheduleReport);
     return () => {

--- a/web/src/world/WorldSurface.tsx
+++ b/web/src/world/WorldSurface.tsx
@@ -6,7 +6,7 @@ import {
   RotateCcw,
   Trash2,
 } from "lucide-react";
-import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import type { PointerEvent as ReactPointerEvent, ReactNode, KeyboardEvent as ReactKeyboardEvent } from "react";
 import type { SurfaceComponentProps } from "../surfaceRegistry";
 import { PixelOfficeCanvas } from "./PixelOfficeCanvas";
@@ -264,6 +264,14 @@ function WorldStage({
   }, [persistWorldView]);
   const panelIds = context.conversationBubbles.map(({ id }) => id);
   const panelIdsKey = panelIds.join("|");
+  const conversationTargets = useMemo(
+    () => context.conversationBubbles.map((panel): OfficeConversationAnchorTarget => ({
+      id: panel.id,
+      selectedKey: panel.selectedKey,
+      targetKey: panel.targetKey,
+    })),
+    [context.conversationBubbles],
+  );
   const selectedRoomKey = projection.rooms.find(({ key }) => key === context.selectedKey)?.key ??
     projection.deskRoster.find(({ desk }) => desk.key === context.selectedKey)?.desk.roomKey ??
     projection.roster.find(({ agent }) => agent.key === context.selectedKey)?.agent.roomKey ??
@@ -806,11 +814,7 @@ function WorldStage({
           observability={context.observability}
           selectedKey={context.selectedKey}
           completionSeenKeys={context.completionSeenKeys}
-          conversationTargets={context.conversationBubbles.map((panel): OfficeConversationAnchorTarget => ({
-            id: panel.id,
-            selectedKey: panel.selectedKey,
-            targetKey: panel.targetKey,
-          }))}
+          conversationTargets={conversationTargets}
           onSelect={context.onSelect}
           onActivateAgent={onActivateAgent}
           onActivateRoom={onActivateRoom}

--- a/web/src/world/officeRenderer.ts
+++ b/web/src/world/officeRenderer.ts
@@ -57,6 +57,10 @@ import {
 } from "./officeLayout";
 import { officeDebug } from "../officeDebug";
 import { officeSceneSignature } from "./officeSceneSignature";
+import {
+  destroyOfficeSceneChildren,
+  OFFICE_SCENE_DESTROY_OPTIONS,
+} from "./officeRendererResources";
 import type { OfficeObservability } from "./officeObservability";
 import {
   formatOfficeCost,
@@ -256,7 +260,7 @@ export async function createOfficeRenderer(
     throw error;
   }
   if (disposed) {
-    app.destroy(true, { children: true });
+    app.destroy(true, OFFICE_SCENE_DESTROY_OPTIONS);
     throw new Error("renderer disposed");
   }
   officeDebug("renderer:pixi-ready");
@@ -275,7 +279,7 @@ export async function createOfficeRenderer(
     textures: textures.filter((texture) => texture !== Texture.EMPTY).length,
   });
   if (disposed) {
-    app.destroy(true, { children: true });
+    app.destroy(true, OFFICE_SCENE_DESTROY_OPTIONS);
     destroyTextures(textures);
     diagnostics.destroys += 1;
     diagnostics.activeApplications = Math.max(0, diagnostics.activeApplications - 1);
@@ -373,8 +377,7 @@ export async function createOfficeRenderer(
     lastSceneSignature = sceneSignature;
     diagnostics.sceneRenders += 1;
     animated.splice(0);
-    const children = app.stage.removeChildren();
-    children.forEach((child) => child.destroy({ children: true }));
+    destroyOfficeSceneChildren(app.stage);
     drawBackground(app.stage, layout);
     drawCeoReception(
       app.stage,
@@ -620,7 +623,7 @@ export async function createOfficeRenderer(
     pointerSequences.delete(select);
     canvasActivationCandidates.delete(select);
     app.ticker.remove(ticker);
-    app.destroy(true, { children: true });
+    app.destroy(true, OFFICE_SCENE_DESTROY_OPTIONS);
     destroyTextures(textures);
     diagnostics.activeApplications = Math.max(0, diagnostics.activeApplications - 1);
     diagnostics.activeTickers = Math.max(0, diagnostics.activeTickers - 1);
@@ -684,7 +687,7 @@ export async function createOfficeRenderer(
       pointerSequences.delete(select);
       canvasActivationCandidates.delete(select);
       app.ticker.remove(ticker);
-      app.destroy(true, { children: true });
+      app.destroy(true, OFFICE_SCENE_DESTROY_OPTIONS);
       destroyTextures(textures);
       if (ownsCanvas) {
         element.replaceChildren();

--- a/web/src/world/officeRendererResources.test.ts
+++ b/web/src/world/officeRendererResources.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  destroyOfficeSceneChildren,
+  OFFICE_SCENE_DESTROY_OPTIONS,
+} from "./officeRendererResources";
+
+describe("Office renderer resource cleanup", () => {
+  it("destroys descendant graphics contexts and text styles but preserves shared textures", () => {
+    const first = { destroy: vi.fn() };
+    const second = { destroy: vi.fn() };
+
+    destroyOfficeSceneChildren({ removeChildren: () => [first, second] });
+
+    expect(OFFICE_SCENE_DESTROY_OPTIONS).toEqual({
+      children: true,
+      context: true,
+      style: true,
+    });
+    expect(OFFICE_SCENE_DESTROY_OPTIONS).not.toHaveProperty("texture");
+    expect(first.destroy).toHaveBeenCalledExactlyOnceWith(OFFICE_SCENE_DESTROY_OPTIONS);
+    expect(second.destroy).toHaveBeenCalledExactlyOnceWith(OFFICE_SCENE_DESTROY_OPTIONS);
+  });
+});

--- a/web/src/world/officeRendererResources.ts
+++ b/web/src/world/officeRendererResources.ts
@@ -1,0 +1,20 @@
+export const OFFICE_SCENE_DESTROY_OPTIONS = Object.freeze({
+  children: true,
+  context: true,
+  style: true,
+});
+
+type OfficeSceneChild = {
+  destroy(options: typeof OFFICE_SCENE_DESTROY_OPTIONS): void;
+};
+
+type OfficeSceneContainer = {
+  removeChildren(): OfficeSceneChild[];
+};
+
+/** Release scene-owned Pixi resources without destroying shared character textures. */
+export function destroyOfficeSceneChildren(container: OfficeSceneContainer) {
+  for (const child of container.removeChildren()) {
+    child.destroy(OFFICE_SCENE_DESTROY_OPTIONS);
+  }
+}


### PR DESCRIPTION
## Summary

- break the React/Pixi anchor-report feedback loop that rebuilt the Office scene continuously while idle and during resize
- coalesce resize/scroll anchor measurements without coupling conversation-target changes to renderer-model updates
- release scene-owned Pixi graphics contexts and text styles on redraw and teardown while preserving shared character textures
- add idle, rapid viewport, live bubble-resize, and resource-cleanup regression coverage
- document that PRs stop for independent review and require explicit owner direction before merge

## Root causes

The existing terminal resize transport cap is working: stressed bubble resizing emitted one terminal resize frame and did not outrun Herdr. The stall came from an inline `conversationTargets` array retriggering the renderer effect; its anchor callback then updated React state and recursively repeated the cycle.

Separately, Pixi 8.3.4 does not destroy an owned `GraphicsContext` when `Graphics.destroy` receives an options object without `context: true`. Every discarded scene therefore remained retained for the lifetime of the tab.

## Validation

- `npm run check`
- `npm run test:e2e` (45 passed, 2 environment-gated tests skipped)
- focused 30-step live Office bubble resize regression
- forced-GC renderer stress: 114 redraws retained about 1.55 MiB after the fix, versus about 64 MiB retained by 46 redraws before it; live GraphicsContexts, TextStyles, DOM nodes, listeners, and GPU memory stayed flat

This PR is intentionally left unmerged for independent review.
