### PR TITLE
fix(plugin): recover stale bridge services and document LAN setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,6 +53,16 @@ This is a lightweight internal onboarding note for agents working in this repo.
   `vendor/herdr-compat/target/`, `dist-packages/`, and Android build outputs.
 - The bridge is local-first and currently has no full browser authentication. Treat LAN binding and upload behavior as security-sensitive.
 
+## Privacy And Local Data
+
+- Treat any environment-specific or user-specific data as sensitive by default.
+- Never copy such data into tracked files, tests, fixtures, documentation, issues, PRs, commit
+  messages, or generated artifacts. Keep real configuration outside the repository and use clearly
+  synthetic placeholders or reserved example domains/ranges instead.
+- Before committing or pushing, review the diff and relevant history for accidental disclosure. If
+  sensitive data is staged or pushed, remove it from unmerged history when possible and report what
+  was exposed and scrubbed; a follow-up deletion does not erase commit history.
+
 ## Testing
 
 - Run `npm install --prefix web` if dependencies are missing.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Web's own release history remains in its upstream changelog.
 
 ### Fixed
 
+- Reconciled an owned launchd or systemd service whose runtime record was lost, so changing the
+  plugin bind host or access policy can take effect instead of leaving an old loopback service
+  loaded and blocking restart.
+
 ### Removed
 
 ## [0.1.1] - 2026-09-01

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Web's own release history remains in its upstream changelog.
 - Reconciled an owned launchd or systemd service whose runtime record was lost, so changing the
   plugin bind host or access policy can take effect instead of leaving an old loopback service
   loaded and blocking restart.
+  [Herdr World PR #75](https://github.com/IvoryHeart/herdr-world/pull/75)
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -103,6 +103,26 @@ herdr --session NAME plugin action invoke status --plugin ivoryheart.herdr-world
 herdr plugin uninstall ivoryheart.herdr-world
 ```
 
+The plugin keeps editable settings outside its managed checkout. Find the directory with
+`herdr plugin config-dir ivoryheart.herdr-world` and edit its `config.json`; for a two-host LAN
+setup, `host` is the bind address, `allowed_hosts` lists accepted bridge hostnames/IPs,
+`allowed_origins` lists the exact page origins that may call this bridge, and
+`allowed_connect_origins` lists bridge origins that the page served here may call. For example:
+
+```json
+{
+  "host": "0.0.0.0",
+  "port": 8787,
+  "allowed_hosts": ["bridge-a.example.test", "bridge-b.example.test"],
+  "allowed_origins": ["http://localhost:8787", "http://bridge-a.example.test:8787", "http://bridge-b.example.test:8787"],
+  "allowed_connect_origins": ["http://bridge-a.example.test:8787", "http://bridge-b.example.test:8787"]
+}
+```
+
+Use the actual page origin, including its port; `http://127.0.0.1:8787` does not authorize a page
+opened at a LAN address. Restart the plugin after changing the file:
+`herdr plugin action invoke restart --plugin ivoryheart.herdr-world`.
+
 To run from source:
 
 ```bash

--- a/bridge/src/web_bridge.rs
+++ b/bridge/src/web_bridge.rs
@@ -6106,8 +6106,8 @@ mod tests {
         let policy = RequestPolicy {
             bind_host: "0.0.0.0".to_string(),
             bind_port: 4000,
-            allowed_hosts: vec!["192.168.1.10".to_string()],
-            allowed_origins: vec!["http://192.168.1.10:4000".to_string()],
+            allowed_hosts: vec!["192.0.2.10".to_string()],
+            allowed_origins: vec!["http://192.0.2.10:4000".to_string()],
             allowed_connect_sources: Vec::new(),
         };
         assert!(!request_allowed(
@@ -6115,11 +6115,11 @@ mod tests {
             &policy
         ));
         assert!(request_allowed(
-            &origin_headers("192.168.1.10:4000", Some("http://192.168.1.10:4000")),
+            &origin_headers("192.0.2.10:4000", Some("http://192.0.2.10:4000")),
             &policy
         ));
         assert!(!request_allowed(
-            &origin_headers("192.168.1.10:8787", Some("http://192.168.1.10:8787")),
+            &origin_headers("192.0.2.10:8787", Some("http://192.0.2.10:8787")),
             &policy
         ));
     }
@@ -6132,7 +6132,7 @@ mod tests {
             &policy
         ));
         assert!(!request_allowed(
-            &origin_headers("192.168.1.10:8787", Some("http://127.0.0.1:5173")),
+            &origin_headers("192.0.2.10:8787", Some("http://127.0.0.1:5173")),
             &policy
         ));
         assert!(!request_allowed(
@@ -6146,16 +6146,16 @@ mod tests {
         let policy = RequestPolicy {
             bind_host: "0.0.0.0".to_string(),
             bind_port: 4000,
-            allowed_hosts: vec!["192.168.1.10".to_string()],
+            allowed_hosts: vec!["192.0.2.10".to_string()],
             allowed_origins: vec!["http://localhost".to_string()],
             allowed_connect_sources: Vec::new(),
         };
         assert!(request_allowed(
-            &origin_headers("192.168.1.10:4000", Some("http://localhost")),
+            &origin_headers("192.0.2.10:4000", Some("http://localhost")),
             &policy
         ));
         assert!(!request_allowed(
-            &origin_headers("192.168.1.10:4000", Some("https://example.com")),
+            &origin_headers("192.0.2.10:4000", Some("https://example.com")),
             &policy
         ));
     }
@@ -6185,7 +6185,7 @@ mod tests {
             &policy
         ));
         assert!(!request_origin_allowed(
-            &origin_headers("192.168.1.10:8787", Some("http://127.0.0.1:5173")),
+            &origin_headers("192.0.2.10:8787", Some("http://127.0.0.1:5173")),
             &policy
         ));
         assert!(!request_origin_allowed(
@@ -6204,11 +6204,11 @@ mod tests {
         let lan = RequestPolicy {
             bind_host: "0.0.0.0".to_string(),
             bind_port: 4000,
-            allowed_hosts: vec!["192.168.1.10".to_string()],
-            allowed_origins: vec!["http://192.168.1.10:4000".to_string()],
+            allowed_hosts: vec!["192.0.2.10".to_string()],
+            allowed_origins: vec!["http://192.0.2.10:4000".to_string()],
             allowed_connect_sources: Vec::new(),
         };
-        assert!(host_authority_allowed("192.168.1.10:4000", &lan));
+        assert!(host_authority_allowed("192.0.2.10:4000", &lan));
         assert!(host_authority_allowed("[::1]:5173", &lan));
         assert!(!host_authority_allowed("evil.example:4000", &lan));
     }
@@ -6233,20 +6233,20 @@ mod tests {
         let policy = RequestPolicy {
             bind_host: "0.0.0.0".to_string(),
             bind_port: 4000,
-            allowed_hosts: vec!["192.168.1.10".to_string()],
+            allowed_hosts: vec!["192.0.2.10".to_string()],
             allowed_origins: vec!["http://localhost".to_string()],
             allowed_connect_sources: Vec::new(),
         };
         assert_eq!(
             cors_origin_header(
-                &origin_headers("192.168.1.10:4000", Some("http://localhost")),
+                &origin_headers("192.0.2.10:4000", Some("http://localhost")),
                 &policy
             )
             .and_then(|value| value.to_str().ok().map(str::to_string)),
             Some("http://localhost".to_string())
         );
         assert!(cors_origin_header(
-            &origin_headers("192.168.1.10:4000", Some("https://example.com")),
+            &origin_headers("192.0.2.10:4000", Some("https://example.com")),
             &policy
         )
         .is_none());
@@ -6601,7 +6601,7 @@ mod tests {
         assert!(is_loopback_bind_host("127.0.0.1"));
         assert!(is_loopback_bind_host("localhost"));
         assert!(!is_loopback_bind_host("0.0.0.0"));
-        assert!(!is_loopback_bind_host("192.168.1.10"));
+        assert!(!is_loopback_bind_host("192.0.2.10"));
     }
 
     #[test]
@@ -7154,7 +7154,7 @@ mod tests {
             "--host".to_string(),
             "0.0.0.0".to_string(),
             "--allow-host".to_string(),
-            "192.168.1.10".to_string(),
+            "192.0.2.10".to_string(),
         ];
         assert!(parse_options(&without_origin)
             .unwrap_err()
@@ -7164,14 +7164,14 @@ mod tests {
             "--host".to_string(),
             "0.0.0.0".to_string(),
             "--allow-host".to_string(),
-            "192.168.1.10".to_string(),
+            "192.0.2.10".to_string(),
             "--allow-origin".to_string(),
-            "http://192.168.1.10:4000".to_string(),
+            "http://192.0.2.10:4000".to_string(),
             "--bridge-label".to_string(),
             "Build host".to_string(),
         ];
         let options = parse_options(&explicit).unwrap().unwrap();
-        assert_eq!(options.allowed_hosts, vec!["192.168.1.10"]);
+        assert_eq!(options.allowed_hosts, vec!["192.0.2.10"]);
         assert_eq!(options.configured_label.as_deref(), Some("Build host"));
     }
 

--- a/docs/android.md
+++ b/docs/android.md
@@ -39,8 +39,8 @@ saved bridge in the Bridge area of Settings.
 Supported backend examples:
 
 ```text
-http://192.168.1.20:4000
-http://10.0.0.42:8787
+http://bridge-a.example.test:4000
+http://bridge-b.example.test:8787
 http://herdr-host.local:4000
 https://herdr.example.test
 ```
@@ -191,7 +191,7 @@ On a trusted LAN:
 2. Install the debug APK on an Android device.
 3. Open the app and confirm the shell loads without network access.
 4. Open Settings and select the Bridge area.
-5. Add a backend such as `http://192.168.1.20:4000`.
+5. Add a backend such as `http://bridge-a.example.test:4000`.
 6. Use `Test` and confirm it reports reachable.
 7. Use `Save`, enable the saved bridge with its Enable toggle, and confirm the bridge chip appears
    in the sidebar.

--- a/docs/development.md
+++ b/docs/development.md
@@ -3,7 +3,7 @@
 Work from the `herdr-world` repository root:
 
 ```bash
-cd /home/ny/Forge/ai-palace/herdr-world
+cd /path/to/herdr-world
 ```
 
 ## Quick start
@@ -163,7 +163,7 @@ When a Prometheus-compatible service is available, restart the Herdr World
 bridge with its API URL:
 
 ```bash
-cd /home/ny/Forge/ai-palace/herdr-world
+cd /path/to/herdr-world
 # Stop an existing bridge on 8787 first if dev:local reports that it is healthy.
 HERDR_WORLD_OTEL_PROMETHEUS_URL=http://127.0.0.1:9101 npm run dev:local
 ```

--- a/docs/specs/019-remote-bridge-access-ux-spec.md
+++ b/docs/specs/019-remote-bridge-access-ux-spec.md
@@ -18,8 +18,9 @@ understand.
 
 This specification defines a small UI-managed access flow:
 
-1. a host-side Remote access area controls whether this bridge accepts remote
-   connections and which bridge addresses it accepts; and
+1. a host-side Remote access area, described in the UI as direct network access
+   for LAN/VPN use, controls whether this bridge accepts remote connections and
+   which bridge addresses it accepts; and
 2. the existing client-side Bridges area stores and enables bridge URLs.
 
 The observable outcome is that a user can enable access on one machine and add
@@ -33,7 +34,8 @@ changes.
 | --- | --- |
 | Host UI | Add a Remote access settings area modeled on the existing Bridges settings UI. |
 | Client UI | Keep the existing Bridges UI and saved-profile behavior. |
-| Remote toggle | `Allow remote connections` is off by default and preserves accepted addresses when disabled. |
+| Mode naming | Describe the first mode as `Direct network access` or `LAN/VPN access`; if the section remains `Remote access`, its helper text must not imply secure Internet exposure. |
+| Remote toggle | `Allow direct network connections` is off by default and preserves accepted addresses when disabled. |
 | Accepted addresses | Hostnames or IP literals that clients may use in the bridge URL; they are not source-IP authentication. |
 | Browser policy | Keep accepted bridge hosts, allowed page origins, and allowed bridge destinations as separate high-level lists because they control different request directions. |
 | Suggestions | Show detected non-loopback addresses as unchecked suggestions. |
@@ -65,7 +67,7 @@ This feature includes:
 
 This feature does not:
 
-- implement SSH tunneling or an SSH credential manager;
+- implement SSH tunneling or an SSH credential manager; SSH is a separate future desktop connection mode;
 - implement TLS, HTTPS, WSS, certificates, or a public reverse-proxy service;
 - implement source-IP allowlists or claim that accepted addresses authenticate a client;
 - add user accounts, roles, multi-factor authentication, or a shared identity system;
@@ -325,10 +327,11 @@ use an in-memory bearer/session credential for HTTP and a corresponding
 authenticated WebSocket handshake or first-message ticket. It MUST work for
 cross-origin bridge profiles without requiring insecure wildcard CORS.
 
-The password is a baseline against casual access, not protection against a
-network observer. The UI SHALL state that HTTP exposes credentials and session
-traffic to a capable network observer and recommend TLS, VPN, or SSH for
-untrusted networks.
+The password is defense-in-depth against casual access. Over cleartext HTTP it
+does not provide transport confidentiality, integrity, or server
+authentication, and it is not a substitute for TLS, VPN, or SSH. The UI SHALL
+state that HTTP exposes credentials and session traffic to a capable network
+observer and recommend TLS, VPN, or SSH for untrusted networks.
 
 ## 10. Diagnostics
 
@@ -361,6 +364,20 @@ client connection code. It SHALL not add a generic transport abstraction,
 SSH-tunnel manager, or native Herdr remote-host contract. A future transport
 can introduce its own boundary when a second concrete implementation and its
 common requirements are known.
+
+### Future SSH direction (informative, not part of this specification)
+
+A later desktop-oriented Bridges flow MAY offer two connection modes:
+
+- `SSH` (recommended): use system OpenSSH, the user's SSH config,
+  `known_hosts`, and `ssh-agent`, while keeping the remote World bridge
+  loopback-only; and
+- `Direct URL`: this specification's direct network path for trusted LAN/VPN,
+  Android, browser-only, and existing operator-managed reverse-proxy use.
+
+That SSH mode SHALL be a separate proposal and SHALL reuse the user-facing
+conventions of `herdr --remote` without managing private keys in the browser or
+introducing a generic transport abstraction here.
 
 ## 12. Acceptance scenarios
 

--- a/docs/specs/019-remote-bridge-access-ux-spec.md
+++ b/docs/specs/019-remote-bridge-access-ux-spec.md
@@ -1,0 +1,410 @@
+# UI-managed remote bridge access
+
+- **Spec ID:** `019-remote-bridge-access-ux`
+- **Status:** Draft
+- **Created:** 2026-09-02
+- **Owner:** IvoryHeart / Herdr World
+- **Reviewers:** —
+- **Approved by:** —
+- **Approved at:** —
+- **Depends on:** existing Herdr World bridge manager and plugin lifecycle
+
+## 1. Purpose
+
+Herdr World currently requires users to edit the plugin's `config.json` to
+expose a bridge beyond loopback. The configuration contains low-level bind,
+Host, browser-origin, and bridge-connect settings that users should not need to
+understand.
+
+This specification defines a small UI-managed access flow:
+
+1. a host-side Remote access area controls whether this bridge accepts remote
+   connections and which bridge addresses it accepts; and
+2. the existing client-side Bridges area stores and enables bridge URLs.
+
+The observable outcome is that a user can enable access on one machine and add
+that machine from another without editing JSON, while the bridge continues to
+apply exact Host/Origin policy and safely restarts when its service definition
+changes.
+
+## 2. Decisions
+
+| Concern | Decision |
+| --- | --- |
+| Host UI | Add a Remote access settings area modeled on the existing Bridges settings UI. |
+| Client UI | Keep the existing Bridges UI and saved-profile behavior. |
+| Remote toggle | `Allow remote connections` is off by default and preserves accepted addresses when disabled. |
+| Accepted addresses | Hostnames or IP literals that clients may use in the bridge URL; they are not source-IP authentication. |
+| Suggestions | Show detected non-loopback addresses as unchecked suggestions. |
+| Password | Optional per-bridge password; `null` means no password. |
+| Local access | Loopback access bypasses the optional remote password. |
+| Persistence | Host settings persist in the plugin configuration; client profiles persist in browser/native client storage. |
+| Restart | Saving host settings applies them through the local controller and safely restarts the managed bridge. |
+| Transport | Direct HTTP/WebSocket remains the first implementation. SSH and native Herdr host transport remain replaceable future adapters. |
+
+## 3. Scope
+
+This feature includes:
+
+- a host-side Remote access settings area;
+- an explicit remote-access toggle;
+- accepted-address editing with detected unchecked suggestions;
+- a copyable bridge address and current access status;
+- optional password setup, change, removal, and local reset;
+- persistence of host settings without user-facing JSON editing;
+- a local-only management path for validating, persisting, and applying settings;
+- safe restart and rollback behavior when applying settings;
+- automatic derivation of low-level bind, Host, Origin, and CSP settings;
+- authentication covering HTTP APIs and all WebSocket routes when a password is set;
+- actionable status and connection errors in the existing Bridges test flow; and
+- an internal transport boundary that can later support SSH or native Herdr host connections.
+
+## 4. Non-goals
+
+This feature does not:
+
+- implement SSH tunneling or an SSH credential manager;
+- implement TLS, HTTPS, WSS, certificates, or a public reverse-proxy service;
+- implement source-IP allowlists or claim that accepted addresses authenticate a client;
+- add user accounts, roles, multi-factor authentication, or a shared identity system;
+- add QR codes, automatic LAN discovery, pairing codes, or a bridge registry;
+- replace the existing client-side Bridges settings UI;
+- expose raw `allowed_origins` or `allowed_connect_origins` fields to users;
+- permit a remote browser to change host-side access settings;
+- change the Herdr protocol; or
+- preempt or duplicate main Herdr's future native remote-host protocol.
+
+## 5. Terminology
+
+| Term | Meaning in this specification |
+| --- | --- |
+| Host | The machine running the Herdr World bridge being configured. |
+| Client | A browser or native app using a bridge profile to connect to a host bridge. |
+| Accepted address | A hostname or IP literal that the host bridge accepts in the request Host header and advertises as a usable bridge URL. |
+| Remote access | A host bridge bound beyond loopback and admitting configured remote bridge requests. |
+| Local access | A connection whose peer is loopback and which uses the host's local UI path. |
+| Host settings | Server-owned access settings persisted with the plugin configuration. |
+| Bridge profile | Client-owned URL, label, color, and enabled state persisted by the current Bridges UI. |
+
+An accepted address identifies how the bridge may be reached. It does not
+identify the source machine and is not an authentication boundary. A client
+that can reach an accepted address may attempt to connect; the optional
+password is the basic access-control layer in this feature.
+
+## 6. User experience
+
+### 6.1 Host-side settings
+
+The Settings dialog SHALL add a Remote access area with the same interaction
+patterns as the current Bridges area.
+
+When remote access is disabled, the area SHALL show:
+
+- the disabled toggle;
+- the retained accepted-address list, if any; and
+- a short explanation that the bridge is available only locally.
+
+When remote access is enabled, it SHALL show:
+
+- the enabled toggle;
+- accepted addresses as removable rows;
+- detected non-loopback address suggestions as unchecked rows;
+- an `Add address` control for a hostname or IP literal;
+- the connection URL for the selected address with a copy action;
+- password state: `Not set` or `Protected`, with set/change/remove actions; and
+- apply status: applying, ready, or failed with a bounded reason.
+
+The UI SHALL not expose bind flags, generated origins, CSP sources, supervisor
+names, service labels, or raw configuration paths in the normal flow.
+
+The primary action SHALL be `Save` or `Apply`. Applying settings MAY briefly
+disconnect the current browser because the bridge process may restart. The UI
+SHALL explain this before or during the transition and SHALL reconnect when the
+new service is ready.
+
+### 6.2 Address suggestions
+
+The host-side controller SHALL return a bounded set of detected candidates. A
+candidate MAY include the machine hostname and usable non-loopback interface
+addresses. Loopback, link-local, container-only, and otherwise unusable
+interfaces SHOULD be omitted unless the user adds them manually.
+
+Suggestions SHALL be unchecked by default. Selecting a suggestion adds it to
+the accepted-address draft; it does not apply the setting until the user saves.
+
+The user MAY enter a hostname or IP literal manually. The field SHALL reject a
+scheme, path, query, fragment, credentials, or port because the bridge port is
+configured separately.
+
+The UI MAY display real addresses to the local operator because they are the
+subject of the setting. It MUST NOT write them to logs, telemetry, generated
+documentation, test fixtures, or other repository content.
+
+### 6.3 Client-side bridge profiles
+
+The existing Bridges area SHALL remain the client configuration surface. A
+client user continues to add a bridge URL, test it, save it, and enable it.
+
+When a password-protected bridge is tested or first used, the client SHALL ask
+for the password in a masked field. The password SHALL not be placed in a URL,
+browser history entry, log, exported profile, or persistent client profile.
+
+The initial implementation SHALL retain the authenticated session only for the
+current client runtime. A future explicit “remember” choice may use a platform
+secure store, but is not part of this feature.
+
+## 7. Host configuration and persistence
+
+The plugin configuration remains the source of truth for host-side settings and
+continues to live outside the managed plugin checkout. The UI SHALL update it
+through a controlled host-management path rather than asking users to edit it.
+
+The user-facing host model SHALL be high-level:
+
+```json
+{
+  "remote_access": {
+    "enabled": false,
+    "accepted_hosts": [],
+    "password_hash": null
+  }
+}
+```
+
+The exact storage representation MAY preserve the existing low-level fields for
+backward compatibility, but the plugin SHALL have one authoritative normalized
+model. The runtime SHALL derive low-level bind and browser policy arguments from
+that model. The plaintext password MUST never be persisted.
+
+Existing configurations SHALL migrate as follows:
+
+- loopback-only configurations infer `remote_access.enabled = false`;
+- non-loopback configurations infer `remote_access.enabled = true`;
+- existing accepted Host values are retained as `accepted_hosts`; and
+- an absent password remains `null`.
+
+Host settings SHALL be written atomically with restrictive permissions. A
+partial write or invalid setting SHALL leave the previous valid configuration
+intact.
+
+The client-side bridge profile store remains independent. It continues to own
+URLs, labels, colors, enabled IDs, and selection state in browser storage or
+the native preferences store. It MUST NOT be used as the host configuration
+store.
+
+## 8. Local management path
+
+The implementation SHALL provide a narrow management path callable by the local
+host UI. It MAY be implemented by the bridge with a plugin-owned controller
+handoff, or by another local controller owned by the plugin lifecycle. The
+choice SHALL not expose arbitrary command execution to the browser.
+
+The management path SHALL support:
+
+- reading the current host access state and detected suggestions;
+- validating a draft update;
+- setting, changing, or removing the password;
+- atomically persisting the update; and
+- applying the update through the managed supervisor.
+
+Management requests SHALL be restricted to local operator access. In
+particular, a browser arriving through an accepted remote address MUST NOT be
+able to modify host settings. Origin checks alone are insufficient for the
+local-password bypass; the implementation SHALL use the loopback peer path or
+an equivalent local capability boundary.
+
+Applying an update SHALL follow this sequence:
+
+1. Read and retain the current valid configuration.
+2. Validate the proposed high-level settings.
+3. Derive and validate the complete runtime configuration.
+4. Write the new configuration atomically.
+5. Ask the plugin supervisor to reconcile the owned service.
+6. Wait for bridge, Herdr, protocol, and web readiness.
+7. Report ready only after the new service is usable.
+
+If steps 5–7 fail, the controller SHALL attempt to restore the previous
+configuration and service state. The UI SHALL report the bounded failure and
+offer retry; it SHALL not leave the user guessing whether the service is still
+running.
+
+The browser reloads its own connection after a successful apply. A page reload
+alone is not considered a bridge restart.
+
+## 9. Access behavior
+
+### 9.1 Toggle
+
+When `remote_access.enabled` is false, the bridge SHALL bind only to loopback
+and SHALL preserve accepted hosts and password state for later use.
+
+When it is true, the bridge SHALL bind to the configured LAN-accessible
+interface policy and accept only the normalized accepted addresses. The first
+implementation MAY bind all interfaces while relying on exact Host/Origin
+checks, but the UI SHALL warn that this is not a network firewall or source-IP
+allowlist.
+
+The plugin SHALL continue to reject malformed, unconfigured, or wrong-port
+Host values. The bridge SHALL continue to enforce exact browser Origin policy
+and CSP connect sources derived from the accepted-address model.
+
+### 9.2 Optional password
+
+`password_hash = null` SHALL mean that no password is required. When remote
+access is enabled without a password, the UI SHALL show a concise warning that
+anyone able to reach an accepted address may connect.
+
+When a password is configured:
+
+- loopback peer connections MAY bypass password authentication;
+- non-loopback HTTP requests SHALL authenticate before receiving protected data;
+- all event, activity, UI-event, and terminal WebSockets SHALL authenticate
+  before sending events or terminal bytes;
+- commands, uploads, notes, and other mutating APIs SHALL require authentication;
+- password verification SHALL use a memory-hard password hash and constant-time
+  comparison; and
+- failed attempts SHALL be rate-limited or delayed.
+
+The authentication session mechanism SHALL not put a password in a URL. It MAY
+use an in-memory bearer/session credential for HTTP and a corresponding
+authenticated WebSocket handshake or first-message ticket. It MUST work for
+cross-origin bridge profiles without requiring insecure wildcard CORS.
+
+The password is a baseline against casual access, not protection against a
+network observer. The UI SHALL state that HTTP exposes credentials and session
+traffic to a capable network observer and recommend TLS, VPN, or SSH for
+untrusted networks.
+
+## 10. Diagnostics
+
+The existing client `Test` action SHALL retain its current layout and controls.
+Its result SHALL distinguish at least:
+
+- address/network failure;
+- Host or Origin policy rejection;
+- password required or rejected;
+- API capability incompatibility;
+- WebSocket upgrade failure; and
+- terminal attach failure.
+
+The diagnostic response MAY be composed by the client from staged requests or
+returned as a bounded structured capability result. It SHALL not expose raw
+server paths, environment variables, credentials, or unbounded process output.
+
+The host Remote access area SHALL distinguish:
+
+- settings saved but not yet applied;
+- service restarting;
+- bridge ready;
+- configuration rejected; and
+- service failed to become ready and previous settings restored.
+
+## 11. Transport boundary
+
+The web application SHALL address a host through a transport-neutral bridge
+connection interface. The direct HTTP/WebSocket bridge remains the first
+implementation.
+
+The interface SHALL keep connection identity, capability probing, snapshot
+loading, event subscriptions, terminal sessions, and error classification
+separate from the storage and settings UI. A future SSH-backed connection or
+native Herdr remote-host adapter MAY implement the same interface.
+
+This feature SHALL not require or assume the final shape of main Herdr's
+multi-host protocol. When that protocol is available, Herdr World can replace
+the direct transport adapter without changing the host/client mental model.
+
+## 12. Acceptance scenarios
+
+### Scenario: Local-only setup remains seamless
+
+- **GIVEN** a fresh bridge with remote access disabled
+- **WHEN** the local user opens Herdr World
+- **THEN** the same-origin UI and terminal work without a password or remote
+  settings setup
+
+### Scenario: The host enables remote access
+
+- **GIVEN** the local user opens Remote access
+- **WHEN** they enable the toggle, select one suggested address, and save
+- **THEN** the host settings persist, the owned service restarts, and the UI
+  reports the selected connection URL as ready
+
+### Scenario: Accepted addresses remain disabled without being lost
+
+- **GIVEN** a host has saved accepted addresses
+- **WHEN** the user disables remote access and later reopens settings
+- **THEN** the addresses remain available as the next draft but the bridge is
+  loopback-only
+
+### Scenario: A client adds a host
+
+- **GIVEN** a host is enabled and reachable at an accepted address
+- **WHEN** a client adds that URL, tests it, saves it, and enables it
+- **THEN** the existing Bridges UI shows the enabled bridge and runtime data,
+  events, and terminal output become available
+
+### Scenario: An unaccepted address is rejected
+
+- **GIVEN** remote access is enabled with a bounded accepted-address list
+- **WHEN** a client targets another Host value on the bridge port
+- **THEN** the capability test and WebSocket paths fail with a specific bounded
+  policy error
+
+### Scenario: An optional password protects remote access
+
+- **GIVEN** remote access is enabled with a password
+- **WHEN** a remote client connects without a valid session
+- **THEN** protected APIs and every WebSocket route reject the request without
+  returning snapshot, event, or terminal data
+
+### Scenario: Local access bypasses the password
+
+- **GIVEN** remote access is enabled with a password
+- **WHEN** the local UI connects through the loopback path
+- **THEN** it remains usable without a password
+
+### Scenario: Applying settings fails safely
+
+- **GIVEN** the proposed settings cannot produce a ready bridge
+- **WHEN** the user saves them
+- **THEN** the previous configuration and service remain or are restored, and
+  the UI reports the bounded failure with a retry path
+
+### Scenario: Existing client profiles survive host changes
+
+- **GIVEN** the client has saved bridge profiles in its current store
+- **WHEN** a host changes remote-access settings
+- **THEN** the client profiles remain unchanged and can be retested or edited
+
+## 13. Validation
+
+The implementation SHALL include:
+
+- unit tests for high-level configuration validation and low-level derivation;
+- migration tests for existing loopback and non-loopback configurations;
+- management-path tests proving remote requests cannot mutate host settings;
+- supervisor/restart tests covering success, readiness failure, rollback, and
+  lost runtime records;
+- password tests covering null, valid, invalid, rate-limited, loopback, HTTP,
+  and every WebSocket route;
+- browser tests for suggestions, draft/save behavior, restart status, and
+  bounded diagnostics;
+- regression coverage proving existing Bridges storage and UI behavior remains;
+- privacy-audit coverage for documentation, fixtures, logs, and generated
+  output; and
+- available web, bridge, plugin, packaging, and end-to-end checks in proportion
+  to the changed layers.
+
+## 14. Open implementation notes
+
+The implementation plan SHALL resolve these technical details without changing
+the user-facing decisions above:
+
+- which existing plugin/controller boundary owns the local management path;
+- how a managed service restart reports readiness to the browser;
+- the exact password hash and session-ticket libraries already compatible with
+  the bridge build;
+- how the bridge obtains peer address information for the local bypass; and
+- how the transport-neutral interface maps native Herdr host errors when that
+  adapter is added later.

--- a/docs/specs/019-remote-bridge-access-ux-spec.md
+++ b/docs/specs/019-remote-bridge-access-ux-spec.md
@@ -35,12 +35,13 @@ changes.
 | Client UI | Keep the existing Bridges UI and saved-profile behavior. |
 | Remote toggle | `Allow remote connections` is off by default and preserves accepted addresses when disabled. |
 | Accepted addresses | Hostnames or IP literals that clients may use in the bridge URL; they are not source-IP authentication. |
+| Browser policy | Keep accepted bridge hosts, allowed page origins, and allowed bridge destinations as separate high-level lists because they control different request directions. |
 | Suggestions | Show detected non-loopback addresses as unchecked suggestions. |
 | Password | Optional per-bridge password; `null` means no password. |
-| Local access | Loopback access bypasses the optional remote password. |
+| Local access | A verified local UI may bypass the optional remote password; loopback appearance alone never does. |
 | Persistence | Host settings persist in the plugin configuration; client profiles persist in browser/native client storage. |
 | Restart | Saving host settings applies them through the local controller and safely restarts the managed bridge. |
-| Transport | Direct HTTP/WebSocket remains the first implementation. SSH and native Herdr host transport remain replaceable future adapters. |
+| Transport | Use the existing direct HTTP/WebSocket bridge for this feature. Do not introduce a generic transport abstraction until a second concrete transport exists. |
 
 ## 3. Scope
 
@@ -54,10 +55,11 @@ This feature includes:
 - persistence of host settings without user-facing JSON editing;
 - a local-only management path for validating, persisting, and applying settings;
 - safe restart and rollback behavior when applying settings;
-- automatic derivation of low-level bind, Host, Origin, and CSP settings;
+- automatic derivation of low-level bind, Host, Origin, and CSP settings from
+  separate high-level policy lists;
 - authentication covering HTTP APIs and all WebSocket routes when a password is set;
 - actionable status and connection errors in the existing Bridges test flow; and
-- an internal transport boundary that can later support SSH or native Herdr host connections.
+- direct use of the existing HTTP/WebSocket bridge transport.
 
 ## 4. Non-goals
 
@@ -110,6 +112,8 @@ When remote access is enabled, it SHALL show:
 - accepted addresses as removable rows;
 - detected non-loopback address suggestions as unchecked rows;
 - an `Add address` control for a hostname or IP literal;
+- a compact browser-permissions section for page origins allowed to call this
+  bridge and bridge origins that the page served here may call;
 - the connection URL for the selected address with a copy action;
 - password state: `Not set` or `Protected`, with set/change/remove actions; and
 - apply status: applying, ready, or failed with a bounded reason.
@@ -136,6 +140,23 @@ The user MAY enter a hostname or IP literal manually. The field SHALL reject a
 scheme, path, query, fragment, credentials, or port because the bridge port is
 configured separately.
 
+The browser-permissions section SHALL keep these directional policies separate:
+
+- `Allowed page origins`: exact page origins permitted to call this bridge;
+- `Allowed bridge destinations`: exact bridge origins that the page served by
+  this bridge may call.
+
+The UI SHALL explain that the first protects this bridge's inbound browser
+requests and the second controls the page's outbound HTTP/WebSocket CSP. It
+SHALL offer bounded suggestions from the current page origin, supported local
+app origins, and saved client bridge profiles, all unchecked until selected.
+The user MAY add an origin manually, but the field SHALL accept only a complete
+HTTP(S) origin without credentials, path, query, fragment, or wildcard.
+
+When a tested bridge is missing a reciprocal page-origin or destination policy,
+the UI SHOULD show a short setup hint identifying which host-side permission is
+missing. It MUST not silently broaden either list.
+
 The UI MAY display real addresses to the local operator because they are the
 subject of the setting. It MUST NOT write them to logs, telemetry, generated
 documentation, test fixtures, or other repository content.
@@ -144,6 +165,10 @@ documentation, test fixtures, or other repository content.
 
 The existing Bridges area SHALL remain the client configuration surface. A
 client user continues to add a bridge URL, test it, save it, and enable it.
+When the current page is served by a managed local bridge, a saved bridge
+profile MAY be offered as an `Allowed bridge destination` suggestion in that
+host's Remote access area. The client profile store remains independent and is
+not itself authoritative for the host's CSP.
 
 When a password-protected bridge is tested or first used, the client SHALL ask
 for the password in a masked field. The password SHALL not be placed in a URL,
@@ -166,6 +191,8 @@ The user-facing host model SHALL be high-level:
   "remote_access": {
     "enabled": false,
     "accepted_hosts": [],
+    "allowed_page_origins": [],
+    "allowed_bridge_origins": [],
     "password_hash": null
   }
 }
@@ -180,7 +207,10 @@ Existing configurations SHALL migrate as follows:
 
 - loopback-only configurations infer `remote_access.enabled = false`;
 - non-loopback configurations infer `remote_access.enabled = true`;
-- existing accepted Host values are retained as `accepted_hosts`; and
+- existing accepted Host values are retained as `accepted_hosts`;
+- existing `allowed_origins` values are retained as `allowed_page_origins`;
+- existing `allowed_connect_origins` values are retained as
+  `allowed_bridge_origins`; and
 - an absent password remains `null`.
 
 Host settings SHALL be written atomically with restrictive permissions. A
@@ -195,9 +225,17 @@ store.
 ## 8. Local management path
 
 The implementation SHALL provide a narrow management path callable by the local
-host UI. It MAY be implemented by the bridge with a plugin-owned controller
-handoff, or by another local controller owned by the plugin lifecycle. The
-choice SHALL not expose arbitrary command execution to the browser.
+host UI. The plugin-owned controller SHALL own configuration writes and
+supervisor operations. The public bridge SHALL not expose privileged management
+routes.
+
+The local UI SHALL invoke the controller through a separate unforgeable local
+capability or an OS-level IPC/controller boundary. A loopback HTTP listener,
+the request Host header, or an ordinary Origin check alone is insufficient:
+SSH forwards and same-host reverse proxies can make remote traffic appear to
+come from loopback. If an environment cannot establish this local boundary,
+remote settings mutation and the local password bypass SHALL remain disabled
+there rather than falling back to loopback trust.
 
 The management path SHALL support:
 
@@ -207,11 +245,11 @@ The management path SHALL support:
 - atomically persisting the update; and
 - applying the update through the managed supervisor.
 
-Management requests SHALL be restricted to local operator access. In
-particular, a browser arriving through an accepted remote address MUST NOT be
-able to modify host settings. Origin checks alone are insufficient for the
-local-password bypass; the implementation SHALL use the loopback peer path or
-an equivalent local capability boundary.
+The capability SHALL be scoped to the local UI session, kept out of URLs, page
+markup, logs, exported profiles, and persistent bridge configuration, and must
+not be transferable through a remotely reachable bridge request. A browser
+arriving through an accepted remote address MUST NOT be able to modify host
+settings.
 
 Applying an update SHALL follow this sequence:
 
@@ -246,7 +284,21 @@ allowlist.
 
 The plugin SHALL continue to reject malformed, unconfigured, or wrong-port
 Host values. The bridge SHALL continue to enforce exact browser Origin policy
-and CSP connect sources derived from the accepted-address model.
+from `allowed_page_origins`, and CSP connect sources from
+`allowed_bridge_origins`. Neither list SHALL be inferred from
+`accepted_hosts` alone.
+
+For a page served from bridge A to call bridge B directly, A's
+`allowed_bridge_origins` MUST include B's bridge origin and B's
+`allowed_page_origins` MUST include A's page origin. An Android WebView page
+origin such as `http://localhost` is another explicit page-origin candidate;
+it is not implied by the bridge address.
+
+The direct two-host setup therefore has two host-side saves: the page-serving
+host permits the other bridge as a destination, and the target host permits the
+page origin. Adding a URL in the client Bridges area does not silently change
+either host's policy; it can only provide a local suggestion for the destination
+list.
 
 ### 9.2 Optional password
 
@@ -256,7 +308,10 @@ anyone able to reach an accepted address may connect.
 
 When a password is configured:
 
-- loopback peer connections MAY bypass password authentication;
+- loopback connections MAY bypass password authentication only after the same
+  unforgeable local capability or IPC/controller check used for management;
+- a forwarded or reverse-proxied connection that merely appears to be loopback
+  SHALL still require the password;
 - non-loopback HTTP requests SHALL authenticate before receiving protected data;
 - all event, activity, UI-event, and terminal WebSockets SHALL authenticate
   before sending events or terminal bytes;
@@ -299,20 +354,13 @@ The host Remote access area SHALL distinguish:
 - configuration rejected; and
 - service failed to become ready and previous settings restored.
 
-## 11. Transport boundary
+## 11. Direct transport
 
-The web application SHALL address a host through a transport-neutral bridge
-connection interface. The direct HTTP/WebSocket bridge remains the first
-implementation.
-
-The interface SHALL keep connection identity, capability probing, snapshot
-loading, event subscriptions, terminal sessions, and error classification
-separate from the storage and settings UI. A future SSH-backed connection or
-native Herdr remote-host adapter MAY implement the same interface.
-
-This feature SHALL not require or assume the final shape of main Herdr's
-multi-host protocol. When that protocol is available, Herdr World can replace
-the direct transport adapter without changing the host/client mental model.
+This feature SHALL use the existing direct HTTP/WebSocket bridge and its current
+client connection code. It SHALL not add a generic transport abstraction,
+SSH-tunnel manager, or native Herdr remote-host contract. A future transport
+can introduce its own boundary when a second concrete implementation and its
+common requirements are known.
 
 ## 12. Acceptance scenarios
 
@@ -358,11 +406,19 @@ the direct transport adapter without changing the host/client mental model.
 - **THEN** protected APIs and every WebSocket route reject the request without
   returning snapshot, event, or terminal data
 
-### Scenario: Local access bypasses the password
+### Scenario: Local access bypasses the password safely
 
 - **GIVEN** remote access is enabled with a password
-- **WHEN** the local UI connects through the loopback path
+- **WHEN** the local UI connects through the loopback path with the local
+  capability or IPC proof
 - **THEN** it remains usable without a password
+
+### Scenario: A forwarded loopback connection does not bypass the password
+
+- **GIVEN** remote access is enabled with a password
+- **WHEN** a browser reaches the bridge through an SSH forward or reverse proxy
+  that terminates on loopback without the local capability
+- **THEN** it still must authenticate
 
 ### Scenario: Applying settings fails safely
 
@@ -383,7 +439,10 @@ The implementation SHALL include:
 
 - unit tests for high-level configuration validation and low-level derivation;
 - migration tests for existing loopback and non-loopback configurations;
-- management-path tests proving remote requests cannot mutate host settings;
+- policy tests proving accepted hosts, allowed page origins, and allowed bridge
+  destinations remain directional and are not inferred from one another;
+- management-path tests proving remote requests cannot mutate host settings and
+  loopback appearance alone cannot satisfy the local boundary;
 - supervisor/restart tests covering success, readiness failure, rollback, and
   lost runtime records;
 - password tests covering null, valid, invalid, rate-limited, loopback, HTTP,
@@ -402,9 +461,12 @@ The implementation plan SHALL resolve these technical details without changing
 the user-facing decisions above:
 
 - which existing plugin/controller boundary owns the local management path;
+- how the local capability or IPC proof is minted and verified without making
+  it available to forwarded browsers;
 - how a managed service restart reports readiness to the browser;
 - the exact password hash and session-ticket libraries already compatible with
   the bridge build;
-- how the bridge obtains peer address information for the local bypass; and
-- how the transport-neutral interface maps native Herdr host errors when that
-  adapter is added later.
+- how the bridge obtains peer address information for diagnostics after the
+  capability check; and
+- how the UI presents separate page-origin and bridge-destination policy
+  without exposing raw runtime flags.

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "test:observability": "npm run test --prefix web -- observability.test.ts && cargo test --manifest-path bridge/Cargo.toml --bin herdr-web-bridge observability",
     "test:e2e": "npm run build:web && playwright test",
     "test:independence": "scripts/independence-audit.sh",
+    "test:privacy": "scripts/privacy-audit.sh",
     "test:security": "scripts/security-audit.sh",
     "lint:web": "npm run lint --prefix web",
     "vendor:check": "scripts/check-vendor.sh",
@@ -32,7 +33,7 @@
     "build": "npm run build:web && npm run bridge:build",
     "test": "npm run test:dev && npm run test:release && npm run test:pages && npm run test:web && npm run bridge:test",
     "lint": "npm run lint:web && npm run bridge:fmt",
-    "check": "npm run vendor:check && npm run notices:check && npm run lint && npm run test && npm run build",
+    "check": "npm run vendor:check && npm run notices:check && npm run test:privacy && npm run lint && npm run test && npm run build",
     "check:acceptance": "npm run check && npm run test:e2e && npm run test:security && npm run test:independence"
   },
   "devDependencies": {

--- a/scripts/herdr-world-plugin.mjs
+++ b/scripts/herdr-world-plugin.mjs
@@ -1027,6 +1027,86 @@ function launchdServicePresent(record, command) {
   return result.status === 0;
 }
 
+function launchdServiceDefinition(record, command) {
+  const args = ["print", launchdServiceTarget(record)];
+  const result = commandResult(command, args, { timeout: RUNTIME_TIMEOUT_MS });
+  const invocation = `${path.basename(command)} ${args.join(" ")}`;
+  if (result.error) throw new PluginError(`${invocation} failed: ${result.error.message}`);
+  if (result.status !== 0) return null;
+  return String(result.stdout ?? "");
+}
+
+function launchdServicePath(record, command) {
+  const definition = launchdServiceDefinition(record, command);
+  if (definition === null) return null;
+  return definition.match(/^\s*path = (.+)$/m)?.[1]?.trim() ?? null;
+}
+
+function unrecordedService(identity, supervisor) {
+  return {
+    target_identity: identity,
+    supervisor: supervisor.kind,
+    service_name: serviceName(identity, supervisor.kind),
+  };
+}
+
+async function recoverUnrecordedService(identity, stateDir, supervisor) {
+  if (supervisor.kind === "launchd") {
+    const record = unrecordedService(identity, supervisor);
+    if (!launchdServicePresent(record, supervisor.command)) return false;
+
+    const expectedPath = pathForSupervisor(stateDir, record, "plist");
+    const actualPath = launchdServicePath(record, supervisor.command);
+    if (actualPath !== expectedPath) {
+      throw new PluginError(
+        `launchd service ${record.service_name} is already loaded from an unexpected definition; refusing to stop an unrelated service`,
+      );
+    }
+    await unloadLaunchd(record, supervisor.command);
+    return true;
+  }
+
+  if (supervisor.kind === "systemd-user") {
+    const record = unrecordedService(identity, supervisor);
+    const result = commandResult(
+      supervisor.command,
+      ["--user", "show", record.service_name, "--property=LoadState", "--value"],
+      { timeout: RUNTIME_TIMEOUT_MS },
+    );
+    if (result.error) {
+      throw new PluginError(`systemctl --user show ${record.service_name} failed: ${result.error.message}`);
+    }
+    if (result.status !== 0 || String(result.stdout ?? "").trim() !== "loaded") return false;
+
+    const fragment = commandResult(
+      supervisor.command,
+      ["--user", "show", record.service_name, "--property=FragmentPath", "--value"],
+      { timeout: RUNTIME_TIMEOUT_MS },
+    );
+    if (fragment.error || fragment.status !== 0) {
+      throw new PluginError(
+        `systemd service ${record.service_name} is already loaded but its definition could not be verified; refusing to stop an unrelated service`,
+      );
+    }
+    const expectedPath = pathForSupervisor(stateDir, record, "service");
+    const actualPath = String(fragment.stdout ?? "").trim();
+    if (actualPath !== expectedPath) {
+      throw new PluginError(
+        `systemd service ${record.service_name} is already loaded from an unexpected definition; refusing to stop an unrelated service`,
+      );
+    }
+    runChecked(supervisor.command, ["--user", "stop", record.service_name]);
+    try {
+      runChecked(supervisor.command, ["--user", "disable", record.service_name]);
+    } catch {
+      // A stopped unit may already be disabled by the user supervisor.
+    }
+    return true;
+  }
+
+  return false;
+}
+
 export function selectSupervisor(platform, env) {
   if (platform === "linux") {
     const systemctl = systemdAvailable(env);
@@ -1359,6 +1439,10 @@ async function startPrepared(plan, { lockHeld = false } = {}) {
       if (ownership.state.active) await stopRecord(previous, env, platform);
       removeRecord(recordPath);
     }
+    const recovered = await recoverUnrecordedService(context.target.identity, context.stateDir, supervisor);
+    if (recovered) {
+      console.log("Recovered an unrecorded Herdr World service; applying the current configuration.");
+    }
     const port = await choosePort(context.config, context.target.identity, context.stateDir);
     const { record, environment } = createRecord({
       identity: context.target.identity,
@@ -1442,6 +1526,12 @@ async function stopAction({ root = ROOT, env = process.env, platform = process.p
   const recordPath = targetRecordPath(context.stateDir, context.target.identity);
   const record = readRecord(recordPath);
   if (!record) {
+    const supervisor = selectSupervisor(platform, env);
+    const recovered = await recoverUnrecordedService(context.target.identity, context.stateDir, supervisor);
+    if (recovered) {
+      console.log(`Stopped the unrecorded Herdr World service for ${displayTarget(context.target)}.`);
+      return null;
+    }
     console.log(`Herdr World is not running for ${displayTarget(context.target)}`);
     return null;
   }

--- a/scripts/herdr-world-plugin.test.mjs
+++ b/scripts/herdr-world-plugin.test.mjs
@@ -121,13 +121,16 @@ const logPath = path.join(bin, "launchctl.log");
 const commandPath = path.join(bin, "service-command.json");
 const failPath = path.join(bin, "bootstrap-fails");
 const cleanupFailPath = path.join(bin, "bootout-fails");
+const servicePath = path.join(bin, "service.plist");
 appendFileSync(logPath, JSON.stringify(args) + "\\n");
 if (args[0] === "print") {
   const service = args[1]?.split("/").length === 3;
   if (!service) process.exit(0);
   if (!existsSync(statePath)) process.exit(1);
   const pid = readFileSync(statePath, "utf8").trim();
+  const plistPath = existsSync(servicePath) ? readFileSync(servicePath, "utf8") : "";
   process.stdout.write("pid = " + pid + "\\nstate = running\\n");
+  if (plistPath) process.stdout.write("path = " + plistPath + "\\n");
   process.exit(0);
 }
 if (args[0] === "bootstrap") {
@@ -135,6 +138,7 @@ if (args[0] === "bootstrap") {
   const child = spawn(command[0], command.slice(1), { detached: true, stdio: "ignore" });
   child.unref();
   writeFileSync(statePath, String(child.pid));
+  writeFileSync(servicePath, args[2]);
   if (existsSync(failPath)) {
     process.stderr.write("fixture bootstrap failed\\n");
     process.exit(7);
@@ -150,6 +154,7 @@ if (args[0] === "bootout") {
     const pid = Number(readFileSync(statePath, "utf8"));
     try { process.kill(pid, "SIGTERM"); } catch {}
     rmSync(statePath, { force: true });
+    rmSync(servicePath, { force: true });
   }
   process.exit(0);
 }
@@ -520,6 +525,47 @@ test("launchd bootstraps RunAtLoad services once and unloads partial startup", a
       const pid = Number(readFileSync(fixture.statePath, "utf8"));
       try { process.kill(pid, "SIGTERM"); } catch {}
     }
+    await new Promise((resolve) => fixture.socketServer.close(resolve));
+    rmSync(fixture.socketPath, { force: true });
+    rmSync(fixture.root, { recursive: true, force: true });
+  }
+});
+
+test("start recovers an owned launchd service when its runtime record is missing", async () => {
+  const fixture = await launchdFixture();
+  const options = { root: fixture.root, env: fixture.env, platform: "darwin", arch: "arm64" };
+  const identity = resolveTargetIdentity(validateConfig({}), fixture.env);
+  const recordPath = targetRecordPath(fixture.stateDir, identity.identity);
+  try {
+    await runAction("start", options);
+    rmSync(recordPath, { force: true });
+
+    const configPath = path.join(fixture.env.HERDR_PLUGIN_CONFIG_DIR, "config.json");
+    writeFileSync(
+      configPath,
+      JSON.stringify({
+        host: "0.0.0.0",
+        port: fixture.port,
+        port_range: [fixture.port, fixture.port],
+        allowed_hosts: ["world.example"],
+        allowed_origins: ["https://world.example"],
+      }),
+    );
+    await runAction("start", options);
+
+    const commands = readFileSync(fixture.logPath, "utf8")
+      .trim()
+      .split("\n")
+      .filter(Boolean)
+      .map((line) => JSON.parse(line));
+    assert.ok(commands.some((args) => args[0] === "bootout"));
+    assert.ok(commands.some((args) => args[0] === "bootstrap"));
+    const plistName = readdirSync(path.join(fixture.stateDir, "supervisors")).find((name) => name.endsWith(".plist"));
+    assert.ok(plistName);
+    const serviceDefinition = readFileSync(path.join(fixture.stateDir, "supervisors", plistName), "utf8");
+    assert.match(serviceDefinition, /<string>0\.0\.0\.0<\/string>/);
+  } finally {
+    try { await runAction("stop", options); } catch {}
     await new Promise((resolve) => fixture.socketServer.close(resolve));
     rmSync(fixture.socketPath, { force: true });
     rmSync(fixture.root, { recursive: true, force: true });

--- a/scripts/privacy-audit.sh
+++ b/scripts/privacy-audit.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root=$(git rev-parse --show-toplevel)
+cd "$repo_root"
+
+scan_paths=(
+  .
+  ':(exclude)scripts/privacy-audit.sh'
+  ':(exclude)scripts/security-audit.sh'
+  ':(exclude).github/workflows/release.yml'
+)
+failed=0
+
+scan() {
+  local label=$1
+  local pattern=$2
+  local matches
+  matches=$(git grep -l -E "$pattern" -- "${scan_paths[@]}" || true)
+  if [[ -n "$matches" ]]; then
+    printf 'privacy audit: %s found in:\n%s\n' "$label" "$matches" >&2
+    failed=1
+  fi
+}
+
+scan 'private network identifiers' \
+  '192\.168\.[0-9]+\.[0-9]+|10\.[0-9]+\.[0-9]+\.[0-9]+|172\.(1[6-9]|2[0-9]|3[0-1])\.[0-9]+\.[0-9]+|(^|[^[:alnum:]])f[cd][0-9a-f]{2}:|(^|[^0-9])169\.254\.'
+scan 'environment-specific absolute paths' \
+  '/(Users|home)/[^/[:space:]]+/|[A-Za-z]:[\\/]+Users[\\/]+[^\\/[:space:]]+'
+scan 'credential-shaped values' \
+  '(^|[^A-Za-z])(sk-[A-Za-z0-9_-]{16,}|gh[pousr]_[A-Za-z0-9_]{16,}|xox[baprs]-[A-Za-z0-9-]{16,}|BEGIN (RSA|OPENSSH|EC|PGP) PRIVATE KEY|Bearer [A-Za-z0-9._-]{20,})'
+
+if ((failed)); then
+  exit 1
+fi
+
+printf '%s\n' 'privacy audit passed'

--- a/web/src/BackendSettingsDialog.tsx
+++ b/web/src/BackendSettingsDialog.tsx
@@ -472,7 +472,7 @@ export function BackendSettingsDialog({
                           <input
                             className="field"
                             value={form.baseUrl}
-                            placeholder="http://192.168.1.20:4000"
+                            placeholder="http://bridge-a.example.test:4000"
                             autoComplete="off"
                             spellCheck={false}
                             onBlur={validateDuplicate}

--- a/web/src/bridge.test.ts
+++ b/web/src/bridge.test.ts
@@ -25,27 +25,27 @@ afterEach(() => {
 
 describe("bridge URL normalization", () => {
   it("normalizes origin-only bridge URLs", () => {
-    expect(normalizeBridgeBaseUrl("192.168.1.20:4000")).toBe("http://192.168.1.20:4000");
+    expect(normalizeBridgeBaseUrl("192.0.2.20:4000")).toBe("http://192.0.2.20:4000");
     expect(normalizeBridgeBaseUrl(" http://herdr-host.local:4000/ ")).toBe(
       "http://herdr-host.local:4000",
     );
     expect(normalizeBridgeBaseUrl("https://herdr-host.local:443")).toBe(
       "https://herdr-host.local",
     );
-    expect(normalizeBridgeBaseUrl("http://192.168.1.20:80")).toBe("http://192.168.1.20");
-    expect(normalizeBridgeBaseUrl("http://[fd00::1234]:4000")).toBe(
-      "http://[fd00::1234]:4000",
+    expect(normalizeBridgeBaseUrl("http://192.0.2.20:80")).toBe("http://192.0.2.20");
+    expect(normalizeBridgeBaseUrl("http://[2001:db8::1234]:4000")).toBe(
+      "http://[2001:db8::1234]:4000",
     );
     expect(normalizeBridgeBaseUrl("http://100.64.0.1:4000")).toBe("http://100.64.0.1:4000");
     expect(normalizeBridgeBaseUrl("http://8.8.8.8:4000")).toBe("http://8.8.8.8:4000");
   });
 
   it("rejects unsupported URL shapes", () => {
-    expect(() => normalizeBridgeBaseUrl("ftp://192.168.1.20:4000")).toThrow(/http or https/iu);
-    expect(() => normalizeBridgeBaseUrl("http://user@192.168.1.20:4000")).toThrow(
+    expect(() => normalizeBridgeBaseUrl("ftp://192.0.2.20:4000")).toThrow(/http or https/iu);
+    expect(() => normalizeBridgeBaseUrl("http://user@192.0.2.20:4000")).toThrow(
       /credentials/iu,
     );
-    expect(() => normalizeBridgeBaseUrl("http://192.168.1.20:4000/api")).toThrow(
+    expect(() => normalizeBridgeBaseUrl("http://192.0.2.20:4000/api")).toThrow(
       /path/iu,
     );
   });
@@ -73,11 +73,11 @@ describe("bridge URL builders", () => {
   it("builds configured HTTP and WebSocket URLs", () => {
     const query = new URLSearchParams({ terminal_id: "term-1" });
 
-    expect(buildHttpUrl("http://192.168.1.20:4000", "/api/snapshot")).toBe(
-      "http://192.168.1.20:4000/api/snapshot",
+    expect(buildHttpUrl("http://192.0.2.20:4000", "/api/snapshot")).toBe(
+      "http://192.0.2.20:4000/api/snapshot",
     );
-    expect(buildWsUrl("http://192.168.1.20:4000", "/ws/terminal", query)).toBe(
-      "ws://192.168.1.20:4000/ws/terminal?terminal_id=term-1",
+    expect(buildWsUrl("http://192.0.2.20:4000", "/ws/terminal", query)).toBe(
+      "ws://192.0.2.20:4000/ws/terminal?terminal_id=term-1",
     );
   });
 });
@@ -101,8 +101,8 @@ describe("backend store parsing", () => {
         version: 1,
         activeBackendId: "missing",
         backends: [
-          { id: "one", name: "Home", baseUrl: "http://192.168.1.20:4000" },
-          { id: "bad", name: "Bad", baseUrl: "http://192.168.1.20:4000/api" },
+          { id: "one", name: "Home", baseUrl: "http://192.0.2.20:4000" },
+          { id: "bad", name: "Bad", baseUrl: "http://192.0.2.20:4000/api" },
         ],
       }),
     ).toEqual({
@@ -113,7 +113,7 @@ describe("backend store parsing", () => {
         {
           id: "one",
           name: "Home",
-          baseUrl: "http://192.168.1.20:4000",
+          baseUrl: "http://192.0.2.20:4000",
           lastConnectedAt: undefined,
         },
       ],
@@ -125,7 +125,7 @@ describe("backend store parsing", () => {
       parseBackendStore({
         version: 1,
         activeBackendId: "one",
-        backends: [{ id: "one", name: "Home", baseUrl: "http://192.168.1.20:4000" }],
+        backends: [{ id: "one", name: "Home", baseUrl: "http://192.0.2.20:4000" }],
       }),
     ).toEqual({
       version: 2,
@@ -135,7 +135,7 @@ describe("backend store parsing", () => {
         {
           id: "one",
           name: "Home",
-          baseUrl: "http://192.168.1.20:4000",
+          baseUrl: "http://192.0.2.20:4000",
           lastConnectedAt: undefined,
         },
       ],
@@ -148,7 +148,7 @@ describe("backend store parsing", () => {
         version: 2,
         enabledBridgeIds: ["one", "missing", "one", SAME_ORIGIN_BRIDGE_ID],
         lastSelectedBridgeId: "missing",
-        backends: [{ id: "one", name: "Home", baseUrl: "http://192.168.1.20:4000" }],
+        backends: [{ id: "one", name: "Home", baseUrl: "http://192.0.2.20:4000" }],
       }),
     ).toEqual({
       version: 2,
@@ -158,7 +158,7 @@ describe("backend store parsing", () => {
         {
           id: "one",
           name: "Home",
-          baseUrl: "http://192.168.1.20:4000",
+          baseUrl: "http://192.0.2.20:4000",
           lastConnectedAt: undefined,
         },
       ],
@@ -175,13 +175,13 @@ describe("backend store parsing", () => {
           {
             id: "one",
             name: "Home",
-            baseUrl: "http://192.168.1.20:4000",
+            baseUrl: "http://192.0.2.20:4000",
             color: "#A1b2C3",
           },
           {
             id: "two",
             name: "Work",
-            baseUrl: "http://192.168.1.21:4000",
+            baseUrl: "http://192.0.2.21:4000",
             color: "red",
           },
         ],
@@ -190,14 +190,14 @@ describe("backend store parsing", () => {
       {
         id: "one",
         name: "Home",
-        baseUrl: "http://192.168.1.20:4000",
+        baseUrl: "http://192.0.2.20:4000",
         color: "#a1b2c3",
         lastConnectedAt: undefined,
       },
       {
         id: "two",
         name: "Work",
-        baseUrl: "http://192.168.1.21:4000",
+        baseUrl: "http://192.0.2.21:4000",
         lastConnectedAt: undefined,
       },
     ]);
@@ -213,7 +213,7 @@ describe("backend store parsing", () => {
           {
             id: SAME_ORIGIN_BRIDGE_ID,
             name: "Impostor",
-            baseUrl: "http://192.168.1.20:4000",
+            baseUrl: "http://192.0.2.20:4000",
           },
         ],
       }),
@@ -229,7 +229,7 @@ describe("backend store parsing", () => {
     const legacyStore = {
       version: 1,
       activeBackendId: "one",
-      backends: [{ id: "one", name: "Home", baseUrl: "http://192.168.1.20:4000" }],
+      backends: [{ id: "one", name: "Home", baseUrl: "http://192.0.2.20:4000" }],
     };
     const setItem = vi.fn();
     const removeItem = vi.fn();
@@ -251,7 +251,7 @@ describe("backend store parsing", () => {
         {
           id: "one",
           name: "Home",
-          baseUrl: "http://192.168.1.20:4000",
+          baseUrl: "http://192.0.2.20:4000",
           lastConnectedAt: undefined,
         },
       ],
@@ -263,10 +263,10 @@ describe("backend store parsing", () => {
   });
 
   it("detects duplicate normalized backend URLs", () => {
-    const backends = [{ id: "one", name: "Home", baseUrl: "http://192.168.1.20:4000" }];
+    const backends = [{ id: "one", name: "Home", baseUrl: "http://192.0.2.20:4000" }];
 
-    expect(duplicateBackend(backends, "192.168.1.20:4000")?.id).toBe("one");
-    expect(duplicateBackend(backends, "192.168.1.20:4000", "one")).toBeNull();
+    expect(duplicateBackend(backends, "192.0.2.20:4000")?.id).toBe("one");
+    expect(duplicateBackend(backends, "192.0.2.20:4000", "one")).toBeNull();
   });
 
   it("removes note drafts scoped to a retired backend connection", () => {
@@ -421,9 +421,9 @@ describe("capabilities", () => {
       new Response(JSON.stringify(response), { status: 200 }),
     );
 
-    await expect(probeBridgeBaseUrl("192.168.1.20:4000")).resolves.toEqual(response);
+    await expect(probeBridgeBaseUrl("192.0.2.20:4000")).resolves.toEqual(response);
     expect(fetchMock).toHaveBeenCalledWith(
-      "http://192.168.1.20:4000/api/capabilities",
+      "http://192.0.2.20:4000/api/capabilities",
       expect.objectContaining({ signal: expect.any(AbortSignal) }),
     );
 
@@ -437,7 +437,7 @@ describe("capabilities", () => {
       }),
     );
 
-    await expect(probeBridgeBaseUrl("192.168.1.20:4000")).rejects.toThrow(/protocol 16/iu);
+    await expect(probeBridgeBaseUrl("192.0.2.20:4000")).rejects.toThrow(/protocol 16/iu);
 
     fetchMock.mockRestore();
   });
@@ -449,7 +449,7 @@ describe("capabilities", () => {
       }),
     );
 
-    await expect(probeBridgeBaseUrl("192.168.1.20:4000")).rejects.toThrow(
+    await expect(probeBridgeBaseUrl("192.0.2.20:4000")).rejects.toThrow(
       new RegExp(`protocol ${terminalProtocol}`),
     );
 
@@ -463,7 +463,7 @@ describe("capabilities", () => {
       }),
     );
 
-    await expect(probeBridgeBaseUrl("192.168.1.20:4000")).rejects.toThrow(/0\.8\.2/iu);
+    await expect(probeBridgeBaseUrl("192.0.2.20:4000")).rejects.toThrow(/0\.8\.2/iu);
 
     fetchMock.mockRestore();
   });

--- a/web/src/commands.test.ts
+++ b/web/src/commands.test.ts
@@ -27,7 +27,7 @@ describe("command helpers", () => {
   });
 
   it("uses injected bridge URLs for commands", async () => {
-    const httpUrl = (path: string) => `http://192.168.1.20:4000${path}`;
+    const httpUrl = (path: string) => `http://192.0.2.20:4000${path}`;
     vi.spyOn(globalThis, "fetch").mockResolvedValue(
       new Response(JSON.stringify({ type: "ok" }), {
         status: 200,
@@ -38,7 +38,7 @@ describe("command helpers", () => {
 
     expect(fetch).toHaveBeenNthCalledWith(
       1,
-      "http://192.168.1.20:4000/api/command",
+      "http://192.0.2.20:4000/api/command",
       expect.objectContaining({ method: "POST" }),
     );
   });

--- a/web/src/state.test.ts
+++ b/web/src/state.test.ts
@@ -336,7 +336,7 @@ describe("sortPanesForPicker", () => {
 
 describe("paneTitle", () => {
   it("uses cwd basename before falling back to a generic terminal title", () => {
-    expect(paneTitle({ ...pane("1-1"), foreground_cwd: "/home/kevin/worktrees/herdr" })).toBe(
+    expect(paneTitle({ ...pane("1-1"), foreground_cwd: "/tmp/example/worktrees/herdr" })).toBe(
       "herdr",
     );
     expect(paneTitle(pane("1-2"))).toBe("Terminal");
@@ -350,7 +350,7 @@ describe("paneListSubtitle", () => {
         {
           ...pane("1-1"),
           display_agent: "Codex",
-          foreground_cwd: "/home/kevin/worktrees/herdr-web",
+          foreground_cwd: "/tmp/example/worktrees/herdr-web",
         },
         "development",
         "review",
@@ -366,7 +366,7 @@ describe("paneListSubtitle", () => {
           ...pane("1-1"),
           label: "Codex",
           display_agent: "Codex",
-          foreground_cwd: "/home/kevin/Codex",
+          foreground_cwd: "/tmp/example/Codex",
         },
         "workspace",
         "Codex",
@@ -442,14 +442,14 @@ describe("rename clear heuristics", () => {
   });
 
   it("treats cwd-derived workspace labels as already default", () => {
-    const panes = [{ ...pane("1-1"), cwd: "/home/kevin/worktrees/herdr-web" }];
+    const panes = [{ ...pane("1-1"), cwd: "/tmp/example/worktrees/herdr-web" }];
 
     expect(canClearWorkspaceName(workspace("herdr-web"), panes)).toBe(false);
     expect(canClearWorkspaceName(workspace("Herdr Web"), panes)).toBe(true);
   });
 
   it("uses bridge-provided workspace clearability when cwd heuristics would differ", () => {
-    const panes = [{ ...pane("1-1"), cwd: "/home/kevin/worktrees/herdr-web/web/src" }];
+    const panes = [{ ...pane("1-1"), cwd: "/tmp/example/worktrees/herdr-web/web/src" }];
 
     expect(canClearWorkspaceName({ ...workspace("herdr-web"), can_clear_name: false }, panes)).toBe(
       false,


### PR DESCRIPTION
## Summary\n\n- Recover an owned launchd or systemd-user bridge when its runtime record is missing, so current bind and access configuration can take effect.\n- Verify the supervisor definition path before stopping an unrecorded service; refuse to stop an unrelated service.\n- Document LAN configuration, including exact Host, page-origin, and CSP connect-source policy.\n- Add a regression test for an orphaned launchd service.\n- Add concise repository privacy guidance and an automated privacy audit; replace environment-specific examples with synthetic domains, reserved test ranges, and placeholder paths.\n- Add a draft product/technical spec for UI-managed direct network bridge access, optional defense-in-depth password protection, safe apply/rollback, and local trust boundaries.\n\n## Root cause covered\n\nA previously loaded supervisor service could retain old loopback arguments after its runtime record was lost. Restart then saw the port as occupied and could not apply the new bind configuration. Browser requests also require exact Host and Origin policy plus CSP connect-src entries; a successful curl does not exercise those browser checks.\n\n## Draft direction\n\n[Spec 019: UI-managed remote bridge access](https://github.com/IvoryHeart/herdr-world/blob/fix/plugin-remote-bind/docs/specs/019-remote-bridge-access-ux-spec.md) keeps the client Bridges UI, adds a simple host-side Remote access area, models accepted hosts separately from page origins and bridge destinations, persists host settings through a protected local controller, and uses the existing direct HTTP/WebSocket bridge for trusted LAN/VPN, Android, browser-only, and existing operator-managed reverse-proxy use. The optional password is explicitly not a substitute for TLS, VPN, or SSH.\n\nA later desktop-only SSH connection mode can be proposed separately, using system OpenSSH conventions and a loopback-only remote bridge. It is not part of Spec 019 and does not introduce browser-managed SSH keys or a generic transport abstraction.\n\n## Validation\n\n- npm run test:privacy\n- node --test scripts/herdr-world-plugin.test.mjs (25 passed)\n- git diff --check\n- Selected web tests were not runnable in this checkout because the web Vitest dependency is not installed.