### PR TITLE
Release v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ Web's own release history remains in its upstream changelog.
   stable channels, removed release-candidate-only download labels, and made Pages validation aware
   of the selected release channel. Release preparation also keeps the changelog preamble outside
   the fresh empty `Unreleased` section so tag validation sees the intended release boundary.
+  [Herdr World PR #64](https://github.com/IvoryHeart/herdr-world/pull/64)
 - Stopped Office anchor updates from recursively rebuilding the Pixi scene while idle or resizing,
   keeping the interface responsive without increasing terminal resize traffic.
   [Herdr World PR #62](https://github.com/IvoryHeart/herdr-world/pull/62)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,19 @@ Web's own release history remains in its upstream changelog.
 
 ### Added
 
+### Changed
+
+### Fixed
+
+### Removed
+
+## [0.1.0] - 2026-08-31
+
+> **Herdr Web baseline:** Derived from v0.5.0 plus the JetBrains Mono Nerd Font fallback merged in upstream PR #74 at
+> [`4384c884`](https://github.com/kcosr/herdr-web/commit/4384c884da418ea3f3fb75954da5347b2e12f063).
+
+### Added
+
 - Added `herdr-world task-summary` for agent harnesses to publish or clear bounded, expiring,
   session-qualified Office summaries through Herdr's existing pane-metadata contract.
   [Herdr World PR #61](https://github.com/IvoryHeart/herdr-world/pull/61)
@@ -35,6 +48,10 @@ Web's own release history remains in its upstream changelog.
 
 ### Fixed
 
+- Kept stable README and project-site installation instructions on the npm `latest` and Homebrew
+  stable channels, removed release-candidate-only download labels, and made Pages validation aware
+  of the selected release channel. Release preparation also keeps the changelog preamble outside
+  the fresh empty `Unreleased` section so tag validation sees the intended release boundary.
 - Stopped Office anchor updates from recursively rebuilding the Pixi scene while idle or resizing,
   keeping the interface responsive without increasing terminal resize traffic.
   [Herdr World PR #62](https://github.com/IvoryHeart/herdr-world/pull/62)
@@ -46,8 +63,6 @@ Web's own release history remains in its upstream changelog.
   conversation window.
   [Issue #5](https://github.com/IvoryHeart/herdr-world/issues/5),
   [Herdr World PR #61](https://github.com/IvoryHeart/herdr-world/pull/61)
-
-### Removed
 
 ## [0.1.0-rc.15] - 2026-08-30
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ It combines live terminal Spaces with a visual Pixel Office, multi-host viewing,
 mobile controls, notes, uploads, and agent-aware workflows.
 
 The current public preview is
-[`v0.1.0-rc.15`](https://github.com/IvoryHeart/herdr-world/releases/tag/v0.1.0-rc.15).
+[`v0.1.0`](https://github.com/IvoryHeart/herdr-world/releases/tag/v0.1.0).
 It supports Linux x86-64 and macOS on Apple Silicon and Intel, and requires Herdr `v0.8.2` or newer
 with terminal protocol `20`. Visit the [project site](https://ivoryheart.github.io/herdr-world/) for
 an interactive overview.
@@ -26,27 +26,27 @@ require Node.js `22.14.0` or newer.
 ### npm
 
 ```bash
-npm install --global @ivoryheart/herdr-world@next
+npm install --global @ivoryheart/herdr-world@latest
 herdr-world
 ```
 
 ### Homebrew
 
 ```bash
-brew install IvoryHeart/tap/herdr-world-rc
+brew install IvoryHeart/tap/herdr-world
 herdr-world
 ```
 
 ### Herdr plugin
 
 ```bash
-herdr plugin install IvoryHeart/herdr-world --ref v0.1.0-rc.15
+herdr plugin install IvoryHeart/herdr-world --ref v0.1.0
 herdr plugin action invoke open --plugin ivoryheart.herdr-world
 ```
 
 Open [http://127.0.0.1:8787](http://127.0.0.1:8787) if the browser does not open automatically.
 Checksum-verified standalone archives are available on the
-[release page](https://github.com/IvoryHeart/herdr-world/releases/tag/v0.1.0-rc.15).
+[release page](https://github.com/IvoryHeart/herdr-world/releases/tag/v0.1.0).
 
 The macOS binaries are not yet signed or notarized. After verifying the download, the first launch
 may need approval in **System Settings → Privacy & Security**.

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -1,6 +1,6 @@
 id = "ivoryheart.herdr-world"
 name = "Herdr World"
-version = "0.1.0-rc.15"
+version = "0.1.0"
 min_herdr_version = "0.8.2"
 description = "Browser and mobile client for monitoring and controlling Herdr agents."
 platforms = ["linux", "macos"]

--- a/release.json
+++ b/release.json
@@ -1,3 +1,3 @@
 {
-  "current": "v0.1.0-rc.15"
+  "current": "v0.1.0"
 }

--- a/scripts/pages.test.mjs
+++ b/scripts/pages.test.mjs
@@ -5,7 +5,11 @@ import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import test from "node:test";
 
-import { readCurrentReleaseTag } from "./release-version.mjs";
+import {
+  homebrewFormulaName,
+  npmDistributionTag,
+  readCurrentReleaseTag,
+} from "./release-version.mjs";
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const output = join(root, "_site");
@@ -54,15 +58,24 @@ test("the Pages artifact is self-contained and release-accurate", () => {
   assert.match(html, /data-install-tab="herdr"/);
   assert.match(html, /data-install-tab="cli"/);
   assert.match(html, /data-install-tab="cli">CLI<\/button>/);
-  assert.match(html, /npm install --global @ivoryheart\/herdr-world@next/);
+  assert.match(
+    html,
+    new RegExp(
+      "npm install --global @ivoryheart/herdr-world@" + npmDistributionTag(currentRelease),
+    ),
+  );
   assert.ok(html.includes(`@ivoryheart/herdr-world@${currentRelease.slice(1)}`));
-  assert.match(html, /brew install IvoryHeart\/tap\/herdr-world-rc/);
+  assert.match(
+    html,
+    new RegExp("brew install IvoryHeart/tap/" + homebrewFormulaName(currentRelease)),
+  );
   assert.match(html, new RegExp("herdr plugin install IvoryHeart/herdr-world --ref " + currentRelease));
   assert.match(html, /<details class="install-advanced">/);
   assert.ok(html.includes(`data-install-command="cli">VERSION=${currentRelease}`));
   assert.match(html, /curl -fLO .*herdr-world-\$\{VERSION\}-\$\{PLATFORM\}\.tar\.gz/);
   assert.match(html, /tar -xzf .*herdr-world-\$\{VERSION\}-\$\{PLATFORM\}\.tar\.gz/);
   assert.doesNotMatch(html, /Runtime and Herdr plugin commands/);
+  assert.doesNotMatch(html, /Download the RC|current release candidate|preview Formula/);
   assert.match(readFileSync(join(output, "site.js"), "utf8"), /data-install-tab/);
   assert.doesNotMatch(html, /(?:src|href)="\/(?!\/)/, "local references must be relative");
   assert.doesNotMatch(html, /file:\/\//, "local filesystem URLs must not ship");

--- a/scripts/release-changelog.mjs
+++ b/scripts/release-changelog.mjs
@@ -61,15 +61,12 @@ export function prepareReleaseChangelog(changelog, tag, date, upstream) {
     throw new Error("CHANGELOG.md has no release notes under Unreleased");
   }
 
-  const released = changelog.replace(
+  const prepared = changelog.replace(
     unreleasedPattern,
-    `${unreleased[1]}## [${version}] - ${date}\n\n${herdrWebBaselineNote(upstream)}\n${releaseBody}`,
+    `${unreleased[1]}${UNRELEASED_CHANGELOG_TEMPLATE}\n` +
+      `## [${version}] - ${date}\n\n${herdrWebBaselineNote(upstream)}\n${releaseBody}`,
   );
-  const prepared = released.replace(
-    "# Changelog\n\n",
-    `# Changelog\n\n${UNRELEASED_CHANGELOG_TEMPLATE}\n`,
-  );
-  if (prepared === released) {
+  if (prepared === changelog) {
     throw new Error("could not open the next Unreleased changelog section");
   }
   return prepared;

--- a/scripts/release-changelog.test.mjs
+++ b/scripts/release-changelog.test.mjs
@@ -17,6 +17,8 @@ Current synchronization points:
 
 const source = `# Changelog
 
+World releases and downstream changes only.
+
 ## [Unreleased]
 
 ### Breaking Changes
@@ -45,7 +47,10 @@ const source = `# Changelog
 test("prepares one reviewed release diff with the next Unreleased section already open", () => {
   const prepared = prepareReleaseChangelog(source, "v1.0.0", "2026-08-31", upstream);
 
-  assert.match(prepared, /^# Changelog\n\n## \[Unreleased\]/);
+  assert.match(
+    prepared,
+    /^# Changelog\n\nWorld releases and downstream changes only\.\n\n## \[Unreleased\]/,
+  );
   assert.match(prepared, /## \[1\.0\.0\] - 2026-08-31/);
   assert.match(
     prepared,

--- a/scripts/release-version.mjs
+++ b/scripts/release-version.mjs
@@ -129,7 +129,7 @@ export function stampCurrentRelease(
     const oldReference = relativePath === "herdr-plugin.toml" ? releaseVersion(current) : current;
     const newReference = relativePath === "herdr-plugin.toml" ? releaseVersion(newTag) : newTag;
     let updated = contents.replaceAll(oldReference, newReference);
-    if (relativePath === "site/index.html" || relativePath === "site/site.js") {
+    if (["README.md", "site/index.html", "site/site.js"].includes(relativePath)) {
       updated = updated
         .replaceAll(`@${npmDistributionTag(current)}`, `@${npmDistributionTag(newTag)}`)
         .replaceAll(

--- a/scripts/release-version.test.mjs
+++ b/scripts/release-version.test.mjs
@@ -118,12 +118,15 @@ test("stamps the plugin manifest's intentionally unprefixed version", () => {
   }
 });
 
-test("switches site install channels when moving from an RC to stable", () => {
+test("switches public install channels when moving from an RC to stable", () => {
   const root = mkdtempSync(join(tmpdir(), "herdr-world-release-channels-"));
   try {
     mkdirSync(join(root, "site"));
     writeFileSync(join(root, "release.json"), '{"current":"v1.2.3-rc.1"}\n');
-    writeFileSync(join(root, "README.md"), "v1.2.3-rc.1\n");
+    writeFileSync(
+      join(root, "README.md"),
+      "v1.2.3-rc.1 @1.2.3-rc.1 @next tap/herdr-world-rc upgrade herdr-world-rc uninstall herdr-world-rc\n",
+    );
     writeFileSync(
       join(root, "site", "index.html"),
       "v1.2.3-rc.1 @1.2.3-rc.1 @next tap/herdr-world-rc upgrade herdr-world-rc uninstall herdr-world-rc\n",
@@ -135,7 +138,7 @@ test("switches site install channels when moving from an RC to stable", () => {
 
     stampCurrentRelease("v1.2.3", root);
 
-    for (const relativePath of ["site/index.html", "site/site.js"]) {
+    for (const relativePath of ["README.md", "site/index.html", "site/site.js"]) {
       const contents = readFileSync(join(root, relativePath), "utf8");
       assert.match(contents, /@1\.2\.3/);
       assert.match(contents, /@latest/);

--- a/site/index.html
+++ b/site/index.html
@@ -44,7 +44,7 @@
           <h1 id="hero-title">Your agents.<br /><em>One office.</em></h1>
           <p class="hero-intro">Herdr World turns live Herdr sessions into one visual workspace: terminal-first Spaces, a multi-host Pixel Office, and the controls to move between them without losing context.</p>
           <div class="hero-actions">
-            <a class="button button-primary" href="https://github.com/IvoryHeart/herdr-world/releases/tag/v0.1.0-rc.15">Download the RC <span aria-hidden="true">↓</span></a>
+            <a class="button button-primary" href="https://github.com/IvoryHeart/herdr-world/releases/tag/v0.1.0">Download <span aria-hidden="true">↓</span></a>
             <a class="button button-secondary" href="#install">View install</a>
           </div>
           <dl class="hero-facts">
@@ -148,14 +148,14 @@
 
           <section class="install-panel" id="install-panel-npm" role="tabpanel" aria-labelledby="install-tab-npm" data-install-panel="npm">
             <p class="install-panel-label">Standalone / Node.js 22.14+</p>
-            <pre tabindex="0" aria-label="npm installation commands"><code data-install-command="npm"><span class="prompt">$</span> npm install --global @ivoryheart/herdr-world@next
+            <pre tabindex="0" aria-label="npm installation commands"><code data-install-command="npm"><span class="prompt">$</span> npm install --global @ivoryheart/herdr-world@latest
 <span class="prompt">$</span> herdr-world</code></pre>
             <p class="install-panel-note">The npm package includes the tested Linux x64, macOS ARM64, and macOS Intel bridges.</p>
             <details class="install-advanced">
               <summary>Advanced npm options</summary>
               <div class="install-advanced-content">
                 <p class="install-panel-label">Pin a version or choose a session</p>
-                <pre tabindex="0" aria-label="Advanced npm commands"><code><span class="prompt">$</span> npm install --global @ivoryheart/herdr-world@0.1.0-rc.15
+                <pre tabindex="0" aria-label="Advanced npm commands"><code><span class="prompt">$</span> npm install --global @ivoryheart/herdr-world@0.1.0
 <span class="prompt">$</span> herdr-world --session NAME
 <span class="prompt">$</span> herdr-world --port 8791</code></pre>
                 <p class="install-panel-note">Release candidates use npm’s <code>next</code> channel. Stable releases use <code>latest</code>; pin an exact version when you need a fixed build.</p>
@@ -165,16 +165,16 @@
 
           <section class="install-panel" id="install-panel-brew" role="tabpanel" aria-labelledby="install-tab-brew" data-install-panel="brew" hidden>
             <p class="install-panel-label">Standalone / macOS or Linux</p>
-            <pre tabindex="0" aria-label="Homebrew installation commands"><code data-install-command="brew"><span class="prompt">$</span> brew install IvoryHeart/tap/herdr-world-rc
+            <pre tabindex="0" aria-label="Homebrew installation commands"><code data-install-command="brew"><span class="prompt">$</span> brew install IvoryHeart/tap/herdr-world
 <span class="prompt">$</span> herdr-world</code></pre>
-            <p class="install-panel-note">This preview Formula exposes the same <code>herdr-world</code> command as the stable Formula.</p>
+            <p class="install-panel-note">The Formula exposes the same <code>herdr-world</code> command on both release channels.</p>
             <details class="install-advanced">
               <summary>Advanced Homebrew options</summary>
               <div class="install-advanced-content">
                 <p class="install-panel-label">Preview and stable channels</p>
                 <pre tabindex="0" aria-label="Advanced Homebrew commands"><code><span class="prompt">$</span> brew update
-<span class="prompt">$</span> brew upgrade IvoryHeart/tap/herdr-world-rc
-<span class="prompt">$</span> brew uninstall herdr-world-rc</code></pre>
+<span class="prompt">$</span> brew upgrade IvoryHeart/tap/herdr-world
+<span class="prompt">$</span> brew uninstall herdr-world</code></pre>
                 <p class="install-panel-note">RCs use <code>herdr-world-rc</code>; stable releases use <code>herdr-world</code>. The Formulae conflict because both provide the same command, so they cannot be installed together.</p>
               </div>
             </details>
@@ -182,7 +182,7 @@
 
           <section class="install-panel" id="install-panel-herdr" role="tabpanel" aria-labelledby="install-tab-herdr" data-install-panel="herdr" hidden>
             <p class="install-panel-label">Herdr-managed / Herdr 0.8.2+</p>
-            <pre tabindex="0" aria-label="Herdr plugin installation commands"><code data-install-command="herdr"><span class="prompt">$</span> herdr plugin install IvoryHeart/herdr-world --ref v0.1.0-rc.15
+            <pre tabindex="0" aria-label="Herdr plugin installation commands"><code data-install-command="herdr"><span class="prompt">$</span> herdr plugin install IvoryHeart/herdr-world --ref v0.1.0
 <span class="prompt">$</span> herdr plugin action invoke open --plugin ivoryheart.herdr-world</code></pre>
             <p class="install-panel-note">Install registers and builds the plugin. The <code>open</code> action starts the bridge for an already-running Herdr server.</p>
             <details class="install-advanced">
@@ -201,14 +201,14 @@
 
           <section class="install-panel" id="install-panel-cli" role="tabpanel" aria-labelledby="install-tab-cli" data-install-panel="cli" hidden>
             <p class="install-panel-label">Manual release archive / Linux x86-64, macOS ARM64, or macOS Intel</p>
-            <pre tabindex="0" aria-label="CLI archive installation commands"><code data-install-command="cli">VERSION=v0.1.0-rc.15
+            <pre tabindex="0" aria-label="CLI archive installation commands"><code data-install-command="cli">VERSION=v0.1.0
 PLATFORM=linux-x86_64 # or macos-arm64 / macos-x86_64
 <span class="prompt">$</span> curl -fLO "https://github.com/IvoryHeart/herdr-world/releases/download/${VERSION}/herdr-world-${VERSION}-${PLATFORM}.tar.gz"
 <span class="prompt">$</span> curl -fLO "https://github.com/IvoryHeart/herdr-world/releases/download/${VERSION}/herdr-world-${VERSION}-${PLATFORM}.tar.gz.sha256"
 <span class="prompt">$</span> tar -xzf "herdr-world-${VERSION}-${PLATFORM}.tar.gz"
 <span class="prompt">$</span> cd "herdr-world-${VERSION}-${PLATFORM}"
 <span class="prompt">$</span> bin/herdr-world</code></pre>
-            <p class="install-panel-note">Use <code>sha256sum --check</code> on Linux or <code>shasum -a 256 --check</code> on macOS before extracting. <a href="https://github.com/IvoryHeart/herdr-world/releases/tag/v0.1.0-rc.15">Download the current release candidate ↗</a></p>
+            <p class="install-panel-note">Use <code>sha256sum --check</code> on Linux or <code>shasum -a 256 --check</code> on macOS before extracting. <a href="https://github.com/IvoryHeart/herdr-world/releases/tag/v0.1.0">Download the current release ↗</a></p>
             <details class="install-advanced">
               <summary>Advanced CLI options</summary>
               <div class="install-advanced-content">
@@ -239,7 +239,7 @@ PLATFORM=linux-x86_64 # or macos-arm64 / macos-x86_64
         <p class="eyebrow">The office is open</p>
         <h2 id="cta-title">Bring your agents<br /><em>into the room.</em></h2>
         <div class="hero-actions">
-          <a class="button button-primary" href="https://github.com/IvoryHeart/herdr-world/releases/tag/v0.1.0-rc.15">Download v0.1.0-rc.15</a>
+          <a class="button button-primary" href="https://github.com/IvoryHeart/herdr-world/releases/tag/v0.1.0">Download v0.1.0</a>
           <a class="button button-secondary" href="https://github.com/IvoryHeart/herdr-world/discussions">Join the discussion</a>
         </div>
       </section>

--- a/site/site.js
+++ b/site/site.js
@@ -1,12 +1,12 @@
-// Current public preview: v0.1.0-rc.15
+// Current public preview: v0.1.0
 const installCommands = {
-  npm: `npm install --global @ivoryheart/herdr-world@next
+  npm: `npm install --global @ivoryheart/herdr-world@latest
 herdr-world`,
-  brew: `brew install IvoryHeart/tap/herdr-world-rc
+  brew: `brew install IvoryHeart/tap/herdr-world
 herdr-world`,
-  herdr: `herdr plugin install IvoryHeart/herdr-world --ref v0.1.0-rc.15
+  herdr: `herdr plugin install IvoryHeart/herdr-world --ref v0.1.0
 herdr plugin action invoke open --plugin ivoryheart.herdr-world`,
-  cli: `VERSION=v0.1.0-rc.15
+  cli: `VERSION=v0.1.0
 PLATFORM=linux-x86_64
 curl -fLO "https://github.com/IvoryHeart/herdr-world/releases/download/\${VERSION}/herdr-world-\${VERSION}-\${PLATFORM}.tar.gz"
 curl -fLO "https://github.com/IvoryHeart/herdr-world/releases/download/\${VERSION}/herdr-world-\${VERSION}-\${PLATFORM}.tar.gz.sha256"


### PR DESCRIPTION
## Summary

- promote the accumulated World changes from Unreleased to v0.1.0 with the exact Herdr Web baseline
- stamp README, plugin, project-site, and release metadata for the stable version
- switch npm and Homebrew instructions from RC channels to latest/stable
- make Pages and release-changelog validation cover stable preparation accurately

## Validation

- npm run check
- npm run test:release
- npm run test:pages
- git diff --check

This PR prepares the stable release commit. It does not create or push the tag; tagging occurs only after this squash merge and the exact-main distribution preflight.