### PR TITLE
Release v0.1.0

### DIFF
--- a/scripts/herdr-world-plugin.test.mjs
+++ b/scripts/herdr-world-plugin.test.mjs
@@ -599,6 +599,10 @@ test("release workflow trusts the published peer Formula before conflict validat
     homebrewSection,
     /if \[\[ -f "\$tap_root\/Formula\/\$\{other_formula\}\.rb" \]\]; then\s+# Homebrew requires explicit trust[\s\S]*brew trust --formula "\$tap_name\/\$other_formula"/,
   );
+  assert.ok(
+    homebrewSection.indexOf('brew trust --formula "$tap_name/$other_formula"') <
+      homebrewSection.indexOf('run_brew_audit "${audit_args[@]}" "$qualified_formula"'),
+  );
 });
 
 test("PR CI exercises real launchd on both macOS architectures", () => {


### PR DESCRIPTION
## Summary

- strengthen the Homebrew lifecycle regression to prove peer trust happens before Formula audit
- produce the exact reviewed squash-merge subject required by the protected release provenance gate

## Validation

- `node --test scripts/herdr-world-plugin.test.mjs`

PR #66 delivered the Homebrew compatibility fix and passed all required CI, but GitHub selected its single branch commit as the squash subject. This follow-up keeps the release provenance contract intact rather than weakening it.