### PR TITLE
Release v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,19 @@ Web's own release history remains in its upstream changelog.
 
 ### Added
 
+### Changed
+
+### Fixed
+
+### Removed
+
+## [0.1.1] - 2026-09-01
+
+> **Herdr Web baseline:** Derived from v0.5.0 plus the JetBrains Mono Nerd Font fallback merged in upstream PR #74 at
+> [`4384c884`](https://github.com/kcosr/herdr-web/commit/4384c884da418ea3f3fb75954da5347b2e12f063).
+
+### Added
+
 - Added an accessible live Graph theme with bounded project/space and attached-terminal topology,
   detected agent or empty-shell identity, stable force layout, search, collapse, pan/zoom/fit
   controls, semantic navigation, connected live terminal overlays, and explicit Open-in-Spaces
@@ -38,8 +51,6 @@ Web's own release history remains in its upstream changelog.
   do not stall Office, and bounded terminal canvas refits and preference writes during rapid window
   resizing so neither World theme can saturate the browser tab.
   [Herdr World PR #73](https://github.com/IvoryHeart/herdr-world/pull/73)
-
-### Removed
 
 ## [0.1.0] - 2026-08-31
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ It combines live terminal Spaces with visual Pixel Office and Graph themes, mult
 shared navigation, mobile controls, notes, uploads, and agent-aware workflows.
 
 The current public preview is
-[`v0.1.0`](https://github.com/IvoryHeart/herdr-world/releases/tag/v0.1.0).
+[`v0.1.1`](https://github.com/IvoryHeart/herdr-world/releases/tag/v0.1.1).
 It supports Linux x86-64 and macOS on Apple Silicon and Intel, and requires Herdr `v0.8.2` or newer
 with terminal protocol `20`. Visit the [project site](https://ivoryheart.github.io/herdr-world/) for
 an interactive overview.
@@ -44,13 +44,13 @@ herdr-world
 ### Herdr plugin
 
 ```bash
-herdr plugin install IvoryHeart/herdr-world --ref v0.1.0
+herdr plugin install IvoryHeart/herdr-world --ref v0.1.1
 herdr plugin action invoke open --plugin ivoryheart.herdr-world
 ```
 
 Open [http://127.0.0.1:8787](http://127.0.0.1:8787) if the browser does not open automatically.
 Checksum-verified standalone archives are available on the
-[release page](https://github.com/IvoryHeart/herdr-world/releases/tag/v0.1.0).
+[release page](https://github.com/IvoryHeart/herdr-world/releases/tag/v0.1.1).
 
 The macOS binaries are not yet signed or notarized. After verifying the download, the first launch
 may need approval in **System Settings → Privacy & Security**.

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -1,6 +1,6 @@
 id = "ivoryheart.herdr-world"
 name = "Herdr World"
-version = "0.1.0"
+version = "0.1.1"
 min_herdr_version = "0.8.2"
 description = "Browser and mobile client for monitoring and controlling Herdr agents."
 platforms = ["linux", "macos"]

--- a/release.json
+++ b/release.json
@@ -1,3 +1,3 @@
 {
-  "current": "v0.1.0"
+  "current": "v0.1.1"
 }

--- a/site/index.html
+++ b/site/index.html
@@ -44,7 +44,7 @@
           <h1 id="hero-title">Your agents.<br /><em>One office.</em></h1>
           <p class="hero-intro">Herdr World turns live Herdr sessions into one visual workspace: terminal-first Spaces, a multi-host Pixel Office, a live topology Graph, and the controls to move between them without losing context.</p>
           <div class="hero-actions">
-            <a class="button button-primary" href="https://github.com/IvoryHeart/herdr-world/releases/tag/v0.1.0">Download <span aria-hidden="true">↓</span></a>
+            <a class="button button-primary" href="https://github.com/IvoryHeart/herdr-world/releases/tag/v0.1.1">Download <span aria-hidden="true">↓</span></a>
             <a class="button button-secondary" href="#install">View install</a>
           </div>
           <dl class="hero-facts">
@@ -181,7 +181,7 @@
               <summary>Advanced npm options</summary>
               <div class="install-advanced-content">
                 <p class="install-panel-label">Pin a version or choose a session</p>
-                <pre tabindex="0" aria-label="Advanced npm commands"><code><span class="prompt">$</span> npm install --global @ivoryheart/herdr-world@0.1.0
+                <pre tabindex="0" aria-label="Advanced npm commands"><code><span class="prompt">$</span> npm install --global @ivoryheart/herdr-world@0.1.1
 <span class="prompt">$</span> herdr-world --session NAME
 <span class="prompt">$</span> herdr-world --port 8791</code></pre>
                 <p class="install-panel-note">Release candidates use npm’s <code>next</code> channel. Stable releases use <code>latest</code>; pin an exact version when you need a fixed build.</p>
@@ -208,7 +208,7 @@
 
           <section class="install-panel" id="install-panel-herdr" role="tabpanel" aria-labelledby="install-tab-herdr" data-install-panel="herdr" hidden>
             <p class="install-panel-label">Herdr-managed / Herdr 0.8.2+</p>
-            <pre tabindex="0" aria-label="Herdr plugin installation commands"><code data-install-command="herdr"><span class="prompt">$</span> herdr plugin install IvoryHeart/herdr-world --ref v0.1.0
+            <pre tabindex="0" aria-label="Herdr plugin installation commands"><code data-install-command="herdr"><span class="prompt">$</span> herdr plugin install IvoryHeart/herdr-world --ref v0.1.1
 <span class="prompt">$</span> herdr plugin action invoke open --plugin ivoryheart.herdr-world</code></pre>
             <p class="install-panel-note">Install registers and builds the plugin. The <code>open</code> action starts the bridge for an already-running Herdr server.</p>
             <details class="install-advanced">
@@ -227,14 +227,14 @@
 
           <section class="install-panel" id="install-panel-cli" role="tabpanel" aria-labelledby="install-tab-cli" data-install-panel="cli" hidden>
             <p class="install-panel-label">Manual release archive / Linux x86-64, macOS ARM64, or macOS Intel</p>
-            <pre tabindex="0" aria-label="CLI archive installation commands"><code data-install-command="cli">VERSION=v0.1.0
+            <pre tabindex="0" aria-label="CLI archive installation commands"><code data-install-command="cli">VERSION=v0.1.1
 PLATFORM=linux-x86_64 # or macos-arm64 / macos-x86_64
 <span class="prompt">$</span> curl -fLO "https://github.com/IvoryHeart/herdr-world/releases/download/${VERSION}/herdr-world-${VERSION}-${PLATFORM}.tar.gz"
 <span class="prompt">$</span> curl -fLO "https://github.com/IvoryHeart/herdr-world/releases/download/${VERSION}/herdr-world-${VERSION}-${PLATFORM}.tar.gz.sha256"
 <span class="prompt">$</span> tar -xzf "herdr-world-${VERSION}-${PLATFORM}.tar.gz"
 <span class="prompt">$</span> cd "herdr-world-${VERSION}-${PLATFORM}"
 <span class="prompt">$</span> bin/herdr-world</code></pre>
-            <p class="install-panel-note">Use <code>sha256sum --check</code> on Linux or <code>shasum -a 256 --check</code> on macOS before extracting. <a href="https://github.com/IvoryHeart/herdr-world/releases/tag/v0.1.0">Download the current release ↗</a></p>
+            <p class="install-panel-note">Use <code>sha256sum --check</code> on Linux or <code>shasum -a 256 --check</code> on macOS before extracting. <a href="https://github.com/IvoryHeart/herdr-world/releases/tag/v0.1.1">Download the current release ↗</a></p>
             <details class="install-advanced">
               <summary>Advanced CLI options</summary>
               <div class="install-advanced-content">
@@ -265,7 +265,7 @@ PLATFORM=linux-x86_64 # or macos-arm64 / macos-x86_64
         <p class="eyebrow">The office is open</p>
         <h2 id="cta-title">Bring your agents<br /><em>into the room.</em></h2>
         <div class="hero-actions">
-          <a class="button button-primary" href="https://github.com/IvoryHeart/herdr-world/releases/tag/v0.1.0">Download v0.1.0</a>
+          <a class="button button-primary" href="https://github.com/IvoryHeart/herdr-world/releases/tag/v0.1.1">Download v0.1.1</a>
           <a class="button button-secondary" href="https://github.com/IvoryHeart/herdr-world/discussions">Join the discussion</a>
         </div>
       </section>

--- a/site/site.js
+++ b/site/site.js
@@ -1,12 +1,12 @@
-// Current public preview: v0.1.0
+// Current public preview: v0.1.1
 const installCommands = {
   npm: `npm install --global @ivoryheart/herdr-world@latest
 herdr-world`,
   brew: `brew install IvoryHeart/tap/herdr-world
 herdr-world`,
-  herdr: `herdr plugin install IvoryHeart/herdr-world --ref v0.1.0
+  herdr: `herdr plugin install IvoryHeart/herdr-world --ref v0.1.1
 herdr plugin action invoke open --plugin ivoryheart.herdr-world`,
-  cli: `VERSION=v0.1.0
+  cli: `VERSION=v0.1.1
 PLATFORM=linux-x86_64
 curl -fLO "https://github.com/IvoryHeart/herdr-world/releases/download/\${VERSION}/herdr-world-\${VERSION}-\${PLATFORM}.tar.gz"
 curl -fLO "https://github.com/IvoryHeart/herdr-world/releases/download/\${VERSION}/herdr-world-\${VERSION}-\${PLATFORM}.tar.gz.sha256"


### PR DESCRIPTION
## Summary

- promote the Spec 018 Graph and live-terminal changes from Unreleased into v0.1.1
- stamp README, project site, plugin manifest, and release metadata with v0.1.1
- retain a fresh empty Unreleased section and exact Herdr Web baseline

## Validation

- `node scripts/release.mjs prepare v0.1.1`
- complete `npm run check` executed by release preparation
- 499 frontend tests, 119 compatibility tests, and 166 bridge tests passed
- production web and bridge builds passed
- `git diff --check`

The release must be squash-merged with the generated subject `Release v0.1.1 (#<number>)`. After merge, run the protected distribution preflight on the exact main commit before tagging.