### PR TITLE
Release v0.1.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -691,7 +691,11 @@ jobs:
           other_formula="herdr-world-rc"
           [[ "$formula_name" == "herdr-world-rc" ]] && other_formula="herdr-world"
           audit_args=()
-          if [[ ! -f "$tap_root/Formula/${other_formula}.rb" ]]; then
+          if [[ -f "$tap_root/Formula/${other_formula}.rb" ]]; then
+            # Homebrew requires explicit trust before loading a Formula from a
+            # third-party tap indirectly through conflicts_with.
+            brew trust --formula "$tap_name/$other_formula"
+          else
             # The first channel cannot resolve its declared peer until that peer is published.
             audit_args+=(--except=conflicts)
           fi

--- a/scripts/herdr-world-plugin.test.mjs
+++ b/scripts/herdr-world-plugin.test.mjs
@@ -589,6 +589,18 @@ test("release workflow retries only the known Linux Homebrew SIGPIPE audit failu
   assert.match(homebrewSection, /run_brew_audit "\$\{audit_args\[@\]\}" "\$qualified_formula"/);
 });
 
+test("release workflow trusts the published peer Formula before conflict validation", () => {
+  const workflow = readFileSync(path.join(ROOT, ".github/workflows/release.yml"), "utf8");
+  const homebrewJob = workflow.indexOf("  homebrew_test:");
+  const npmPublishJob = workflow.indexOf("  npm_publish:", homebrewJob);
+  assert.ok(homebrewJob >= 0 && npmPublishJob > homebrewJob);
+  const homebrewSection = workflow.slice(homebrewJob, npmPublishJob);
+  assert.match(
+    homebrewSection,
+    /if \[\[ -f "\$tap_root\/Formula\/\$\{other_formula\}\.rb" \]\]; then\s+# Homebrew requires explicit trust[\s\S]*brew trust --formula "\$tap_name\/\$other_formula"/,
+  );
+});
+
 test("PR CI exercises real launchd on both macOS architectures", () => {
   const workflow = readFileSync(path.join(ROOT, ".github/workflows/ci.yml"), "utf8");
   assert.match(workflow, /macos-15/);


### PR DESCRIPTION
## Summary

- trust the already-published peer Formula from `IvoryHeart/homebrew-tap` before Homebrew evaluates `conflicts_with`
- keep trust scoped to that peer Formula while preserving all existing Formula audit failures
- add regression coverage for the release workflow contract

## Failure addressed

The first tagged `v0.1.0` distribution run was correctly publication-gated when all three Homebrew lifecycle jobs rejected the peer `herdr-world-rc` Formula under Homebrew’s new third-party tap trust requirement: https://github.com/IvoryHeart/herdr-world/actions/runs/33351053381

No release channel was published: GitHub release, npm `0.1.0`, and stable Homebrew Formula are all absent. After this replacement release commit is fully preflighted, the unpublished `v0.1.0` tag can be safely recreated at it.

## Validation

- `node --test scripts/herdr-world-plugin.test.mjs`
- `npm run check`