### PR TITLE
Make stable release preparation reviewable

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,8 +88,13 @@ This is a lightweight internal onboarding note for agents working in this repo.
 
 ## Changelog
 
-- `CHANGELOG.md` records Herdr World releases only. Do not copy the Herdr Web changelog into it;
-  correlate each World release with its exact Web synchronization point from `UPSTREAM.md`.
+- `CHANGELOG.md` records Herdr World release identities and downstream changes only. Do not copy or
+  relabel Herdr Web release sections. Follow the release-lineage convention in `UPSTREAM.md`.
+- Correlate every World release with the exact Herdr Web synchronization point from `UPSTREAM.md`.
+  Use "derived from" for synchronized Web source, "compatible with" for the external Herdr runtime
+  and protocol, and "depends on" only for an actual package or runtime dependency.
+- Update the synchronization point before release preparation. The release helper inserts it into
+  the World release section and release validation rejects a missing or stale correlation.
 - Add user-facing changes to `CHANGELOG.md` under `## [Unreleased]`.
 - Use these subsections when applicable: Breaking Changes, Added, Changed, Fixed, Removed.
 - Add the needed subsection under `## [Unreleased]` if it is missing; do not create duplicate subsection headings.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,8 +78,9 @@ This is a lightweight internal onboarding note for agents working in this repo.
   Mac, and `macos-x86_64` tarballs from an Intel Mac. Supplemental local build-service notes may
   describe the release operator's available build hosts, but the repo-owned packaging script remains
   the source of truth for tarball layout.
-- Build final release artifacts from the final release commit/tag after `scripts/release.mjs`
-  stamps the changelog and creates the release. Inspect tarball/APK contents before upload.
+- Build final release artifacts from the final reviewed release commit/tag after
+  `scripts/release.mjs tag` creates the immutable release tag. Inspect tarball/APK contents before
+  upload.
 - Desktop tarballs include `herdr-world-bridge`, bundled `web/dist` assets, the `herdr-world`
   wrapper, complete generated dependency licences, source/asset notices, and
   docs. They do not include Herdr itself. The development Cargo target remains
@@ -87,6 +88,8 @@ This is a lightweight internal onboarding note for agents working in this repo.
 
 ## Changelog
 
+- `CHANGELOG.md` records Herdr World releases only. Do not copy the Herdr Web changelog into it;
+  correlate each World release with its exact Web synchronization point from `UPSTREAM.md`.
 - Add user-facing changes to `CHANGELOG.md` under `## [Unreleased]`.
 - Use these subsections when applicable: Breaking Changes, Added, Changed, Fixed, Removed.
 - Add the needed subsection under `## [Unreleased]` if it is missing; do not create duplicate subsection headings.
@@ -98,13 +101,17 @@ This is a lightweight internal onboarding note for agents working in this repo.
 
 ## Release
 
-- Release from a clean `main` branch.
-- Ensure `CHANGELOG.md` has the release notes under `## [Unreleased]`.
-- Run `npm run check`.
-- Run the browser smoke checklist in `docs/release.md`.
-- Run `node scripts/release.mjs vX.Y.Z`.
-- The release script promotes the changelog, commits, tags, pushes, creates a GitHub release from changelog notes, and opens the next `## [Unreleased]` section.
-- Build/upload tarball and APK artifacts manually after the release exists. Use
-  `docs/packaging.md` and `docs/release.md`; do not commit `dist-packages/`, APKs, or generated
-  Android outputs.
+- Create a clean release branch from current `origin/main` and ensure `CHANGELOG.md` has the release
+  notes under `## [Unreleased]`.
+- Run `node scripts/release.mjs prepare vX.Y.Z`. Review the generated release-reference and
+  changelog diff, commit it as `Release vX.Y.Z`, and deliver it through an independently reviewed
+  pull request.
+- After that PR merges, synchronize a clean origin-only `main`, run the complete distribution
+  preflight and browser smoke checklist in `docs/release.md`, then run
+  `node scripts/release.mjs tag vX.Y.Z`.
+- The tag command verifies the reviewed squash-merge commit and exact successful preflight, then
+  pushes only the immutable release tag. It never commits or pushes `main`.
+- The release workflow builds and uploads the desktop, npm, plugin, and Homebrew outputs. Android
+  remains separate until a signed public APK exists. Do not commit `dist-packages/`, APKs, or
+  generated Android outputs.
 - Do not bump npm package versions until package publishing is defined.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Web's own release history remains in its upstream changelog.
 - Made release preparation a reviewed pull-request change, correlated each World release with its
   exact Herdr Web baseline instead of duplicating the upstream changelog, and restricted the
   post-merge release command to verifying exact `main` and creating the immutable release tag.
+  [Herdr World PR #63](https://github.com/IvoryHeart/herdr-world/pull/63)
 - Replaced the reference-heavy README with a concise user guide covering installation, essential
   advanced usage, contribution and support paths, licensing, acknowledgements, and Pixel Office
   previews for desktop and mobile.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+This changelog records Herdr World releases and downstream changes. Each release identifies the
+exact [Herdr Web](https://github.com/kcosr/herdr-web) baseline from which it was derived; Herdr
+Web's own release history remains in its upstream changelog.
+
 ## [Unreleased]
 
 ### Breaking Changes
@@ -20,6 +24,9 @@
 
 ### Changed
 
+- Made release preparation a reviewed pull-request change, correlated each World release with its
+  exact Herdr Web baseline instead of duplicating the upstream changelog, and restricted the
+  post-merge release command to verifying exact `main` and creating the immutable release tag.
 - Replaced the reference-heavy README with a concise user guide covering installation, essential
   advanced usage, contribution and support paths, licensing, acknowledgements, and Pixel Office
   previews for desktop and mobile.
@@ -43,6 +50,9 @@
 
 ## [0.1.0-rc.15] - 2026-08-30
 
+> **Herdr Web baseline:** Derived from v0.5.0 plus its next-development marker at
+> [`e67537b6`](https://github.com/kcosr/herdr-web/commit/e67537b6bdd99fe489584252ba2f84ea070a3193).
+
 ### Changed
 
 - Made release publication fail closed behind the exact unpublished npm payload's full Herdr plugin
@@ -58,6 +68,9 @@
 
 ## [0.1.0-rc.14] - 2026-08-30
 
+> **Herdr Web baseline:** Derived from v0.5.0 plus its next-development marker at
+> [`e67537b6`](https://github.com/kcosr/herdr-web/commit/e67537b6bdd99fe489584252ba2f84ea070a3193).
+
 ### Fixed
 
 - Fixed macOS launchd startup to rely on the plist's `RunAtLoad` behavior, include the failing
@@ -66,12 +79,18 @@
 
 ## [0.1.0-rc.13] - 2026-08-29
 
+> **Herdr Web baseline:** Derived from v0.5.0 plus its next-development marker at
+> [`e67537b6`](https://github.com/kcosr/herdr-web/commit/e67537b6bdd99fe489584252ba2f84ea070a3193).
+
 ### Fixed
 
 - Synchronized the Herdr plugin release smoke with asynchronous startup-hook completion on macOS.
   [Herdr World PR #55](https://github.com/IvoryHeart/herdr-world/pull/55)
 
 ## [0.1.0-rc.12] - 2026-08-29
+
+> **Herdr Web baseline:** Derived from v0.5.0 plus its next-development marker at
+> [`e67537b6`](https://github.com/kcosr/herdr-web/commit/e67537b6bdd99fe489584252ba2f84ea070a3193).
 
 ### Fixed
 
@@ -80,11 +99,17 @@
 
 ## [0.1.0-rc.11] - 2026-08-29
 
+> **Herdr Web baseline:** Derived from v0.5.0 plus its next-development marker at
+> [`e67537b6`](https://github.com/kcosr/herdr-web/commit/e67537b6bdd99fe489584252ba2f84ea070a3193).
+
 ### Fixed
 
 - Made the Herdr plugin release smoke deterministic across asynchronous startup-hook execution.
 
 ## [0.1.0-rc.10] - 2026-08-29
+
+> **Herdr Web baseline:** Derived from v0.5.0 plus its next-development marker at
+> [`e67537b6`](https://github.com/kcosr/herdr-web/commit/e67537b6bdd99fe489584252ba2f84ea070a3193).
 
 ### Fixed
 
@@ -93,6 +118,9 @@
   [Herdr World PR #47](https://github.com/IvoryHeart/herdr-world/pull/47)
 
 ## [0.1.0-rc.9] - 2026-08-29
+
+> **Herdr Web baseline:** Derived from v0.5.0 plus its next-development marker at
+> [`e67537b6`](https://github.com/kcosr/herdr-web/commit/e67537b6bdd99fe489584252ba2f84ea070a3193).
 
 ### Added
 
@@ -116,6 +144,9 @@
 
 ## [0.1.0-rc.8] - 2026-08-29
 
+> **Herdr Web baseline:** Derived from v0.5.0 plus its next-development marker at
+> [`e67537b6`](https://github.com/kcosr/herdr-web/commit/e67537b6bdd99fe489584252ba2f84ea070a3193).
+
 ### Fixed
 
 - Fixed RC npm publication to pass the downloaded package tarball as an explicit filesystem path.
@@ -123,6 +154,9 @@
   [Herdr World PR #40](https://github.com/IvoryHeart/herdr-world/pull/40)
 
 ## [0.1.0-rc.6] - 2026-08-29
+
+> **Herdr Web baseline:** Derived from v0.5.0 plus its next-development marker at
+> [`e67537b6`](https://github.com/kcosr/herdr-web/commit/e67537b6bdd99fe489584252ba2f84ea070a3193).
 
 ### Added
 
@@ -140,6 +174,9 @@
 
 ## [0.1.0-rc.5] - 2026-08-29
 
+> **Herdr Web baseline:** Derived from v0.5.0 plus its next-development marker at
+> [`e67537b6`](https://github.com/kcosr/herdr-web/commit/e67537b6bdd99fe489584252ba2f84ea070a3193).
+
 ### Fixed
 
 - Let Homebrew derive the package version from immutable release URLs, avoiding a redundant
@@ -147,6 +184,9 @@
   [Herdr World PR #33](https://github.com/IvoryHeart/herdr-world/pull/33)
 
 ## [0.1.0-rc.4] - 2026-08-29
+
+> **Herdr Web baseline:** Derived from v0.5.0 plus its next-development marker at
+> [`e67537b6`](https://github.com/kcosr/herdr-web/commit/e67537b6bdd99fe489584252ba2f84ea070a3193).
 
 ### Fixed
 
@@ -157,12 +197,18 @@
 
 ## [0.1.0-rc.3] - 2026-08-29
 
+> **Herdr Web baseline:** Derived from v0.5.0 plus its next-development marker at
+> [`e67537b6`](https://github.com/kcosr/herdr-web/commit/e67537b6bdd99fe489584252ba2f84ea070a3193).
+
 ### Fixed
 
 - Updated Homebrew release validation for current name-based audit and trusted-tap requirements.
   [Herdr World PR #31](https://github.com/IvoryHeart/herdr-world/pull/31)
 
 ## [0.1.0-rc.2] - 2026-08-29
+
+> **Herdr Web baseline:** Derived from v0.5.0 plus its next-development marker at
+> [`e67537b6`](https://github.com/kcosr/herdr-web/commit/e67537b6bdd99fe489584252ba2f84ea070a3193).
 
 ### Added
 
@@ -186,13 +232,8 @@
 
 ## [0.1.0-rc.1] - 2026-08-26
 
-### Fixed
-
-- Kept the official Herdr installer's stdout diagnostics out of the launcher's resolved executable
-  path, allowing guided macOS installation to stop an incompatible daemon and continue startup.
-  [Herdr World PR #21](https://github.com/IvoryHeart/herdr-world/pull/21)
-
-## [0.1.0-rc.1] - 2026-08-26
+> **Herdr Web baseline:** Derived from v0.5.0 plus its next-development marker at
+> [`e67537b6`](https://github.com/kcosr/herdr-web/commit/e67537b6bdd99fe489584252ba2f84ea070a3193).
 
 ### Added
 
@@ -350,6 +391,9 @@
 
 ### Fixed
 
+- Kept the official Herdr installer's stdout diagnostics out of the launcher's resolved executable
+  path, allowing guided macOS installation to stop an incompatible daemon and continue startup.
+  [Herdr World PR #21](https://github.com/IvoryHeart/herdr-world/pull/21)
 - Added a guarded same-tag prerelease reissue mode for correcting an unannounced candidate without
   inventing another release-candidate number. It retains all normal remote, tag, release, and test
   safety checks and cannot replace a stable release.
@@ -390,379 +434,3 @@
   alphanumeric continuations when terminal edge metadata is unavailable, while preserving ordinary
   line breaks.
   [PR #61](https://github.com/kcosr/herdr-web/pull/61)
-
-## [0.4.1] - 2026-08-05
-
-### Breaking Changes
-
-- Herdr `v0.8.0` or newer with terminal protocol exactly `19` is now required. The bridge rejects
-  the previous protocol `17` baseline and other unreviewed protocols instead of attempting a
-  backward-compatible wire fallback. [PR #48](https://github.com/kcosr/herdr-web/pull/48)
-
-### Added
-
-- Added a contextual Move Space mode to the Spaces menu. The selected space card becomes draggable,
-  retains a cancel control and arrow/Home/End keyboard support, mutes unrelated sidebar actions
-  until the move is completed or canceled, and moves worktree groups atomically within their host's
-  canonical workspace order. [PR #48](https://github.com/kcosr/herdr-web/pull/48)
-- Added persistent expand/collapse controls to grouped Agents, Tabs, and Spaces headers, including
-  independent, visually nested host and workspace controls for Host + workspace grouping and a
-  bulk expand/collapse control for the current Agents or Tabs list.
-  [PR #47](https://github.com/kcosr/herdr-web/pull/47)
-- Added a default-off Display setting that combines same-named workspaces across hosts when using
-  Workspace grouping, while retaining host context on each agent or pane row.
-  [PR #47](https://github.com/kcosr/herdr-web/pull/47)
-
-### Changed
-
-- Refreshed the minimal vendored Herdr compatibility sources to the `v0.8.0`/protocol `19`
-  baseline, including the current API schemas, terminal wire definitions, and input model shims.
-  [PR #48](https://github.com/kcosr/herdr-web/pull/48)
-- Follow Herdr's canonical workspace order when atomic worktree groups are reordered.
-  [PR #48](https://github.com/kcosr/herdr-web/pull/48)
-- Simplified Workspace grouping in the Agents and Tabs sidebars to show workspace-only group
-  headers and move host context into each detail row. Host + workspace grouping keeps its nested
-  host and workspace headers. [PR #47](https://github.com/kcosr/herdr-web/pull/47)
-
-### Fixed
-
-- Fixed built-in agent launches against Herdr `v0.8.0` by waiting for a newly created pane's shell
-  to become available before starting the managed agent.
-  [PR #48](https://github.com/kcosr/herdr-web/pull/48)
-
-## [0.4.0] - 2026-07-30
-
-### Breaking Changes
-
-- Herdr `v0.7.5` or newer with terminal protocol exactly `17` is now required. The bridge rejects
-  older protocol `16` daemons and unreviewed newer protocols rather than attempting a
-  backward-compatible wire fallback. [PR #45](https://github.com/kcosr/herdr-web/pull/45)
-- Removed the obsolete `custom_status` field from bridge snapshots and activity events; agent
-  presentation now uses Herdr's `state_labels`, title, display-agent, and status fields.
-  [PR #45](https://github.com/kcosr/herdr-web/pull/45)
-- Changed the default ungrouped Tabs and Spaces sidebar presentation to compact rows with inline
-  host, Space, and tab context instead of contextual headers. Agent panes in Tabs also use the
-  Agents row presentation and agent-aware ordering by default. Choose a grouping mode to restore
-  contextual headers, or disable Agent features in Tabs to restore generic pane rows and the
-  original tab order. [PR #41](https://github.com/kcosr/herdr-web/pull/41)
-
-### Added
-
-- Added a default-on client-local Sync navigation setting. Browser tabs and windows with sync off
-  can view different panes through the same bridge without publishing or following shared pane
-  selection or changing Herdr's focused tab through ordinary navigation.
-  [PR #42](https://github.com/kcosr/herdr-web/pull/42)
-- Added default-on Agent features in Tabs, including consistent Agents row metadata and pin
-  placement, agent-aware sorting, and pinned-only and active-only filters. Non-agent tabs remain
-  visible at the bottom of agent-aware sorts; disabling the setting restores generic pane rows.
-  [PR #41](https://github.com/kcosr/herdr-web/pull/41)
-- Added multi-host Spaces controls: Spaces can be shown as a flat list with host context or grouped
-  under host headers, and the default-on Multi-host Space selection setting can be disabled to limit
-  Space-scoped Agents, Tabs, and Notes to one globally selected Space. All scope remains unchanged.
-  [PR #41](https://github.com/kcosr/herdr-web/pull/41)
-
-### Changed
-
-- Refreshed the minimal vendored Herdr compatibility sources to the `v0.7.5`/protocol `17` baseline,
-  including the current API schemas and terminal wire definitions.
-  [PR #45](https://github.com/kcosr/herdr-web/pull/45)
-- Updated launching for Herdr `v0.7.5`: built-in agents use the managed `agent.start` flow after the
-  destination pane is created. The bridge waits for interactive readiness and rolls back its new
-  tab or pane after rejection, early process exit, or timeout. Custom launcher presets continue to
-  execute their exact configured `argv`. [PR #45](https://github.com/kcosr/herdr-web/pull/45)
-- Store the Sync navigation setting browser-wide while keeping sync-off pane selections only in
-  memory. The app no longer creates per-tab navigation storage records.
-  [PR #43](https://github.com/kcosr/herdr-web/pull/43)
-- Simplified agent-row metadata by removing generic status text already communicated by the status
-  indicator and badge, while retaining bridge-defined state labels.
-  [PR #41](https://github.com/kcosr/herdr-web/pull/41)
-
-### Fixed
-
-- Cleared and remounted the mobile terminal command field after Send or Stage so stale native input
-  cannot prefix the next command. [PR #44](https://github.com/kcosr/herdr-web/pull/44), with an
-  earlier implementation contributed by
-  [Alexander Makarov (@AlexanderMakarov)](https://github.com/AlexanderMakarov) in
-  [PR #38](https://github.com/kcosr/herdr-web/pull/38).
-- Fixed client-local navigation synchronization across reloads, reconnects, lagging snapshots, and
-  rapid multi-client selection races. Sync-off split navigation now stays local, and independent
-  clients no longer rewrite shared navigation persistence. After a bridge restart, the focused
-  Herdr pane now seeds shared navigation so synced clients immediately converge.
-  [PR #43](https://github.com/kcosr/herdr-web/pull/43)
-
-## [0.3.3] - 2026-07-19
-
-### Added
-
-- Added Grok and OpenCode agent icons in the Agents sidebar and create-menu launch choices.
-  [PR #36](https://github.com/kcosr/herdr-web/pull/36)
-- Added built-in launcher presets for Grok and OpenCode (`builtin:grok`, `builtin:opencode`).
-  [PR #36](https://github.com/kcosr/herdr-web/pull/36)
-- Added optional `builtins` allowlist/order in `launcher-presets.json` so the create menu can show a
-  subset of built-ins without PATH probing. Omitting `builtins` keeps the full default set; `[]`
-  hides all built-ins (custom presets still appear). Short names (`shell`) and full ids
-  (`builtin:shell`) are accepted; unknown entries warn and are ignored.
-  [PR #36](https://github.com/kcosr/herdr-web/pull/36)
-
-### Fixed
-
-- Kept the first selected character anchored during mobile endpoint dragging, aligned the loupe caret
-  with the selected row, and centered a hollow drag handle over the anchored character.
-  [PR #35](https://github.com/kcosr/herdr-web/pull/35)
-
-## [0.3.2] - 2026-07-07
-
-### Breaking Changes
-
-- Users must upgrade Herdr to `v0.7.2` or newer before upgrading herdr-web. The bridge now requires
-  a Herdr daemon with protocol `16` because browser snapshots use Herdr's native
-  `session.snapshot` API.
-  [PR #32](https://github.com/kcosr/herdr-web/pull/32)
-
-### Added
-
-- Added an Agents-view active-status filter that shows only agents currently
-  marked working, blocked, or done, with grouped views hiding empty groups after
-  filtering. [PR #31](https://github.com/kcosr/herdr-web/pull/31)
-
-### Changed
-
-- Refreshed the vendored Herdr compatibility baseline to `v0.7.2`, including protocol `16`, native
-  session snapshots, layout/scroll event schema drift, and terminal observe/control wire messages.
-  [PR #32](https://github.com/kcosr/herdr-web/pull/32)
-- Changed `/api/snapshot` to use one native Herdr `session.snapshot` request instead of separate
-  workspace, tab, pane, and per-tab layout requests.
-  [PR #32](https://github.com/kcosr/herdr-web/pull/32)
-
-## [0.3.1] - 2026-07-03
-
-### Added
-
-- Added bridge-owned configurable launcher presets for the create menu, including argv-based custom
-  agent commands, optional Herdr agent hints, and horizontally scrollable launch choices.
-  [PR #30](https://github.com/kcosr/herdr-web/pull/30)
-- Documented macOS x86_64 desktop tarball support alongside Linux x86_64 and macOS ARM64 release
-  artifacts.
-  [PR #30](https://github.com/kcosr/herdr-web/pull/30)
-- Refreshed the vendored Herdr compatibility baseline to `v0.7.1` for launcher preset agent hints.
-  [PR #30](https://github.com/kcosr/herdr-web/pull/30)
-
-### Fixed
-
-- Fixed mobile sidebar space selection so tapping a space updates the scoped Tabs list instead of
-  snapping back to tabs from the previously selected pane.
-  [PR #29](https://github.com/kcosr/herdr-web/pull/29)
-- Fixed a bridge reattach race where a client reconnecting right after the last viewer left a
-  terminal could be rejected by the daemon with `already has an attached client` and shown a
-  permanent `Attached elsewhere` error; the bridge now shuts detached attach connections down and
-  reattaches only after the pending detach has been delivered.
-  [PR #26](https://github.com/kcosr/herdr-web/pull/26)
-- Stopped detached terminal attach connections from leaking a blocked reader thread and an open
-  socket on both the bridge and daemon sides after every pane switch.
-  [PR #26](https://github.com/kcosr/herdr-web/pull/26)
-- Serialized concurrent first attaches per terminal in the bridge and made the web client briefly
-  retry `already has an attached client` rejections, so multiple viewers reconnecting at once
-  (for example after a bridge restart) no longer strand a terminal on a permanent
-  `Attached elsewhere` error. The bridge also now logs daemon-initiated attach connection closes,
-  which were previously recorded nowhere.
-  [PR #26](https://github.com/kcosr/herdr-web/pull/26)
-
-## [0.3.0] - 2026-07-02
-
-### Added
-
-- Added an `Add note` action to pane and agent sidebar context menus, opening a quick-create
-  dialog with a focused title and optional body that attaches the new note to the target pane.
-  [PR #24](https://github.com/kcosr/herdr-web/pull/24)
-- Added Mobile settings for an expanding terminal command input and Enter-as-newline
-  editing, allowing long prompts to wrap and remain viewable while preserving send-on-Enter
-  by default. [PR #21](https://github.com/kcosr/herdr-web/pull/21)
-- Added bridge-tracked agent status transition activity with an Agents view sort option for
-  `Last status change`, using semantic status changes rather than terminal output activity.
-  [PR #23](https://github.com/kcosr/herdr-web/pull/23)
-- Added server-side agent pins with pinned-first agent ordering, a pinned-only sidebar toggle, and
-  a selected-pane header toggle plus a small pinned indicator on pinned agent rows.
-  [PR #22](https://github.com/kcosr/herdr-web/pull/22)
-- Added bridge-owned pane notes with a sidebar Notes view, desktop/mobile notes editor, pane
-  attachment recovery states, and per-bridge note synchronization. Notes are exposed through the
-  same bridge request policy as terminal controls, so allowed bridge clients can read and mutate
-  saved note content. [PR #20](https://github.com/kcosr/herdr-web/pull/20)
-- Added a Notes feature toggle plus persisted desktop notes panel sizing, notes list collapse
-  state, notes panel open state, pane note tabs, and a dedicated Other notes list.
-  [PR #20](https://github.com/kcosr/herdr-web/pull/20)
-- Added a Markdown preview mode for notes that remembers Edit/Preview preference locally and keeps
-  the Markdown renderer lazy-loaded until preview is used. [PR #20](https://github.com/kcosr/herdr-web/pull/20)
-
-### Changed
-
-- Unified the `session_key` reported by `/api/agent-activity` with the notes and agent-pins
-  endpoints (`session:default` and FNV-1a socket hashes instead of a divergent local format).
-  [PR #25](https://github.com/kcosr/herdr-web/pull/25)
-- Extended the pinned-only sidebar toggle to the Tabs view so pinned panes can be found outside the
-  Agents view. [PR #23](https://github.com/kcosr/herdr-web/pull/23)
-- Notes created from the notes panel now open in Edit mode with the title selected, so the default
-  title can be replaced immediately. [PR #24](https://github.com/kcosr/herdr-web/pull/24)
-
-### Fixed
-
-- Made the bridge close and cleanly reattach terminal sockets that fall behind fast output instead
-  of silently dropping frames and corrupting the rendered stream.
-  [PR #25](https://github.com/kcosr/herdr-web/pull/25)
-- Moved the bridge's remaining blocking daemon round-trips (snapshot, selection, agent activity,
-  rename-label lookups) off async worker threads, so a stalled daemon no longer freezes unrelated
-  requests and terminal websockets.
-  [PR #25](https://github.com/kcosr/herdr-web/pull/25)
-- Bounded the bridge's per-terminal input queue so a client sending faster than the pty drains no
-  longer grows bridge memory without limit.
-  [PR #25](https://github.com/kcosr/herdr-web/pull/25)
-- Fixed terminal session races where a client connecting while the previous one disconnected could
-  be handed an already-detached session, and where the daemon handshake blocked all other terminal
-  clients.
-  [PR #25](https://github.com/kcosr/herdr-web/pull/25)
-- Stopped the bridge from silently tightening permissions on a pre-existing operator-supplied
-  `--upload-dir`; only directories the bridge creates itself are set to 0700.
-  [PR #25](https://github.com/kcosr/herdr-web/pull/25)
-- Applied the standard 120-byte label validation to `pane.rename` requests, matching every other
-  rename/create command.
-  [PR #25](https://github.com/kcosr/herdr-web/pull/25)
-- Stopped a cancelled terminal mount from leaking an orphaned renderer and duplicated canvas when
-  the pane changes while the terminal module is still loading.
-  [PR #25](https://github.com/kcosr/herdr-web/pull/25)
-- Made single-cell touch selections highlight correctly instead of silently storing a wrong
-  scrollback row.
-  [PR #25](https://github.com/kcosr/herdr-web/pull/25)
-- Preserved combining characters and multi-codepoint emoji when copying terminal text via touch
-  selection.
-  [PR #25](https://github.com/kcosr/herdr-web/pull/25)
-- Kept the selected note open while no pane is selected, so notes no longer deselect mid-edit when
-  a bridge disconnects, has zero panes, or a notes refresh lands.
-  [PR #25](https://github.com/kcosr/herdr-web/pull/25)
-- Made Escape in settings number fields discard the typed value instead of committing it, and stop
-  it from closing the whole settings dialog; out-of-range numbers now snap back to the clamped
-  value in the field.
-  [PR #25](https://github.com/kcosr/herdr-web/pull/25)
-- Reordered Android hardware-back handling so open menus and dialogs close before the notes panel
-  underneath them.
-  [PR #25](https://github.com/kcosr/herdr-web/pull/25)
-- Made Escape cancel the rename dialog from any focused control, not just the text input.
-  [PR #25](https://github.com/kcosr/herdr-web/pull/25)
-- Extended long-press text-selection prevention to the stage header pane title.
-  [PR #25](https://github.com/kcosr/herdr-web/pull/25)
-- Restored the intended drop shadow and muted URL color on the terminal selection sheet, which
-  referenced undefined CSS variables.
-  [PR #25](https://github.com/kcosr/herdr-web/pull/25)
-- Validated agent-pins responses at the fetch boundary so a malformed bridge response degrades
-  gracefully instead of crashing the sidebar render.
-  [PR #25](https://github.com/kcosr/herdr-web/pull/25)
-- Prevented sidebar row labels and terminal tab labels from being text-selected during long-press
-  context-menu gestures. [PR #24](https://github.com/kcosr/herdr-web/pull/24)
-- Fixed notes editor selection and autosave edge cases so switching to panes without notes clears
-  the editor, deleting the selected note no longer shows a deleted note, and stale local save
-  refreshes do not appear as external note changes. Also fixed mobile delete-dialog back handling
-  and unresolved note recovery actions in the notes panel. [PR #20](https://github.com/kcosr/herdr-web/pull/20)
-- On mobile, kept the note editor's terminal action available for the current pane and made it
-  close the full-screen notes surface. [PR #20](https://github.com/kcosr/herdr-web/pull/20)
-- Changed mobile notes back navigation so back closes the notes surface from the editor, while a
-  separate header button shows the notes list. [PR #20](https://github.com/kcosr/herdr-web/pull/20)
-- Kept the new-tab button pinned at the right edge of the top tab bar while the tab list scrolls.
-  [PR #20](https://github.com/kcosr/herdr-web/pull/20)
-- Improved terminal reconnect/resume handling so Android foregrounding and quick terminal switches
-  keep the renderer stable, avoid stale tab flashes, and suppress transient connecting overlays.
-  [PR #19](https://github.com/kcosr/herdr-web/pull/19)
-
-## [0.2.1] - 2026-06-20
-
-### Added
-
-- Added a Terminal font size setting. [PR #16](https://github.com/kcosr/herdr-web/pull/16)
-- Added desktop click-to-open support for detected HTTP(S) terminal URLs.
-  [PR #16](https://github.com/kcosr/herdr-web/pull/16)
-
-### Changed
-
-- Added a Mobile setting for long-press behavior, with Off, Copy, and Loupe modes; Loupe uses a
-  two-stage endpoint flow, selected URLs keep the action sheet, and tapped HTTP(S) URLs open
-  directly; original mobile selection work contributed by Will Hampson.
-  [PR #16](https://github.com/kcosr/herdr-web/pull/16)
-
-### Fixed
-
-- Fixed Android/tablet bridge color picker dismissal so saving a backend after choosing a color
-  keeps the Settings dialog open. [PR #16](https://github.com/kcosr/herdr-web/pull/16)
-- Fixed sidebar keyboard shortcuts so agent and tab navigation follows the visible host/sidebar
-  order across selected-host and all-host views. [PR #18](https://github.com/kcosr/herdr-web/pull/18)
-
-## [0.2.0] - 2026-06-19
-
-### Added
-
-- Added multi-bridge connections, allowing multiple saved bridges to stay enabled at once with
-  server chips and an all-agents sidebar overview. [PR #17](https://github.com/kcosr/herdr-web/pull/17)
-- Added a bridge `--allow-connect-origin` option so bridge-served web pages can opt into connecting
-  to other trusted bridge origins without relaxing the default Content Security Policy.
-  [PR #17](https://github.com/kcosr/herdr-web/pull/17)
-- Added a Host + workspace grouping option for agent lists.
-  [PR #17](https://github.com/kcosr/herdr-web/pull/17)
-- Added configurable bridge colors with a mobile-friendly color picker.
-  [PR #17](https://github.com/kcosr/herdr-web/pull/17)
-
-### Changed
-
-- Moved sidebar agent/tab sorting and grouping controls into a vertical options menu, and removed
-  redundant host prefixes from grouped tab labels. [PR #17](https://github.com/kcosr/herdr-web/pull/17)
-
-## [0.1.2] - 2026-06-18
-
-### Added
-
-- Added a bridge-owned agent activity stream so pane status, title, display agent, and custom
-  status updates reach connected browsers without waiting for a full snapshot refresh; concepts
-  derived from the @roy-levi-amazon fork. [PR #11](https://github.com/kcosr/herdr-web/pull/11)
-- Added Display settings for top/bottom app padding and mobile terminal controls size.
-  [PR #13](https://github.com/kcosr/herdr-web/pull/13)
-- Added configurable terminal input transport, with binary payload concepts derived from the
-  @roy-levi-amazon fork. [PR #12](https://github.com/kcosr/herdr-web/pull/12)
-- Added opt-in terminal input batching controls with a fixed 32-byte flush threshold for slow
-  connections. [PR #12](https://github.com/kcosr/herdr-web/pull/12)
-- Added a Shift-Tab key to the expanded mobile terminal key panel. [PR #11](https://github.com/kcosr/herdr-web/pull/11)
-
-### Changed
-
-- Coalesced fast terminal output bursts in the bridge before forwarding them to browser clients,
-  with a per-client Terminal output batching setting for tuning frame churn during rapid TUI
-  redraws; concepts derived from the @roy-levi-amazon fork.
-  [PR #14](https://github.com/kcosr/herdr-web/pull/14)
-- Reworked Settings into Bridge, Terminal, and Mobile areas, with horizontal area tabs on narrow
-  screens. [PR #12](https://github.com/kcosr/herdr-web/pull/12)
-- Improved browser startup by lazy-loading the terminal renderer with retry after load failures,
-  adding installable mobile web app metadata and raster icons, and compressing static
-  bridge-served web assets; concepts derived from the @roy-levi-amazon fork.
-  [PR #10](https://github.com/kcosr/herdr-web/pull/10)
-
-## [0.1.1] - 2026-06-17
-
-### Breaking Changes
-
-### Added
-
-- Added a native Android setting, on by default, to blur text inputs and refit the terminal after
-  the keyboard closes.
-- Added an opt-in mobile terminal long-press selection setting with drag-to-copy selection, selected
-  URL actions, and touch hit-testing for Ghostty-detected links.
-
-### Changed
-
-- Changed bridge URL validation so users can save HTTP bridge URLs at any valid host or IP address.
-
-### Fixed
-
-- Forced and reapplied Android dark system bar styling with light status/navigation bar icons.
-- Removed duplicate bottom safe-area padding inside the mobile terminal controls.
-
-### Removed
-
-## [0.1.0] - 2026-06-16
-
-### Added
-
-- Initial release.

--- a/UPSTREAM.md
+++ b/UPSTREAM.md
@@ -31,6 +31,29 @@ above is a merge ancestor of this repository. `CHANGELOG.md` repeats only the
 per-release baseline correlation; it does not copy the upstream release history
 or maintain a separate adoption ledger.
 
+## Release Lineage Convention
+
+Herdr World and Herdr Web keep independent release identities and changelogs. A World version does
+not imply a matching Web version, and a Web version is never added as a World changelog section.
+Each World release instead records one exact Web baseline: the descriptive upstream version or
+marker together with the full synchronization commit from this file. The release helper renders
+that correlation as "Herdr Web baseline: Derived from …" and release validation requires it to
+match the synchronization point at the tagged commit.
+
+Use these terms consistently:
+
+- **Derived from** describes Herdr Web source synchronized into this repository and then changed
+  downstream.
+- **Compatible with** describes the external Herdr release and terminal protocol accepted by the
+  bridge.
+- **Depends on** is reserved for a package or runtime dependency that remains independently
+  installed and resolved; it does not describe copied or synchronized Web source.
+
+Record World-owned changes under the current World `Unreleased` section. An adopted upstream
+change may be mentioned when it changes the World product, with its upstream attribution and World
+integration PR, but do not reproduce the upstream release notes. Update this file's synchronization
+point before preparing a World release; the prepared changelog correlation is generated from it.
+
 To update:
 
 ```bash

--- a/UPSTREAM.md
+++ b/UPSTREAM.md
@@ -26,9 +26,10 @@ admitted by the protocol-20 bridge. The stable compatibility reference above
 remains unchanged until a release is available for a complete refresh and
 stock-daemon validation.
 
-Git history is the synchronization record. The Herdr Web commit above is a
-merge ancestor of this repository; there is no separate hand-maintained
-adoption ledger.
+Git history is the detailed synchronization record, and the Herdr Web commit
+above is a merge ancestor of this repository. `CHANGELOG.md` repeats only the
+per-release baseline correlation; it does not copy the upstream release history
+or maintain a separate adoption ledger.
 
 To update:
 

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -279,8 +279,10 @@ WebSocket.
 
 ## Automated Desktop Publication
 
-`node scripts/release.mjs vX.Y.Z` updates the public version references, pushes the stamped release
-tag, and triggers `.github/workflows/release.yml`. The workflow builds, inspects, live-tests, and
+`node scripts/release.mjs prepare vX.Y.Z` generates the reviewed release PR diff. After that PR is
+merged and its exact `main` commit passes the distribution preflight,
+`node scripts/release.mjs tag vX.Y.Z` pushes only the stamped release tag and triggers
+`.github/workflows/release.yml`. The workflow builds, inspects, live-tests, and
 retains all six Linux/macOS archive and checksum assets, assembles the GitHub release draft, and
 publishes npm and the matching Homebrew channel from the exact tested outputs. Existing public
 content is never replaced. The release command also updates the website source, so the same release

--- a/docs/release.md
+++ b/docs/release.md
@@ -24,7 +24,7 @@ the release tag.
 - A local Herdr `v0.8.2` or newer session reporting terminal protocol `20` for browser and packaged
   bridge smoke testing.
 
-## Prepare
+## Prepare And Review
 
 1. Confirm the changelog has user-facing notes under `## [Unreleased]`.
    Entries merged through pull requests should include the PR number or link before the PR is
@@ -41,16 +41,30 @@ scripts/check-vendor.sh
 npm run check
 ```
 
-4. From the current `main`, explicitly start the complete distribution preflight:
+4. Create a clean release branch from the current remote `main`:
 
 ```bash
-gh workflow run release.yml --ref main
+git switch main
+git pull --ff-only origin main
+git switch -c release/v0.1.0
 ```
 
-Wait for the `Release distribution` run to pass before cutting the release. Rerun it if `main`
-advances before release preparation continues. The preflight builds synthetic native, npm, and
-Homebrew artifacts; exercises the exact unpublished plugin and Formula on Linux x86-64, macOS
-ARM64, and macOS x86-64; and cannot publish.
+5. Generate the complete release diff without committing, tagging, or pushing:
+
+```bash
+node scripts/release.mjs prepare v0.1.0
+```
+
+The preparation command requires the branch to start exactly at `origin/main`, repeats the normal
+repository check, updates every release reference, promotes the changelog notes, removes empty
+released subsections, records the exact Herdr Web baseline from `UPSTREAM.md`, and opens the next
+empty `## [Unreleased]` section in the same diff. The World changelog contains World releases and
+downstream changes; it links the baseline instead of copying Herdr Web's release history.
+
+6. Inspect the diff, commit it with the exact subject `Release v0.1.0`, push the branch, and open a
+pull request with that exact title. Do not merge until independent review is complete. The squash
+merge subject will become `Release v0.1.0 (#<number>)`, which is the release provenance recorded by
+the tag.
 
 Do not cut a release without bridge test/build coverage.
 
@@ -220,25 +234,41 @@ instead of serving a partially compatible UI.
 
 ## Cut
 
-Choose the GitHub release version explicitly and run:
+After the reviewed release PR merges, use a clean origin-only release checkout. This avoids a
+same-named tag fetched from the Herdr Web upstream being mistaken for a Herdr World tag. Synchronize
+exact `main`, then explicitly start the complete distribution preflight:
 
 ```bash
-node scripts/release.mjs v0.1.0
+git switch main
+git pull --ff-only origin main
+gh workflow run release.yml --ref main
 ```
 
-The script:
+Wait for the `Release distribution` run to pass. The preflight builds synthetic native, npm, and
+Homebrew artifacts; exercises the exact unpublished plugin and Formula on Linux x86-64, macOS
+ARM64, and macOS x86-64; and cannot publish. The tag command rejects a preflight from any other
+commit.
+
+After the exact preflight and the browser/federation smoke above pass, create the release tag:
+
+```bash
+node scripts/release.mjs tag v0.1.0
+```
+
+The tag command:
 
 - requires a clean `main` branch
 - verifies both `origin` URLs and GitHub CLI access against `IvoryHeart/herdr-world`
+- verifies that `main` is the reviewed `Release v0.1.0 (#<number>)` squash merge
+- verifies the exact successful distribution preflight
 - runs `npm run check`
-- updates `release.json` and every current release reference in the README and Pages source
-- promotes `CHANGELOG.md` from `Unreleased` to the release version/date
-- removes empty unused subsections from the released version notes
-- rechecks the stamped release and Pages metadata
-- commits `Release vX.Y.Z`
-- tags `vX.Y.Z`
-- pushes `main` and the tag atomically
-- opens the next `## [Unreleased]` changelog section and pushes it
+- rechecks the stamped release, changelog, plugin manifest, and public references
+- rejects an existing local or public tag, release, npm version, or conflicting Homebrew version
+- pushes only the immutable `v0.1.0` tag at the exact verified commit
+
+It never commits or pushes `main`. If the release checkout already contains an unrelated upstream
+`v0.1.0` tag, stop and use a clean origin-only clone rather than moving or deleting that upstream
+identity.
 
 The tag starts the release distribution workflow. It builds and verifies Linux x86-64, macOS ARM64,
 and macOS x86-64 archives, npm package, plugin lifecycle, and Homebrew Formula before assembling the

--- a/docs/release.md
+++ b/docs/release.md
@@ -61,6 +61,10 @@ released subsections, records the exact Herdr Web baseline from `UPSTREAM.md`, a
 empty `## [Unreleased]` section in the same diff. The World changelog contains World releases and
 downstream changes; it links the baseline instead of copying Herdr Web's release history.
 
+The generated changelog date is the intended UTC release date. Merge, preflight, and tag on that
+date. If review delays the release past it, update the date in the release PR and have that revision
+reviewed. The tag command rejects a stale date instead of publishing inaccurate release notes.
+
 6. Inspect the diff, commit it with the exact subject `Release v0.1.0`, push the branch, and open a
 pull request with that exact title. Do not merge until independent review is complete. The squash
 merge subject will become `Release v0.1.0 (#<number>)`, which is the release provenance recorded by
@@ -260,6 +264,7 @@ The tag command:
 - requires a clean `main` branch
 - verifies both `origin` URLs and GitHub CLI access against `IvoryHeart/herdr-world`
 - verifies that `main` is the reviewed `Release v0.1.0 (#<number>)` squash merge
+- verifies that the changelog release date is the current UTC date
 - verifies the exact successful distribution preflight
 - runs `npm run check`
 - rechecks the stamped release, changelog, plugin manifest, and public references

--- a/docs/specs/017-herdr-world-automated-release-distribution-spec-summary.md
+++ b/docs/specs/017-herdr-world-automated-release-distribution-spec-summary.md
@@ -65,3 +65,20 @@
 - **Follow-up extension:** None. Enabling GitHub release immutability or adding
   another signed/platform publisher remains a separately evaluated deferred
   decision.
+
+### 2026-08-31 — Reviewed release preparation boundary
+
+- **Implemented:** Split the operator command into branch-only `prepare` and post-merge `tag`
+  phases. Preparation now leaves one complete release diff—including the next empty Unreleased
+  section and exact Herdr Web baseline correlation—for independent pull-request review. The World
+  changelog no longer duplicates inherited Herdr Web release history. Tagging accepts only the exact
+  reviewed squash merge on current `origin/main`, requires a successful distribution preflight for
+  that commit, and pushes only the immutable release tag. A same-named tag inherited from Herdr Web
+  is rejected locally and handled by using an origin-only release checkout rather than moving an
+  upstream identity.
+- **Constraints / operational notes:** The protected tag remains the publication trigger and
+  authorization boundary. The first stable `v0.1.0` release remains pending; this workflow change
+  does not cut it.
+- **Drift from approved spec:** The operator command is now explicitly two-phase so repository
+  changes follow the project-wide PR-review rule; artifact and publication semantics are unchanged.
+- **Follow-up extension:** None.

--- a/docs/specs/017-herdr-world-automated-release-distribution-spec-summary.md
+++ b/docs/specs/017-herdr-world-automated-release-distribution-spec-summary.md
@@ -73,9 +73,9 @@
   section and exact Herdr Web baseline correlation—for independent pull-request review. The World
   changelog no longer duplicates inherited Herdr Web release history. Tagging accepts only the exact
   reviewed squash merge on current `origin/main`, requires a successful distribution preflight for
-  that commit, and pushes only the immutable release tag. A same-named tag inherited from Herdr Web
-  is rejected locally and handled by using an origin-only release checkout rather than moving an
-  upstream identity.
+  that commit, rejects a prepared changelog date that no longer matches the UTC tag date, and pushes
+  only the immutable release tag. A same-named tag inherited from Herdr Web is rejected locally and
+  handled by using an origin-only release checkout rather than moving an upstream identity.
 - **Constraints / operational notes:** The protected tag remains the publication trigger and
   authorization boundary. The first stable `v0.1.0` release remains pending; this workflow change
   does not cut it.

--- a/docs/specs/017-herdr-world-automated-release-distribution-spec.md
+++ b/docs/specs/017-herdr-world-automated-release-distribution-spec.md
@@ -146,8 +146,9 @@ Release preparation SHALL never commit or push `main`. It SHALL promote the rele
 all public version references, and open the next empty `Unreleased` section in one branch diff. The
 released section SHALL identify the exact Herdr Web synchronization point recorded by `UPSTREAM.md`;
 the World changelog SHALL NOT duplicate Herdr Web's release history. The tag command SHALL require
-a successful explicit distribution preflight for the exact reviewed `main` commit and SHALL push
-only `HEAD:refs/tags/<tag>`.
+the reviewed changelog release date to equal the current UTC date, require a successful explicit
+distribution preflight for the exact reviewed `main` commit, and push only
+`HEAD:refs/tags/<tag>`.
 
 ### Cross-tag publication critical section
 

--- a/docs/specs/017-herdr-world-automated-release-distribution-spec.md
+++ b/docs/specs/017-herdr-world-automated-release-distribution-spec.md
@@ -16,19 +16,23 @@ application once and automatically publishes every enabled distribution channel.
 npm, Homebrew, the Herdr plugin, and future Android or iOS publishers are outputs
 of that release; they are not separate operator-run release procedures.
 
-The operator interface remains:
+The operator interface is split at the reviewed-main boundary:
 
 ```bash
-node scripts/release.mjs vX.Y.Z
-node scripts/release.mjs vX.Y.Z-rc.N
+node scripts/release.mjs prepare vX.Y.Z
+node scripts/release.mjs tag vX.Y.Z
 ```
+
+The same commands accept `vX.Y.Z-rc.N`. `prepare` creates only a reviewable working-tree diff on a
+branch based exactly on `origin/main`; `tag` runs only after that release PR is squash-merged and
+pushes only the immutable tag.
 
 ## Decisions
 
 | Concern | Decision |
 | --- | --- |
 | Release identities | Stable `vX.Y.Z`; prerelease `vX.Y.Z-rc.N` only |
-| Release authorization | Protected release tags pointing at a stamped commit on protected `main` |
+| Release authorization | Protected release tags pointing at an independently reviewed, stamped squash merge on protected `main` |
 | Orchestration | One tag-triggered GitHub Actions workflow |
 | Cross-tag concurrency | One shared `queue: max`; running releases are never canceled |
 | Native build | Existing Linux x86-64, macOS ARM64, and macOS x86-64 matrix |
@@ -78,10 +82,12 @@ documentation, plugin metadata, package manifests, artifact names, and channel
 versions SHALL agree with it. Formats that do not accept the `v` prefix SHALL
 remove that prefix and no other text.
 
-The release command SHALL reject an invalid or existing local tag, origin tag,
-GitHub release, npm version, or conflicting Homebrew version before publication.
-It SHALL NOT support same-version reissue. Upstream remotes SHALL be fetched
-without importing unrelated tags into the Herdr World release namespace.
+Release preparation SHALL reject an invalid or existing origin tag, GitHub
+release, npm version, or conflicting Homebrew version before changing the working tree. The tag
+command SHALL repeat those checks and reject any same-named local tag, including an inherited
+upstream tag, so the operator must tag from a clean origin-only checkout. It SHALL NOT support
+same-version reissue. Upstream remotes SHALL be fetched without importing unrelated tags into the
+Herdr World release namespace.
 
 Release candidates SHALL increment `N` for corrections. A correction after
 `v1.2.3-rc.2` is `v1.2.3-rc.3`, never a replacement `rc.2`.
@@ -127,13 +133,21 @@ secret, a credential-free validation job SHALL fetch the canonical
 - the ref matches one of the two allowed release-tag forms;
 - the tag resolves to `GITHUB_SHA` and that commit is an ancestor of the fetched
   protected `origin/main`;
-- the commit is the correctly stamped `Release <tag>` commit; and
+- the commit is the correctly stamped, squash-merged `Release <tag> (#<number>)` pull-request
+  commit; and
 - its changelog, `release.json`, manifests, and other public version references
   agree with the tag.
 
 Publication jobs SHALL depend on that validation result and SHALL be the only
 jobs granted their channel credential. The local release helper performs the
 same checks for early feedback but is not the authorization boundary.
+
+Release preparation SHALL never commit or push `main`. It SHALL promote the release notes, update
+all public version references, and open the next empty `Unreleased` section in one branch diff. The
+released section SHALL identify the exact Herdr Web synchronization point recorded by `UPSTREAM.md`;
+the World changelog SHALL NOT duplicate Herdr Web's release history. The tag command SHALL require
+a successful explicit distribution preflight for the exact reviewed `main` commit and SHALL push
+only `HEAD:refs/tags/<tag>`.
 
 ### Cross-tag publication critical section
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "notices:generate": "node scripts/dependency-notices.mjs --generate",
     "notices:check": "node scripts/dependency-notices.mjs --check",
     "test:dev": "node --test scripts/dev.test.mjs",
-    "test:release": "node --test scripts/release-target.test.mjs scripts/release-version.test.mjs scripts/release-notes.test.mjs scripts/release-publication.test.mjs scripts/npm-launcher.test.mjs scripts/npm-registry-query.test.mjs scripts/homebrew-formula.test.mjs scripts/herdr-world-installer.test.mjs scripts/herdr-world-launcher.test.mjs scripts/herdr-world-plugin.test.mjs scripts/terminal-screen.test.mjs",
+    "test:release": "node --test scripts/release-target.test.mjs scripts/release-version.test.mjs scripts/release-changelog.test.mjs scripts/release-notes.test.mjs scripts/release-publication.test.mjs scripts/npm-launcher.test.mjs scripts/npm-registry-query.test.mjs scripts/homebrew-formula.test.mjs scripts/herdr-world-installer.test.mjs scripts/herdr-world-launcher.test.mjs scripts/herdr-world-plugin.test.mjs scripts/terminal-screen.test.mjs",
     "test:pages": "node --test scripts/pages.test.mjs",
     "test:web": "npm run test --prefix web",
     "test:observability": "npm run test --prefix web -- observability.test.ts && cargo test --manifest-path bridge/Cargo.toml --bin herdr-web-bridge observability",

--- a/scripts/release-changelog.mjs
+++ b/scripts/release-changelog.mjs
@@ -1,0 +1,103 @@
+import { escapeRegex, normalizeReleaseTag, releaseVersion } from "./release-version.mjs";
+
+const CHANGELOG_SUBSECTIONS = ["Breaking Changes", "Added", "Changed", "Fixed", "Removed"];
+
+export const UNRELEASED_CHANGELOG_TEMPLATE = `## [Unreleased]
+
+### Breaking Changes
+
+### Added
+
+### Changed
+
+### Fixed
+
+### Removed
+`;
+
+const HERDR_WEB_COMMIT_URL = "https://github.com/kcosr/herdr-web/commit";
+
+export function herdrWebBaselineNote(upstream) {
+  const match = upstream.match(
+    /- Herdr Web: `([0-9a-f]{40})`\s+\(([^)]+)\)/,
+  );
+  if (!match) {
+    throw new Error("UPSTREAM.md is missing a parseable Herdr Web synchronization point");
+  }
+  const [, commit, rawDescription] = match;
+  const description = rawDescription.replaceAll("`", "").replace(/\s+/g, " ").trim();
+  return (
+    `> **Herdr Web baseline:** Derived from ${description} at\n` +
+    `> [\`${commit.slice(0, 8)}\`](${HERDR_WEB_COMMIT_URL}/${commit}).`
+  );
+}
+
+export function removeEmptyChangelogSubsections(body) {
+  let cleaned = body;
+  for (const subsection of CHANGELOG_SUBSECTIONS) {
+    cleaned = cleaned.replace(
+      new RegExp(`(^|\\n)### ${escapeRegex(subsection)}\\n\\n*(?=### |$)`, "g"),
+      "$1",
+    );
+  }
+  cleaned = cleaned.replace(/\n{3,}/g, "\n\n").trimEnd();
+  return cleaned ? `\n${cleaned.trimStart()}\n` : "\n";
+}
+
+export function prepareReleaseChangelog(changelog, tag, date, upstream) {
+  const version = releaseVersion(normalizeReleaseTag(tag));
+  const releaseHeading = new RegExp(`^## \\[${escapeRegex(version)}\\] - `, "m");
+  if (releaseHeading.test(changelog)) {
+    throw new Error(`CHANGELOG.md already contains a release section for ${tag}`);
+  }
+
+  const unreleasedPattern = /(^|\n)## \[Unreleased\]\n([\s\S]*?)(?=\n## |$)/;
+  const unreleased = changelog.match(unreleasedPattern);
+  if (!unreleased) {
+    throw new Error("CHANGELOG.md is missing an Unreleased section");
+  }
+  const releaseBody = removeEmptyChangelogSubsections(unreleased[2]);
+  if (!releaseBody.trim()) {
+    throw new Error("CHANGELOG.md has no release notes under Unreleased");
+  }
+
+  const released = changelog.replace(
+    unreleasedPattern,
+    `${unreleased[1]}## [${version}] - ${date}\n\n${herdrWebBaselineNote(upstream)}\n${releaseBody}`,
+  );
+  const prepared = released.replace(
+    "# Changelog\n\n",
+    `# Changelog\n\n${UNRELEASED_CHANGELOG_TEMPLATE}\n`,
+  );
+  if (prepared === released) {
+    throw new Error("could not open the next Unreleased changelog section");
+  }
+  return prepared;
+}
+
+export function assertPreparedReleaseChangelog(changelog, tag, upstream) {
+  const version = releaseVersion(normalizeReleaseTag(tag));
+  const unreleased = changelog.match(/(?:^|\n)## \[Unreleased\]\n([\s\S]*?)(?=\n## |$)/);
+  if (!unreleased) {
+    throw new Error("CHANGELOG.md is missing an Unreleased section");
+  }
+  if (removeEmptyChangelogSubsections(unreleased[1]).trim()) {
+    throw new Error("CHANGELOG.md Unreleased section must be empty before tagging");
+  }
+
+  const releasePattern = new RegExp(
+    `(?:^|\\n)## \\[${escapeRegex(version)}\\] - [^\\n]+\\n([\\s\\S]*?)(?=\\n## |$)`,
+    "g",
+  );
+  const releases = [...changelog.matchAll(releasePattern)];
+  if (releases.length !== 1 || !releases[0][1].trim()) {
+    throw new Error(`CHANGELOG.md must contain exactly one non-empty release section for ${tag}`);
+  }
+  const expectedBaseline = herdrWebBaselineNote(upstream);
+  if (!releases[0][1].includes(expectedBaseline)) {
+    throw new Error(
+      `CHANGELOG.md release section for ${tag} must record the current Herdr Web baseline`,
+    );
+  }
+  return true;
+}

--- a/scripts/release-changelog.mjs
+++ b/scripts/release-changelog.mjs
@@ -75,7 +75,7 @@ export function prepareReleaseChangelog(changelog, tag, date, upstream) {
   return prepared;
 }
 
-export function assertPreparedReleaseChangelog(changelog, tag, upstream) {
+export function assertPreparedReleaseChangelog(changelog, tag, upstream, expectedDate) {
   const version = releaseVersion(normalizeReleaseTag(tag));
   const unreleased = changelog.match(/(?:^|\n)## \[Unreleased\]\n([\s\S]*?)(?=\n## |$)/);
   if (!unreleased) {
@@ -86,15 +86,23 @@ export function assertPreparedReleaseChangelog(changelog, tag, upstream) {
   }
 
   const releasePattern = new RegExp(
-    `(?:^|\\n)## \\[${escapeRegex(version)}\\] - [^\\n]+\\n([\\s\\S]*?)(?=\\n## |$)`,
+    `(?:^|\\n)## \\[${escapeRegex(version)}\\] - (\\d{4}-\\d{2}-\\d{2})\\n` +
+      `([\\s\\S]*?)(?=\\n## |$)`,
     "g",
   );
   const releases = [...changelog.matchAll(releasePattern)];
-  if (releases.length !== 1 || !releases[0][1].trim()) {
+  if (releases.length !== 1 || !releases[0][2].trim()) {
     throw new Error(`CHANGELOG.md must contain exactly one non-empty release section for ${tag}`);
   }
+  const releaseDate = releases[0][1];
+  if (expectedDate && releaseDate !== expectedDate) {
+    throw new Error(
+      `CHANGELOG.md release date for ${tag} is ${releaseDate}, not ${expectedDate}; ` +
+      "update and review the release PR before tagging",
+    );
+  }
   const expectedBaseline = herdrWebBaselineNote(upstream);
-  if (!releases[0][1].includes(expectedBaseline)) {
+  if (!releases[0][2].includes(expectedBaseline)) {
     throw new Error(
       `CHANGELOG.md release section for ${tag} must record the current Herdr Web baseline`,
     );

--- a/scripts/release-changelog.test.mjs
+++ b/scripts/release-changelog.test.mjs
@@ -1,0 +1,107 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  assertPreparedReleaseChangelog,
+  herdrWebBaselineNote,
+  prepareReleaseChangelog,
+} from "./release-changelog.mjs";
+
+const upstream = `# Upstreams
+
+Current synchronization points:
+
+- Herdr Web: \`4384c884da418ea3f3fb75954da5347b2e12f063\`
+  (\`v0.5.0\` plus the JetBrains Mono fallback)
+`;
+
+const source = `# Changelog
+
+## [Unreleased]
+
+### Breaking Changes
+
+### Added
+
+- Stable feature.
+
+### Changed
+
+### Fixed
+
+- Stable fix.
+
+### Removed
+
+## [0.9.0] - 2026-08-01
+
+- Earlier release.
+
+## Herdr Web 0.1.0 - 2026-06-16
+
+- Upstream release.
+`;
+
+test("prepares one reviewed release diff with the next Unreleased section already open", () => {
+  const prepared = prepareReleaseChangelog(source, "v1.0.0", "2026-08-31", upstream);
+
+  assert.match(prepared, /^# Changelog\n\n## \[Unreleased\]/);
+  assert.match(prepared, /## \[1\.0\.0\] - 2026-08-31/);
+  assert.match(
+    prepared,
+    /> \*\*Herdr Web baseline:\*\* Derived from v0\.5\.0 plus the JetBrains Mono fallback at\n> \[`4384c884`\]\(https:\/\/github\.com\/kcosr\/herdr-web\/commit\/4384c884da418ea3f3fb75954da5347b2e12f063\)\.\n\n### Added/,
+  );
+  assert.match(prepared, /### Added\n\n- Stable feature\./);
+  assert.match(prepared, /### Fixed\n\n- Stable fix\./);
+  assert.doesNotMatch(
+    prepared.match(/## \[1\.0\.0\][\s\S]*?(?=\n## |$)/)?.[0] ?? "",
+    /Breaking Changes|### Changed|### Removed/,
+  );
+  assert.equal(assertPreparedReleaseChangelog(prepared, "v1.0.0", upstream), true);
+});
+
+test("formats the exact Herdr Web synchronization point as release provenance", () => {
+  assert.equal(
+    herdrWebBaselineNote(upstream),
+    "> **Herdr Web baseline:** Derived from v0.5.0 plus the JetBrains Mono fallback at\n" +
+      "> [`4384c884`](https://github.com/kcosr/herdr-web/commit/4384c884da418ea3f3fb75954da5347b2e12f063).",
+  );
+  assert.throws(
+    () => herdrWebBaselineNote("# Upstreams\n"),
+    /missing a parseable Herdr Web synchronization point/,
+  );
+});
+
+test("rejects empty, duplicate, and post-preparation Unreleased notes", () => {
+  assert.throws(
+    () => prepareReleaseChangelog(source, "v0.9.0", "2026-08-31", upstream),
+    /already contains a release section/,
+  );
+  assert.throws(
+    () => prepareReleaseChangelog(
+      source.replace("- Stable feature.", "").replace("- Stable fix.", ""),
+      "v1.0.0",
+      "2026-08-31",
+      upstream,
+    ),
+    /no release notes/,
+  );
+
+  const prepared = prepareReleaseChangelog(source, "v1.0.0", "2026-08-31", upstream);
+  assert.throws(
+    () => assertPreparedReleaseChangelog(
+      prepared.replace("### Added\n\n### Changed", "### Added\n\n- Late change.\n\n### Changed"),
+      "v1.0.0",
+      upstream,
+    ),
+    /Unreleased section must be empty/,
+  );
+  assert.throws(
+    () => assertPreparedReleaseChangelog(
+      prepared.replace("v0.5.0 plus the JetBrains Mono fallback", "v0.4.2"),
+      "v1.0.0",
+      upstream,
+    ),
+    /must record the current Herdr Web baseline/,
+  );
+});

--- a/scripts/release-changelog.test.mjs
+++ b/scripts/release-changelog.test.mjs
@@ -57,7 +57,10 @@ test("prepares one reviewed release diff with the next Unreleased section alread
     prepared.match(/## \[1\.0\.0\][\s\S]*?(?=\n## |$)/)?.[0] ?? "",
     /Breaking Changes|### Changed|### Removed/,
   );
-  assert.equal(assertPreparedReleaseChangelog(prepared, "v1.0.0", upstream), true);
+  assert.equal(
+    assertPreparedReleaseChangelog(prepared, "v1.0.0", upstream, "2026-08-31"),
+    true,
+  );
 });
 
 test("formats the exact Herdr Web synchronization point as release provenance", () => {
@@ -103,5 +106,9 @@ test("rejects empty, duplicate, and post-preparation Unreleased notes", () => {
       upstream,
     ),
     /must record the current Herdr Web baseline/,
+  );
+  assert.throws(
+    () => assertPreparedReleaseChangelog(prepared, "v1.0.0", upstream, "2026-09-01"),
+    /release date for v1\.0\.0 is 2026-08-31, not 2026-09-01/,
   );
 });

--- a/scripts/release-notes.mjs
+++ b/scripts/release-notes.mjs
@@ -8,7 +8,7 @@ import { normalizeReleaseTag, releaseVersion } from "./release-version.mjs";
 export function extractReleaseNotes(changelog, tag) {
   const version = releaseVersion(normalizeReleaseTag(tag));
   const sections = changelog.matchAll(
-    /(?:^|\n)## \[([^\]]+)\] - [^\n]+\n([\s\S]*?)(?=\n## \[|$)/g,
+    /(?:^|\n)## \[([^\]]+)\] - [^\n]+\n([\s\S]*?)(?=\n## |$)/g,
   );
   const match = [...sections].find(([, candidate]) => candidate === version);
   if (!match || !match[2].trim()) {

--- a/scripts/release-notes.test.mjs
+++ b/scripts/release-notes.test.mjs
@@ -37,3 +37,18 @@ test("extractReleaseNotes rejects a missing release section", () => {
     /has no release notes/,
   );
 });
+
+test("extractReleaseNotes stops before any following level-two section", () => {
+  const changelog = `# Changelog
+
+## [1.0.0] - 2026-08-31
+
+- World release.
+
+## Appendix
+
+- Supporting information.
+`;
+
+  assert.equal(extractReleaseNotes(changelog, "v1.0.0"), "- World release.");
+});

--- a/scripts/release-version.mjs
+++ b/scripts/release-version.mjs
@@ -43,7 +43,7 @@ export function escapeRegex(value) {
 
 export function isReleaseCommitSubject(subject, tag) {
   const expected = `Release ${normalizeReleaseTag(tag)}`;
-  return subject === expected || new RegExp(`^${escapeRegex(expected)} \\(#\\d+\\)$`).test(subject);
+  return new RegExp(`^${escapeRegex(expected)} \\(#\\d+\\)$`).test(subject);
 }
 
 export function releaseVersion(value) {

--- a/scripts/release-version.test.mjs
+++ b/scripts/release-version.test.mjs
@@ -59,8 +59,8 @@ test("maps release types to their public install channels", () => {
   assert.equal(homebrewFormulaName("v1.2.3"), "herdr-world");
 });
 
-test("accepts exact and GitHub squash-merged release commit subjects", () => {
-  assert.equal(isReleaseCommitSubject("Release v1.2.3", "v1.2.3"), true);
+test("accepts only the reviewed GitHub squash-merged release commit subject", () => {
+  assert.equal(isReleaseCommitSubject("Release v1.2.3", "v1.2.3"), false);
   assert.equal(isReleaseCommitSubject("Release v1.2.3-rc.9 (#46)", "v1.2.3-rc.9"), true);
   assert.equal(isReleaseCommitSubject("Release v1.2.3-rc.9 (#)", "v1.2.3-rc.9"), false);
   assert.equal(isReleaseCommitSubject("Release v1.2.3-rc.9 (#46) extra", "v1.2.3-rc.9"), false);

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -5,6 +5,10 @@ import { readFileSync, writeFileSync } from "node:fs";
 import { queryNpm } from "./npm-registry-query.mjs";
 import { homebrewFormulaReleaseTag } from "./homebrew-formula.mjs";
 import {
+  assertPreparedReleaseChangelog,
+  prepareReleaseChangelog,
+} from "./release-changelog.mjs";
+import {
   HOMEBREW_TAP_REPOSITORY,
   NPM_PACKAGE_NAME,
 } from "./release-publication.mjs";
@@ -16,17 +20,17 @@ import {
 } from "./release-target.mjs";
 import {
   compareReleaseTags,
-  escapeRegex,
+  assertCurrentReleaseReferences,
+  isReleaseCommitSubject,
   normalizeReleaseTag,
-  releaseReferencePaths,
   stampCurrentRelease,
 } from "./release-version.mjs";
 
 const RELEASE_BRANCH = "main";
-const RELEASE_ARG = process.argv[2];
+const [RELEASE_MODE, RELEASE_ARG] = process.argv.slice(2);
 
-if (!RELEASE_ARG || process.argv.length !== 3) {
-  console.error("Usage: node scripts/release.mjs <vX.Y.Z|X.Y.Z>");
+if (!["prepare", "tag"].includes(RELEASE_MODE) || !RELEASE_ARG || process.argv.length !== 4) {
+  console.error("Usage: node scripts/release.mjs <prepare|tag> <vX.Y.Z|X.Y.Z>");
   process.exit(1);
 }
 
@@ -39,7 +43,6 @@ try {
 }
 const version = tag.slice(1);
 const today = new Date().toISOString().slice(0, 10);
-const changelogSubsections = ["Breaking Changes", "Added", "Changed", "Fixed", "Removed"];
 
 function run(command, args, options = {}) {
   return execFileSync(command, args, {
@@ -188,16 +191,13 @@ function checkExternalVersionAvailability() {
   }
 }
 
-function validatePreflight() {
+function validateCleanWorkingTree() {
   if (output("git", ["status", "--porcelain"]) !== "") {
     fail("release requires a clean working tree");
   }
+}
 
-  const branch = output("git", ["branch", "--show-current"]);
-  if (branch !== RELEASE_BRANCH) {
-    fail(`release must run from ${RELEASE_BRANCH}; current branch is ${branch || "(detached)"}`);
-  }
-
+function validateRepositoryAccess() {
   try {
     const fetchUrls = output("git", ["remote", "get-url", "--all", RELEASE_REMOTE])
       .split("\n")
@@ -228,19 +228,14 @@ function validatePreflight() {
   if (accessibleRepository.toLowerCase() !== RELEASE_REPOSITORY.toLowerCase()) {
     fail(`GitHub CLI resolved the release repository as ${accessibleRepository}`);
   }
+}
 
+function fetchMainWithoutTags() {
   run("git", ["fetch", RELEASE_REMOTE, RELEASE_BRANCH, "--no-tags"]);
-  const local = output("git", ["rev-parse", RELEASE_BRANCH]);
-  const remote = output("git", ["rev-parse", `${RELEASE_REMOTE}/${RELEASE_BRANCH}`]);
-  if (local !== remote) {
-    fail(
-      `${RELEASE_BRANCH} must match ${RELEASE_REMOTE}/${RELEASE_BRANCH}; run git pull --ff-only first`,
-    );
-  }
+  return output("git", ["rev-parse", `${RELEASE_REMOTE}/${RELEASE_BRANCH}`]);
+}
 
-  if (commandSucceeds("git", ["rev-parse", "--verify", "--quiet", tag])) {
-    fail(`tag already exists locally: ${tag}`);
-  }
+function validateRemoteReleaseTarget() {
   if (
     commandSucceeds("git", ["ls-remote", "--exit-code", "--tags", RELEASE_REMOTE, `refs/tags/${tag}`])
   ) {
@@ -253,77 +248,153 @@ function validatePreflight() {
   checkExternalVersionAvailability();
 }
 
-function readChangelogForRelease() {
-  const changelog = readFileSync("CHANGELOG.md", "utf8");
-  const unreleased = changelog.match(/## \[Unreleased\]\n([\s\S]*?)(?=\n## \[|$)/);
-  if (!unreleased) {
-    fail("CHANGELOG.md is missing an Unreleased section");
+function validatePreparationBase() {
+  validateCleanWorkingTree();
+  const branch = output("git", ["branch", "--show-current"]);
+  if (!branch || branch === RELEASE_BRANCH) {
+    fail("release preparation must run from a review branch, not main or detached HEAD");
   }
-  if (!removeEmptyChangelogSubsections(unreleased[1]).trim()) {
-    fail("CHANGELOG.md has no release notes under Unreleased");
-  }
-  return changelog;
-}
-
-function stampChangelog(changelog) {
-  const stamped = changelog.replace("## [Unreleased]", `## [${version}] - ${today}`);
-  const released = removeEmptyReleaseSubsections(stamped);
-  if (stamped === changelog) {
-    fail("CHANGELOG.md is missing an Unreleased section");
-  }
-  writeFileSync("CHANGELOG.md", released);
-  return released;
-}
-
-function removeEmptyReleaseSubsections(changelog) {
-  const releasePattern = new RegExp(
-    `(## \\[${escapeRegex(version)}\\] - [^\\n]+\\n)([\\s\\S]*?)(?=\\n## \\[|$)`,
-  );
-  return changelog.replace(releasePattern, (_match, heading, body) => {
-    return `${heading}${removeEmptyChangelogSubsections(body)}`;
-  });
-}
-
-function removeEmptyChangelogSubsections(body) {
-  let cleaned = body;
-  for (const subsection of changelogSubsections) {
-    cleaned = cleaned.replace(
-      new RegExp(`(^|\\n)### ${escapeRegex(subsection)}\\n\\n*(?=### |$)`, "g"),
-      "$1",
+  validateRepositoryAccess();
+  const remoteMain = fetchMainWithoutTags();
+  const head = output("git", ["rev-parse", "HEAD"]);
+  if (head !== remoteMain) {
+    fail(
+      `release preparation branch must start at ${RELEASE_REMOTE}/${RELEASE_BRANCH}; ` +
+      "create a fresh branch from the current remote main",
     );
   }
-  cleaned = cleaned.replace(/\n{3,}/g, "\n\n").trimEnd();
-  return cleaned ? `\n${cleaned.trimStart()}\n` : "\n";
+  validateRemoteReleaseTarget();
+  return head;
 }
 
-function openNextUnreleased(changelog) {
-  const next = changelog.replace(
-    "# Changelog\n\n",
-    "# Changelog\n\n## [Unreleased]\n\n### Breaking Changes\n\n### Added\n\n### Changed\n\n### Fixed\n\n### Removed\n\n",
-  );
-  if (next === changelog) {
-    fail("could not open next Unreleased changelog section");
+function validateSuccessfulDistributionPreflight(head) {
+  let runs;
+  try {
+    runs = JSON.parse(output("gh", withReleaseRepository([
+      "run",
+      "list",
+      "--workflow",
+      "release.yml",
+      "--event",
+      "workflow_dispatch",
+      "--commit",
+      head,
+      "--status",
+      "success",
+      "--limit",
+      "10",
+      "--json",
+      "databaseId,headSha,status,conclusion,url",
+    ])) || "[]");
+  } catch (error) {
+    fail(`could not verify the distribution preflight: ${error.message}`);
   }
-  writeFileSync("CHANGELOG.md", next);
+  const successful = runs.find((run) =>
+    run.headSha === head && run.status === "completed" && run.conclusion === "success"
+  );
+  if (!successful) {
+    fail(
+      `no successful workflow-dispatch release preflight exists for ${head}; ` +
+      `run gh workflow run release.yml --ref ${RELEASE_BRANCH} and wait for it to pass`,
+    );
+  }
+  return successful;
 }
 
-validatePreflight();
-const changelog = readChangelogForRelease();
+function validateTaggingBase() {
+  validateCleanWorkingTree();
+  const branch = output("git", ["branch", "--show-current"]);
+  if (branch !== RELEASE_BRANCH) {
+    fail(`release tagging must run from ${RELEASE_BRANCH}; current branch is ${branch || "(detached)"}`);
+  }
+  validateRepositoryAccess();
+  const remoteMain = fetchMainWithoutTags();
+  const head = output("git", ["rev-parse", "HEAD"]);
+  if (head !== remoteMain) {
+    fail(
+      `${RELEASE_BRANCH} must match ${RELEASE_REMOTE}/${RELEASE_BRANCH}; run git pull --ff-only first`,
+    );
+  }
+  if (commandSucceeds("git", ["show-ref", "--verify", "--quiet", `refs/tags/${tag}`])) {
+    fail(
+      `tag already exists locally: ${tag}; use a clean origin-only release clone so an ` +
+      "inherited upstream tag cannot be mistaken for the Herdr World release",
+    );
+  }
+  validateRemoteReleaseTarget();
 
-run("npm", ["run", "check"]);
+  let current;
+  try {
+    current = assertCurrentReleaseReferences();
+  } catch (error) {
+    fail(error.message);
+  }
+  if (current !== tag) {
+    fail(`public release references point to ${current}, not ${tag}`);
+  }
+  try {
+    assertPreparedReleaseChangelog(
+      readFileSync("CHANGELOG.md", "utf8"),
+      tag,
+      readFileSync("UPSTREAM.md", "utf8"),
+    );
+  } catch (error) {
+    fail(error.message);
+  }
+  const subject = output("git", ["show", "-s", "--format=%s", "HEAD"]);
+  if (!isReleaseCommitSubject(subject, tag)) {
+    fail(`release commit must be the reviewed squash merge Release ${tag} (#<number>); found ${subject}`);
+  }
+  const preflight = validateSuccessfulDistributionPreflight(head);
+  return { head, preflight };
+}
 
-stampCurrentRelease(tag);
-const released = stampChangelog(changelog);
+function prepareRelease() {
+  const head = validatePreparationBase();
+  const changelog = readFileSync("CHANGELOG.md", "utf8");
+  const upstream = readFileSync("UPSTREAM.md", "utf8");
+  run("npm", ["run", "check"]);
+  if (fetchMainWithoutTags() !== head) {
+    fail(`${RELEASE_REMOTE}/${RELEASE_BRANCH} advanced during release preparation; start again`);
+  }
+  validateRemoteReleaseTarget();
 
-run("npm", ["run", "test:release"]);
-run("npm", ["run", "test:pages"]);
+  try {
+    stampCurrentRelease(tag);
+    writeFileSync("CHANGELOG.md", prepareReleaseChangelog(changelog, tag, today, upstream));
+  } catch (error) {
+    fail(error.message);
+  }
 
-run("git", ["add", "CHANGELOG.md", ...releaseReferencePaths()]);
-run("git", ["commit", "-m", `Release ${tag}`]);
-run("git", ["tag", tag]);
-run("git", ["push", "--atomic", RELEASE_REMOTE, RELEASE_BRANCH, tag]);
+  run("npm", ["run", "test:release"]);
+  run("npm", ["run", "test:pages"]);
+  run("git", ["diff", "--check"]);
+  console.log(
+    `Prepared ${tag}. Review the generated diff, commit it as Release ${tag}, ` +
+    "and deliver it through an independently reviewed pull request.",
+  );
+}
 
-openNextUnreleased(released);
-run("git", ["add", "CHANGELOG.md"]);
-run("git", ["commit", "-m", "Prepare for next release"]);
-run("git", ["push", RELEASE_REMOTE, RELEASE_BRANCH]);
+function tagRelease() {
+  const { head, preflight } = validateTaggingBase();
+  run("npm", ["run", "check"]);
+  if (fetchMainWithoutTags() !== head) {
+    fail(`${RELEASE_REMOTE}/${RELEASE_BRANCH} advanced during release validation; do not tag`);
+  }
+  validateRemoteReleaseTarget();
+  run("git", [
+    "push",
+    RELEASE_REMOTE,
+    `${head}:refs/tags/${tag}`,
+  ]);
+  console.log(
+    `Tagged ${tag} at ${head} after distribution preflight ${preflight.url}. ` +
+    "Monitor Release distribution and Deploy GitHub Pages before announcing the release.",
+  );
+}
+
+if (RELEASE_MODE === "prepare") {
+  prepareRelease();
+} else {
+  tagRelease();
+}

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -42,7 +42,10 @@ try {
   process.exit(1);
 }
 const version = tag.slice(1);
-const today = new Date().toISOString().slice(0, 10);
+
+function currentUtcDate() {
+  return new Date().toISOString().slice(0, 10);
+}
 
 function run(command, args, options = {}) {
   return execFileSync(command, args, {
@@ -301,6 +304,15 @@ function validateSuccessfulDistributionPreflight(head) {
   return successful;
 }
 
+function validatePreparedChangelogForTag() {
+  assertPreparedReleaseChangelog(
+    readFileSync("CHANGELOG.md", "utf8"),
+    tag,
+    readFileSync("UPSTREAM.md", "utf8"),
+    currentUtcDate(),
+  );
+}
+
 function validateTaggingBase() {
   validateCleanWorkingTree();
   const branch = output("git", ["branch", "--show-current"]);
@@ -333,11 +345,7 @@ function validateTaggingBase() {
     fail(`public release references point to ${current}, not ${tag}`);
   }
   try {
-    assertPreparedReleaseChangelog(
-      readFileSync("CHANGELOG.md", "utf8"),
-      tag,
-      readFileSync("UPSTREAM.md", "utf8"),
-    );
+    validatePreparedChangelogForTag();
   } catch (error) {
     fail(error.message);
   }
@@ -358,10 +366,11 @@ function prepareRelease() {
     fail(`${RELEASE_REMOTE}/${RELEASE_BRANCH} advanced during release preparation; start again`);
   }
   validateRemoteReleaseTarget();
+  const releaseDate = currentUtcDate();
 
   try {
     stampCurrentRelease(tag);
-    writeFileSync("CHANGELOG.md", prepareReleaseChangelog(changelog, tag, today, upstream));
+    writeFileSync("CHANGELOG.md", prepareReleaseChangelog(changelog, tag, releaseDate, upstream));
   } catch (error) {
     fail(error.message);
   }
@@ -382,6 +391,11 @@ function tagRelease() {
     fail(`${RELEASE_REMOTE}/${RELEASE_BRANCH} advanced during release validation; do not tag`);
   }
   validateRemoteReleaseTarget();
+  try {
+    validatePreparedChangelogForTag();
+  } catch (error) {
+    fail(error.message);
+  }
   run("git", [
     "push",
     RELEASE_REMOTE,

--- a/scripts/validate-release.mjs
+++ b/scripts/validate-release.mjs
@@ -5,11 +5,11 @@ import { join } from "node:path";
 
 import {
   assertCurrentReleaseReferences,
-  escapeRegex,
   isReleaseCommitSubject,
   normalizeReleaseTag,
   releaseVersion,
 } from "./release-version.mjs";
+import { assertPreparedReleaseChangelog } from "./release-changelog.mjs";
 import { assertPluginManifest, parsePluginManifest } from "./herdr-world-plugin.mjs";
 
 const root = process.cwd();
@@ -59,7 +59,7 @@ try {
 
 const subject = output("git", ["show", "-s", "--format=%s", tagSha]);
 if (!isReleaseCommitSubject(subject, tag)) {
-  fail(`tagged commit subject must be Release ${tag} or GitHub's squash-merge form Release ${tag} (#<number>); found ${subject}`);
+  fail(`tagged commit subject must be the reviewed squash merge Release ${tag} (#<number>); found ${subject}`);
 }
 
 try {
@@ -69,9 +69,14 @@ try {
 }
 
 const changelog = readFileSync(join(root, "CHANGELOG.md"), "utf8");
-const changelogHeading = new RegExp(`^## \\[${escapeRegex(releaseVersion(tag))}\\] - `, "m");
-if (!changelogHeading.test(changelog)) {
-  fail(`CHANGELOG.md has no released section for ${tag}`);
+try {
+  assertPreparedReleaseChangelog(
+    changelog,
+    tag,
+    readFileSync(join(root, "UPSTREAM.md"), "utf8"),
+  );
+} catch (error) {
+  fail(error.message);
 }
 
 for (const relativePath of ["package.json", "web/package.json"]) {


### PR DESCRIPTION
## Summary

- split release operation into a reviewed preparation PR and an exact-main tag-only phase
- keep the World changelog downstream-owned while correlating every release with its exact Herdr Web baseline from UPSTREAM.md
- require the reviewed squash merge and a successful distribution preflight for the exact release commit
- document the two-phase operator workflow and the upstream tag collision handling

## Validation

- npm run check
- npm run test:release
- npm run test:pages
- git diff --check

This PR changes release mechanics only. It does not create, tag, publish, or merge the v0.1.0 release.