### PR TITLE
Release v0.1.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -695,7 +695,36 @@ jobs:
             # The first channel cannot resolve its declared peer until that peer is published.
             audit_args+=(--except=conflicts)
           fi
-          brew audit "${audit_args[@]}" "$qualified_formula"
+          run_brew_audit() {
+            if [[ "$(uname -s)" != "Linux" ]]; then
+              brew audit "$@"
+              return
+            fi
+
+            # Homebrew's Linux bootstrap can still hit its known /proc/cpuinfo
+            # SIGPIPE race. Retry only that exact upstream failure; audit errors
+            # from the Formula itself must fail immediately.
+            local attempt audit_log status
+            audit_log="$(mktemp)"
+            for attempt in 1 2 3; do
+              if brew audit "$@" >"$audit_log" 2>&1; then
+                cat "$audit_log"
+                rm -f "$audit_log"
+                return 0
+              else
+                status=$?
+              fi
+              cat "$audit_log" >&2
+              if ! grep -Fq "Broken pipe" "$audit_log" || [[ "$attempt" == "3" ]]; then
+                rm -f "$audit_log"
+                return "$status"
+              fi
+              echo "Homebrew hit its known Linux SIGPIPE race; retrying audit ($attempt/3)" >&2
+              sleep "$((attempt * 2))"
+              : >"$audit_log"
+            done
+          }
+          run_brew_audit "${audit_args[@]}" "$qualified_formula"
           archive="$(find formula-native -maxdepth 1 -type f -name 'herdr-world-*.tar.gz' -print -quit)"
           [[ -n "$archive" ]] || { echo "no verified native archive was downloaded for Formula validation" >&2; exit 1; }
           archive="$(cd "$(dirname "$archive")" && pwd)/$(basename "$archive")"

--- a/scripts/herdr-world-plugin.test.mjs
+++ b/scripts/herdr-world-plugin.test.mjs
@@ -577,6 +577,18 @@ test("release workflow gates publication on the three-platform unpublished plugi
   assert.match(workflow, /package_path="\$\{GITHUB_WORKSPACE\}\/npm-output\/herdr-world-\$\{VERSION\}\.tgz"/);
 });
 
+test("release workflow retries only the known Linux Homebrew SIGPIPE audit failure", () => {
+  const workflow = readFileSync(path.join(ROOT, ".github/workflows/release.yml"), "utf8");
+  const homebrewJob = workflow.indexOf("  homebrew_test:");
+  const npmPublishJob = workflow.indexOf("  npm_publish:", homebrewJob);
+  assert.ok(homebrewJob >= 0 && npmPublishJob > homebrewJob);
+  const homebrewSection = workflow.slice(homebrewJob, npmPublishJob);
+  assert.match(homebrewSection, /if \[\[ "\$\(uname -s\)" != "Linux" \]\]; then/);
+  assert.match(homebrewSection, /for attempt in 1 2 3; do/);
+  assert.match(homebrewSection, /grep -Fq "Broken pipe" "\$audit_log"/);
+  assert.match(homebrewSection, /run_brew_audit "\$\{audit_args\[@\]\}" "\$qualified_formula"/);
+});
+
 test("PR CI exercises real launchd on both macOS architectures", () => {
   const workflow = readFileSync(path.join(ROOT, ".github/workflows/ci.yml"), "utf8");
   assert.match(workflow, /macos-15/);


### PR DESCRIPTION
## Summary
- retry only the known Linux Homebrew `Broken pipe` audit failure, up to three attempts
- preserve immediate failure for real Formula audit errors
- add regression coverage for the narrow release-workflow guard

## Context
Exact-SHA distribution preflight [33349158079](https://github.com/IvoryHeart/herdr-world/actions/runs/33349158079) failed twice on different Linux runners inside Homebrew CPU-feature startup, before Formula lifecycle validation. Linux native packaging, plugin smoke, npm install, and both macOS Formula lifecycle jobs passed. This follows the upstream Homebrew SIGPIPE failure documented in Homebrew/brew#21365 and fixed upstream by Homebrew/brew#21366, which can still occur on hosted Linux images.

## Validation
- `npm run check`
- focused release workflow regression test