### PR TITLE
feat: add UI-managed Herdr network connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ Web's own release history remains in its upstream changelog.
 
 ### Fixed
 
+- Allowed a shared bridge's own LAN page to authenticate without duplicating its URL under
+  advanced client-origin settings, while retaining explicit policy for pages served elsewhere.
+  [Herdr World PR #77](https://github.com/IvoryHeart/herdr-world/pull/77)
 - Reconciled an owned launchd or systemd service whose runtime record was lost, so changing the
   plugin bind host or access policy can take effect instead of leaving an old loopback service
   loaded and blocking restart.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,10 @@ Web's own release history remains in its upstream changelog.
 ### Added
 
 - Added UI-managed sharing for plugin-hosted bridges, with detected host addresses, an optional
-  memory-hard password, in-memory client sessions, copyable Bridge URLs, readiness/rollback status,
-  and advanced inbound browser-origin controls. Outbound destination permissions now live with
-  client Bridge profiles and reload the page when its browser policy changes.
+  memory-hard password, reload-safe tab-scoped client sessions, copyable Bridge URLs,
+  readiness/rollback status, and advanced inbound browser-origin controls. Outbound destination
+  permissions now live with client Bridge profiles and reload the page when its browser policy
+  changes.
   [Herdr World PR #77](https://github.com/IvoryHeart/herdr-world/pull/77)
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Web's own release history remains in its upstream changelog.
 - Added UI-managed Direct network access for plugin-hosted bridges, with separate accepted-address,
   page-origin, and bridge-destination policies, optional memory-hard password protection, in-memory
   client sessions, copyable addresses, readiness/rollback status, and actionable bridge diagnostics.
+  [Herdr World PR #77](https://github.com/IvoryHeart/herdr-world/pull/77)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,10 @@ Web's own release history remains in its upstream changelog.
 
 ### Added
 
-- Added UI-managed Direct network access for plugin-hosted bridges, with separate accepted-address,
-  page-origin, and bridge-destination policies, optional memory-hard password protection, in-memory
-  client sessions, copyable addresses, readiness/rollback status, and actionable bridge diagnostics.
+- Added UI-managed sharing for plugin-hosted bridges, with detected host addresses, an optional
+  memory-hard password, in-memory client sessions, copyable Bridge URLs, readiness/rollback status,
+  and advanced inbound browser-origin controls. Outbound destination permissions now live with
+  client Bridge profiles and reload the page when its browser policy changes.
   [Herdr World PR #77](https://github.com/IvoryHeart/herdr-world/pull/77)
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Web's own release history remains in its upstream changelog.
 
 ### Added
 
+- Added UI-managed Direct network access for plugin-hosted bridges, with separate accepted-address,
+  page-origin, and bridge-destination policies, optional memory-hard password protection, in-memory
+  client sessions, copyable addresses, readiness/rollback status, and actionable bridge diagnostics.
+
 ### Changed
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,10 @@ Web's own release history remains in its upstream changelog.
 
 ### Added
 
-- Added UI-managed sharing for plugin-hosted bridges, with detected host addresses, an optional
-  memory-hard password, reload-safe tab-scoped client sessions, copyable Bridge URLs,
-  readiness/rollback status, and advanced inbound browser-origin controls. Outbound destination
-  permissions now live with client Bridge profiles and reload the page when its browser policy
-  changes.
+- Added a simplified Network UI for connecting Herdr instances and allowing connections to the
+  current Herdr, with connection status, detected and copyable addresses, an optional memory-hard
+  password, reload-safe tab-scoped client sessions, readiness/rollback status, and progressively
+  disclosed exact host, page-origin, and destination permissions.
   [Herdr World PR #77](https://github.com/IvoryHeart/herdr-world/pull/77)
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -103,25 +103,13 @@ herdr --session NAME plugin action invoke status --plugin ivoryheart.herdr-world
 herdr plugin uninstall ivoryheart.herdr-world
 ```
 
-The plugin keeps editable settings outside its managed checkout. Find the directory with
-`herdr plugin config-dir ivoryheart.herdr-world` and edit its `config.json`; for a two-host LAN
-setup, `host` is the bind address, `allowed_hosts` lists accepted bridge hostnames/IPs,
-`allowed_origins` lists the exact page origins that may call this bridge, and
-`allowed_connect_origins` lists bridge origins that the page served here may call. For example:
-
-```json
-{
-  "host": "0.0.0.0",
-  "port": 8787,
-  "allowed_hosts": ["bridge-a.example.test", "bridge-b.example.test"],
-  "allowed_origins": ["http://localhost:8787", "http://bridge-a.example.test:8787", "http://bridge-b.example.test:8787"],
-  "allowed_connect_origins": ["http://bridge-a.example.test:8787", "http://bridge-b.example.test:8787"]
-}
-```
-
-Use the actual page origin, including its port; `http://127.0.0.1:8787` does not authorize a page
-opened at a LAN address. Restart the plugin after changing the file:
-`herdr plugin action invoke restart --plugin ivoryheart.herdr-world`.
+Host access is managed in Settings → Remote access, where the plugin-managed launch exposes a
+Direct network access toggle, separate accepted-address/page-origin/bridge-destination policies,
+an optional password, and a copyable connection address. Applying a change safely reconciles the
+owned bridge and reports when it is ready. Development or standalone launches show status but keep
+mutation disabled when no controller-owned restart boundary is available. Client bridge URLs,
+labels, colors, and enabled state remain independent in Settings → Bridge. Direct network access
+is intended for a LAN/VPN path; use TLS, a VPN, or SSH for untrusted networks.
 
 To run from source:
 

--- a/README.md
+++ b/README.md
@@ -103,13 +103,14 @@ herdr --session NAME plugin action invoke status --plugin ivoryheart.herdr-world
 herdr plugin uninstall ivoryheart.herdr-world
 ```
 
-Use Settings → Share this machine to let another device reach the bridge running on this machine.
-The basic flow detects this machine's address, provides a copyable Bridge URL, and offers an optional
-password. Inbound browser-origin rules remain under Advanced browser permissions. Use Settings →
-Bridges to add other machines; the local page's outbound destination permission is applied there and
-the page reloads when its browser policy changes. Development or standalone launches show these
-settings as read-only when no controller-owned restart boundary is available. Direct connections are
-intended for a trusted LAN/VPN path; use TLS, a VPN, or SSH for untrusted networks.
+Use Settings → Network → Connections to connect Herdr World to another Herdr. Adding a connection
+normally needs only its address; Herdr World asks for a password when the other Herdr requires one.
+Use Network → Allow connections to let Herdr World elsewhere connect to this Herdr. The basic flow
+provides an on/off control, a copyable address, and optional password protection. Exact host, page,
+and destination restrictions remain available under Advanced network permissions. Development or
+standalone launches show these settings as read-only when no controller-owned restart boundary is
+available. Direct connections are intended for a trusted LAN/VPN path; use TLS, a VPN, or SSH for
+untrusted networks.
 
 To run from source:
 

--- a/README.md
+++ b/README.md
@@ -103,13 +103,13 @@ herdr --session NAME plugin action invoke status --plugin ivoryheart.herdr-world
 herdr plugin uninstall ivoryheart.herdr-world
 ```
 
-Host access is managed in Settings → Remote access, where the plugin-managed launch exposes a
-Direct network access toggle, separate accepted-address/page-origin/bridge-destination policies,
-an optional password, and a copyable connection address. Applying a change safely reconciles the
-owned bridge and reports when it is ready. Development or standalone launches show status but keep
-mutation disabled when no controller-owned restart boundary is available. Client bridge URLs,
-labels, colors, and enabled state remain independent in Settings → Bridge. Direct network access
-is intended for a LAN/VPN path; use TLS, a VPN, or SSH for untrusted networks.
+Use Settings → Share this machine to let another device reach the bridge running on this machine.
+The basic flow detects this machine's address, provides a copyable Bridge URL, and offers an optional
+password. Inbound browser-origin rules remain under Advanced browser permissions. Use Settings →
+Bridges to add other machines; the local page's outbound destination permission is applied there and
+the page reloads when its browser policy changes. Development or standalone launches show these
+settings as read-only when no controller-owned restart boundary is available. Direct connections are
+intended for a trusted LAN/VPN path; use TLS, a VPN, or SSH for untrusted networks.
 
 To run from source:
 

--- a/bridge/Cargo.lock
+++ b/bridge/Cargo.lock
@@ -39,6 +39,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "argon2"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
+dependencies = [
+ "base64ct",
+ "blake2",
+ "cpufeatures 0.2.17",
+ "password-hash",
+]
+
+[[package]]
 name = "async-compression"
 version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -133,6 +145,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
 name = "bincode"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -178,6 +196,15 @@ name = "bitflags"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+
+[[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "block-buffer"
@@ -456,6 +483,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -771,6 +799,7 @@ dependencies = [
 name = "herdr-web-bridge"
 version = "0.1.0"
 dependencies = [
+ "argon2",
  "axum",
  "bytes",
  "flate2",
@@ -778,6 +807,7 @@ dependencies = [
  "herdr-compat",
  "libc",
  "png",
+ "rand 0.8.6",
  "regex",
  "reqwest",
  "serde",
@@ -1420,6 +1450,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "password-hash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
+dependencies = [
+ "base64ct",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1671,6 +1712,8 @@ version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
  "rand_core 0.6.4",
 ]
 
@@ -1680,7 +1723,7 @@ version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
- "rand_chacha",
+ "rand_chacha 0.9.0",
  "rand_core 0.9.5",
 ]
 
@@ -1693,6 +1736,16 @@ dependencies = [
  "chacha20",
  "getrandom 0.4.2",
  "rand_core 0.10.1",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1710,6 +1763,9 @@ name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
+]
 
 [[package]]
 name = "rand_core"

--- a/bridge/Cargo.lock
+++ b/bridge/Cargo.lock
@@ -812,6 +812,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "socket2",
  "tokio",
  "tower",
  "tower-http",

--- a/bridge/Cargo.toml
+++ b/bridge/Cargo.toml
@@ -11,6 +11,7 @@ path = "src/main.rs"
 
 [dependencies]
 axum = { version = "0.8", features = ["ws"] }
+argon2 = "0.5"
 bytes = "1"
 futures-util = "0.3"
 flate2 = "1"
@@ -19,6 +20,7 @@ libc = "0.2"
 png = "0.17"
 regex = "1"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+rand = "0.8"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "net", "sync", "time"] }

--- a/bridge/Cargo.toml
+++ b/bridge/Cargo.toml
@@ -23,6 +23,7 @@ reqwest = { version = "0.12", default-features = false, features = ["json", "rus
 rand = "0.8"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+socket2 = "0.6"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "net", "sync", "time"] }
 tower = "0.5"
 tower-http = { version = "0.6", features = ["fs", "compression-gzip"] }

--- a/bridge/src/agent_pins.rs
+++ b/bridge/src/agent_pins.rs
@@ -107,7 +107,7 @@ impl AgentPinsManager {
     }
 
     #[cfg(test)]
-    fn for_test(dir: PathBuf, session_key: &str) -> io::Result<Self> {
+    pub(crate) fn for_test(dir: PathBuf, session_key: &str) -> io::Result<Self> {
         ensure_private_dir(&dir)?;
         Ok(Self {
             pins_path: dir.join("agent-pins.json"),

--- a/bridge/src/notes.rs
+++ b/bridge/src/notes.rs
@@ -223,7 +223,7 @@ impl NotesManager {
     }
 
     #[cfg(test)]
-    fn for_test(dir: PathBuf, session_key: &str) -> io::Result<Self> {
+    pub(crate) fn for_test(dir: PathBuf, session_key: &str) -> io::Result<Self> {
         ensure_private_dir(&dir)?;
         Ok(Self {
             notes_path: dir.join("notes.json"),

--- a/bridge/src/observability_http.rs
+++ b/bridge/src/observability_http.rs
@@ -6,7 +6,7 @@
 use std::sync::Arc;
 
 use axum::extract::ws::{Message, WebSocket, WebSocketUpgrade};
-use axum::extract::{Query, State};
+use axum::extract::{ConnectInfo, Query, State};
 use axum::http::HeaderMap;
 use axum::response::{IntoResponse, Response};
 use axum::routing::get;
@@ -21,7 +21,7 @@ use crate::observability::{
     UnavailableObservabilityProvider,
 };
 use crate::observability_prometheus::{PrometheusConfig, PrometheusObservabilityProvider};
-use crate::web_bridge::{ensure_allowed_request, preflight_response, BridgeError, RequestPolicy};
+use crate::web_bridge::{preflight_response_from_peer, BridgeError, RequestPolicy};
 
 #[derive(Clone)]
 struct ObservabilityHttpState {
@@ -97,16 +97,15 @@ where
 
 async fn preflight_handler(
     State(state): State<ObservabilityHttpState>,
+    ConnectInfo(peer): ConnectInfo<std::net::SocketAddr>,
     headers: HeaderMap,
 ) -> Result<Response, BridgeError> {
-    preflight_response(&headers, &state.request_policy)
+    preflight_response_from_peer(&headers, &state.request_policy, Some(peer))
 }
 
 async fn descriptor_handler(
     State(state): State<ObservabilityHttpState>,
-    headers: HeaderMap,
 ) -> Result<Json<ObservabilityDescriptor>, BridgeError> {
-    ensure_allowed_request(&headers, &state.request_policy)?;
     let descriptor = state
         .observability
         .descriptor()
@@ -116,9 +115,7 @@ async fn descriptor_handler(
 
 async fn snapshot_handler(
     State(state): State<ObservabilityHttpState>,
-    headers: HeaderMap,
 ) -> Result<Json<ObservabilityExtensionResponse>, BridgeError> {
-    ensure_allowed_request(&headers, &state.request_policy)?;
     let snapshot = state
         .observability
         .snapshot()
@@ -128,18 +125,14 @@ async fn snapshot_handler(
 
 async fn configuration_handler(
     State(state): State<ObservabilityHttpState>,
-    headers: HeaderMap,
 ) -> Result<Json<ObservabilityConfiguration>, BridgeError> {
-    ensure_allowed_request(&headers, &state.request_policy)?;
     Ok(Json(state.observability.configuration()))
 }
 
 async fn update_configuration_handler(
     State(state): State<ObservabilityHttpState>,
-    headers: HeaderMap,
     Json(body): Json<ObservabilityConfigurationRequest>,
 ) -> Result<Json<ObservabilityConfiguration>, BridgeError> {
-    ensure_allowed_request(&headers, &state.request_policy)?;
     let raw_endpoint = body
         .prometheus_url
         .as_deref()
@@ -179,11 +172,7 @@ async fn websocket_handler(
     ws: WebSocketUpgrade,
     State(state): State<ObservabilityHttpState>,
     Query(query): Query<ObservabilityEventsQuery>,
-    headers: HeaderMap,
 ) -> Response {
-    if let Err(error) = ensure_allowed_request(&headers, &state.request_policy) {
-        return error.into_response();
-    }
     ws.on_upgrade(move |socket| handle_socket(socket, state.observability, query.after_sequence))
         .into_response()
 }

--- a/bridge/src/web_bridge.rs
+++ b/bridge/src/web_bridge.rs
@@ -1,20 +1,26 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::env;
 use std::fmt;
 use std::io::{self, ErrorKind, Write};
-use std::net::IpAddr;
+use std::net::{IpAddr, SocketAddr};
 use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{mpsc, Arc, Condvar, Mutex};
 use std::thread;
 use std::time::Duration;
 
+use argon2::password_hash::{
+    rand_core::OsRng as PasswordOsRng, PasswordHash, PasswordHasher, PasswordVerifier, SaltString,
+};
+use argon2::Argon2;
 use axum::body::{Body, Bytes};
 use axum::extract::ws::{Message, WebSocket, WebSocketUpgrade};
-use axum::extract::{DefaultBodyLimit, Path as AxumPath, Query, State};
+use axum::extract::{ConnectInfo, DefaultBodyLimit, Path as AxumPath, Query, State};
 use axum::http::header::{
     ACCESS_CONTROL_ALLOW_HEADERS, ACCESS_CONTROL_ALLOW_METHODS, ACCESS_CONTROL_ALLOW_ORIGIN,
-    ACCESS_CONTROL_MAX_AGE, ACCESS_CONTROL_REQUEST_HEADERS, CACHE_CONTROL, HOST, ORIGIN, VARY,
+    ACCESS_CONTROL_MAX_AGE, ACCESS_CONTROL_REQUEST_HEADERS, AUTHORIZATION, CACHE_CONTROL, HOST,
+    ORIGIN, SEC_WEBSOCKET_PROTOCOL, VARY, WWW_AUTHENTICATE,
 };
 use axum::http::{HeaderMap, HeaderName, HeaderValue, StatusCode};
 use axum::middleware::{self, Next};
@@ -25,6 +31,7 @@ use flate2::write::GzEncoder;
 use flate2::Compression;
 use futures_util::{SinkExt, StreamExt};
 use herdr_compat::TryClone as _;
+use rand::{rngs::OsRng as TokenOsRng, RngCore};
 use serde::{Deserialize, Serialize};
 use tokio::time::Instant;
 use tower::{ServiceBuilder, ServiceExt};
@@ -97,6 +104,15 @@ const MANAGED_AGENT_SHELL_RETRY_INITIAL_DELAY: Duration = Duration::from_millis(
 const MANAGED_AGENT_SHELL_READY_TIMEOUT: Duration = Duration::from_secs(3);
 const MANAGED_AGENT_START_TIMEOUT: Duration = Duration::from_secs(30);
 const MANAGED_AGENT_POLL_INTERVAL: Duration = Duration::from_millis(100);
+const MAX_PASSWORD_BYTES: usize = 1024;
+const MAX_REMOTE_ACCESS_ITEMS: usize = 32;
+const MAX_REMOTE_ACCESS_VALUE_BYTES: usize = 512;
+const AUTH_SESSION_TTL: Duration = Duration::from_secs(60 * 60);
+const AUTH_FAILURE_WINDOW: Duration = Duration::from_secs(60);
+const AUTH_FAILURE_LIMIT: usize = 5;
+const AUTH_FAILURE_DELAY: Duration = Duration::from_millis(250);
+const AUTH_TOKEN_BYTES: usize = 32;
+const MAX_APPLY_REASON_BYTES: usize = 240;
 static UPLOAD_TEMP_COUNTER: AtomicUsize = AtomicUsize::new(0);
 
 #[derive(Debug, Clone)]
@@ -108,7 +124,9 @@ struct BridgeOptions {
     launcher_presets_path: Option<PathBuf>,
     allowed_hosts: Vec<String>,
     allowed_origins: Vec<String>,
+    allowed_connect_origins: Vec<String>,
     allowed_connect_sources: Vec<String>,
+    password_hash: Option<String>,
     configured_label: Option<String>,
 }
 
@@ -117,6 +135,8 @@ struct BridgeState {
     api: ApiClient,
     client_socket_path: PathBuf,
     request_policy: RequestPolicy,
+    auth: Arc<BridgeAuth>,
+    management: ManagementState,
     terminal_sessions: Arc<Mutex<TerminalSessions>>,
     selected_pane_id: Arc<Mutex<Option<String>>>,
     agent_activity: Arc<AgentActivityManager>,
@@ -138,7 +158,467 @@ pub(crate) struct RequestPolicy {
     bind_port: u16,
     allowed_hosts: Vec<String>,
     allowed_origins: Vec<String>,
+    allowed_connect_origins: Vec<String>,
     allowed_connect_sources: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct RemoteAccessModel {
+    enabled: bool,
+    accepted_hosts: Vec<String>,
+    allowed_page_origins: Vec<String>,
+    allowed_bridge_origins: Vec<String>,
+    password_configured: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct RemoteAccessDraft {
+    enabled: bool,
+    accepted_hosts: Vec<String>,
+    allowed_page_origins: Vec<String>,
+    allowed_bridge_origins: Vec<String>,
+    #[serde(default)]
+    password_hash: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RemoteAccessApplyRequest {
+    remote_access: RemoteAccessDraft,
+    #[serde(default)]
+    password_action: PasswordAction,
+    #[serde(default)]
+    password: Option<String>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum PasswordAction {
+    #[default]
+    Keep,
+    Set,
+    Remove,
+}
+
+#[derive(Debug, Serialize)]
+struct RemoteAccessStatusResponse {
+    remote_access: RemoteAccessModel,
+    port: u16,
+    suggestions: Vec<String>,
+    mutation_allowed: bool,
+    mutation_reason: Option<String>,
+    apply: ApplyStatusResponse,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct ApplyStatusResponse {
+    state: String,
+    reason: Option<String>,
+    restored: Option<bool>,
+}
+
+#[derive(Debug, Clone)]
+struct ManagementState {
+    config_path: Option<PathBuf>,
+    state_dir: Option<PathBuf>,
+    controller_node: Option<PathBuf>,
+    controller_script: Option<PathBuf>,
+    mutation_reason: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+struct BridgeAuth {
+    password_hash: Option<String>,
+    sessions: Arc<Mutex<AuthSessions>>,
+}
+
+#[derive(Debug, Default)]
+struct AuthSessions {
+    tokens: HashMap<String, Instant>,
+    failures: HashMap<String, VecDeque<Instant>>,
+}
+
+#[derive(Debug, Serialize)]
+struct AuthenticationCapability {
+    required: bool,
+    session: &'static str,
+    local_peer_bypass: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct PasswordRequest {
+    password: String,
+}
+
+#[derive(Debug, Serialize)]
+struct PasswordSessionResponse {
+    authenticated: bool,
+    expires_in_seconds: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    token: Option<String>,
+}
+
+impl BridgeAuth {
+    fn new(password_hash: Option<String>) -> Self {
+        Self {
+            password_hash,
+            sessions: Arc::new(Mutex::new(AuthSessions::default())),
+        }
+    }
+
+    fn required(&self) -> bool {
+        self.password_hash.is_some()
+    }
+
+    fn password_hash(&self) -> Option<String> {
+        self.password_hash.clone()
+    }
+
+    fn local_peer_allowed(peer: Option<SocketAddr>) -> bool {
+        // This is intentionally based only on the accepted TCP peer address.
+        // Host, Origin, and forwarding headers are not authentication input.
+        peer.is_some_and(|address| address.ip().is_loopback())
+    }
+
+    fn token_is_valid(&self, token: &str) -> bool {
+        if token.is_empty() || token.len() > AUTH_TOKEN_BYTES * 2 {
+            return false;
+        }
+        let now = Instant::now();
+        let Ok(mut sessions) = self.sessions.lock() else {
+            return false;
+        };
+        sessions.tokens.retain(|_, expires_at| *expires_at > now);
+        sessions
+            .tokens
+            .get(token)
+            .is_some_and(|expires_at| *expires_at > now)
+    }
+
+    fn authorization_token(headers: &HeaderMap) -> Option<&str> {
+        let value = headers.get(AUTHORIZATION)?.to_str().ok()?;
+        let token = value.strip_prefix("Bearer ")?.trim();
+        (!token.is_empty()).then_some(token)
+    }
+
+    fn websocket_token(headers: &HeaderMap) -> Option<&str> {
+        headers
+            .get(SEC_WEBSOCKET_PROTOCOL)
+            .and_then(|value| value.to_str().ok())
+            .and_then(|value| {
+                value
+                    .split(',')
+                    .map(str::trim)
+                    .find_map(|protocol| protocol.strip_prefix("herdr-world-auth."))
+            })
+            .filter(|token| !token.is_empty())
+    }
+
+    fn request_is_authorized(&self, headers: &HeaderMap, peer: Option<SocketAddr>) -> bool {
+        if !self.required() || Self::local_peer_allowed(peer) {
+            return true;
+        }
+        Self::authorization_token(headers)
+            .or_else(|| Self::websocket_token(headers))
+            .is_some_and(|token| self.token_is_valid(token))
+    }
+
+    async fn issue_session(
+        &self,
+        peer: Option<SocketAddr>,
+        password: &str,
+    ) -> Result<String, AuthFailure> {
+        if password.as_bytes().len() > MAX_PASSWORD_BYTES {
+            return Err(AuthFailure::InvalidInput);
+        }
+        let Some(expected) = self.password_hash.as_deref() else {
+            return Err(AuthFailure::NotRequired);
+        };
+        let key = peer
+            .map(|address| address.ip().to_string())
+            .unwrap_or_else(|| "unknown-peer".to_string());
+        let now = Instant::now();
+        let (attempts, delay) = {
+            let mut sessions = self.sessions.lock().map_err(|_| AuthFailure::Unavailable)?;
+            let failures = sessions.failures.entry(key.clone()).or_default();
+            failures
+                .retain(|started| now.saturating_duration_since(*started) < AUTH_FAILURE_WINDOW);
+            if failures.len() >= AUTH_FAILURE_LIMIT {
+                return Err(AuthFailure::RateLimited);
+            }
+            let valid = verify_password(expected, password);
+            if !valid {
+                failures.push_back(now);
+            }
+            let attempts = failures.len();
+            let delay = if valid {
+                Duration::ZERO
+            } else {
+                AUTH_FAILURE_DELAY.saturating_mul(attempts as u32)
+            };
+            if valid {
+                sessions.failures.remove(&key);
+            }
+            (valid, delay)
+        };
+        if !delay.is_zero() {
+            tokio::time::sleep(delay).await;
+        }
+        if !attempts {
+            return Err(AuthFailure::Rejected);
+        }
+
+        let mut bytes = [0u8; AUTH_TOKEN_BYTES];
+        TokenOsRng.fill_bytes(&mut bytes);
+        let token = bytes
+            .iter()
+            .map(|byte| format!("{byte:02x}"))
+            .collect::<String>();
+        let mut sessions = self.sessions.lock().map_err(|_| AuthFailure::Unavailable)?;
+        sessions
+            .tokens
+            .insert(token.clone(), Instant::now() + AUTH_SESSION_TTL);
+        Ok(token)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AuthFailure {
+    InvalidInput,
+    NotRequired,
+    RateLimited,
+    Rejected,
+    Unavailable,
+}
+
+fn hash_password(password: &str) -> Result<String, String> {
+    if password.as_bytes().len() > MAX_PASSWORD_BYTES {
+        return Err(format!(
+            "password must be at most {MAX_PASSWORD_BYTES} bytes"
+        ));
+    }
+    if password.is_empty() {
+        return Err("password must not be empty".into());
+    }
+    let salt = SaltString::generate(&mut PasswordOsRng);
+    Argon2::default()
+        .hash_password(password.as_bytes(), &salt)
+        .map(|hash| hash.to_string())
+        .map_err(|_| "could not hash password".to_string())
+}
+
+fn verify_password(encoded: &str, password: &str) -> bool {
+    let Ok(parsed) = PasswordHash::new(encoded) else {
+        return false;
+    };
+    Argon2::default()
+        .verify_password(password.as_bytes(), &parsed)
+        .is_ok()
+}
+
+fn management_state_from_environment() -> ManagementState {
+    let config_path = env::var("HERDR_PLUGIN_CONFIG_DIR")
+        .ok()
+        .map(|dir| PathBuf::from(dir).join("config.json"));
+    let state_dir = env::var("HERDR_PLUGIN_STATE_DIR").ok().map(PathBuf::from);
+    let controller_node = env::var("HERDR_WORLD_NODE_PATH").ok().map(PathBuf::from);
+    let controller_script = env::var("HERDR_WORLD_CONTROLLER").ok().map(PathBuf::from);
+    let mutation_reason = if config_path.is_none() || state_dir.is_none() {
+        Some("Remote access is read-only for this standalone or development launch; use the plugin-managed launch to apply settings safely.".to_string())
+    } else if controller_node.is_none() || controller_script.is_none() {
+        Some("This bridge has no controller-owned restart boundary, so settings mutation is disabled for safety.".to_string())
+    } else if !controller_node
+        .as_ref()
+        .is_some_and(|path| path.is_absolute())
+        || !controller_script
+            .as_ref()
+            .is_some_and(|path| path.is_absolute())
+    {
+        Some("The controller restart boundary is not absolute and cannot be trusted; settings mutation is disabled.".to_string())
+    } else if !controller_node.as_ref().is_some_and(|path| path.is_file())
+        || !controller_script
+            .as_ref()
+            .is_some_and(|path| path.is_file())
+    {
+        Some("The controller restart boundary is unavailable; settings mutation is disabled until the managed launch is repaired.".to_string())
+    } else {
+        None
+    };
+    ManagementState {
+        config_path,
+        state_dir,
+        controller_node,
+        controller_script,
+        mutation_reason,
+    }
+}
+
+fn is_link_local(address: IpAddr) -> bool {
+    match address {
+        IpAddr::V4(address) => address.octets()[0] == 169 && address.octets()[1] == 254,
+        IpAddr::V6(address) => address.segments()[0] & 0xffc0 == 0xfe80,
+    }
+}
+
+fn detected_access_candidates(policy: &RequestPolicy) -> Vec<String> {
+    let mut candidates: Vec<String> = Vec::new();
+    let mut add = |value: &str| {
+        let value = value.trim().trim_matches('.');
+        if value.is_empty() || value.eq_ignore_ascii_case("localhost") {
+            return;
+        }
+        let valid = normalize_allowed_host(value).ok().filter(|host| {
+            host.parse::<IpAddr>()
+                .map(|address| {
+                    !address.is_loopback() && !address.is_unspecified() && !is_link_local(address)
+                })
+                .unwrap_or(true)
+        });
+        if let Some(value) = valid {
+            if !candidates
+                .iter()
+                .any(|item: &String| item.eq_ignore_ascii_case(&value))
+            {
+                candidates.push(value);
+            }
+        }
+    };
+    if !is_loopback_bind_host(&policy.bind_host) {
+        add(&policy.bind_host);
+    }
+    if let Ok(hostname) = env::var("HOSTNAME") {
+        add(&hostname);
+    }
+    candidates.truncate(8);
+    candidates
+}
+
+fn current_remote_access_model(policy: &RequestPolicy, auth: &BridgeAuth) -> RemoteAccessModel {
+    RemoteAccessModel {
+        enabled: !is_loopback_bind_host(&policy.bind_host),
+        accepted_hosts: policy.allowed_hosts.clone(),
+        allowed_page_origins: policy.allowed_origins.clone(),
+        allowed_bridge_origins: policy.allowed_connect_origins.clone(),
+        password_configured: auth.required(),
+    }
+}
+
+fn bounded_access_value(value: &str, label: &str) -> Result<(), BridgeError> {
+    if value.as_bytes().len() > MAX_REMOTE_ACCESS_VALUE_BYTES {
+        return Err(BridgeError::BadRequest(format!(
+            "{label} entries must be at most {MAX_REMOTE_ACCESS_VALUE_BYTES} bytes"
+        )));
+    }
+    Ok(())
+}
+
+fn validate_remote_access_draft(draft: &mut RemoteAccessDraft) -> Result<(), BridgeError> {
+    if draft.accepted_hosts.len() > MAX_REMOTE_ACCESS_ITEMS {
+        return Err(BridgeError::BadRequest(
+            "too many accepted addresses".into(),
+        ));
+    }
+    if draft.allowed_page_origins.len() > MAX_REMOTE_ACCESS_ITEMS {
+        return Err(BridgeError::BadRequest(
+            "too many allowed page origins".into(),
+        ));
+    }
+    if draft.allowed_bridge_origins.len() > MAX_REMOTE_ACCESS_ITEMS {
+        return Err(BridgeError::BadRequest(
+            "too many allowed bridge destinations".into(),
+        ));
+    }
+    let mut accepted_hosts = Vec::new();
+    for value in &draft.accepted_hosts {
+        bounded_access_value(value, "accepted address")?;
+        let normalized = normalize_allowed_host(value).map_err(BridgeError::BadRequest)?;
+        if !accepted_hosts
+            .iter()
+            .any(|item: &String| item.eq_ignore_ascii_case(&normalized))
+        {
+            accepted_hosts.push(normalized);
+        }
+    }
+    let mut page_origins = Vec::new();
+    for value in &draft.allowed_page_origins {
+        bounded_access_value(value, "allowed page origin")?;
+        let normalized = normalize_allowed_origin(value).map_err(BridgeError::BadRequest)?;
+        if !page_origins
+            .iter()
+            .any(|item: &String| item.eq_ignore_ascii_case(&normalized))
+        {
+            page_origins.push(normalized);
+        }
+    }
+    let mut bridge_origins = Vec::new();
+    for value in &draft.allowed_bridge_origins {
+        bounded_access_value(value, "allowed bridge destination")?;
+        let normalized = normalize_allowed_origin(value).map_err(BridgeError::BadRequest)?;
+        if !bridge_origins
+            .iter()
+            .any(|item: &String| item.eq_ignore_ascii_case(&normalized))
+        {
+            bridge_origins.push(normalized);
+        }
+    }
+    if draft.enabled && accepted_hosts.is_empty() {
+        return Err(BridgeError::BadRequest(
+            "remote access needs at least one accepted address".into(),
+        ));
+    }
+    if draft.enabled && page_origins.is_empty() {
+        return Err(BridgeError::BadRequest(
+            "remote access needs at least one allowed page origin".into(),
+        ));
+    }
+    if let Some(hash) = &draft.password_hash {
+        if hash.as_bytes().len() > MAX_REMOTE_ACCESS_VALUE_BYTES || !hash.starts_with("$argon2") {
+            return Err(BridgeError::BadRequest("password hash is invalid".into()));
+        }
+    }
+    draft.accepted_hosts = accepted_hosts;
+    draft.allowed_page_origins = page_origins;
+    draft.allowed_bridge_origins = bridge_origins;
+    Ok(())
+}
+
+fn read_apply_status(management: &ManagementState) -> ApplyStatusResponse {
+    let Some(state_dir) = management.state_dir.as_deref() else {
+        return ApplyStatusResponse {
+            state: "ready".into(),
+            reason: None,
+            restored: None,
+        };
+    };
+    let path = state_dir.join("remote-access-apply.json");
+    let Ok(bytes) = std::fs::read(path) else {
+        return ApplyStatusResponse {
+            state: "ready".into(),
+            reason: None,
+            restored: None,
+        };
+    };
+    let Ok(value) = serde_json::from_slice::<serde_json::Value>(&bytes) else {
+        return ApplyStatusResponse {
+            state: "failed".into(),
+            reason: Some("controller status is unavailable".into()),
+            restored: None,
+        };
+    };
+    let state = value
+        .get("state")
+        .and_then(serde_json::Value::as_str)
+        .filter(|state| matches!(*state, "applying" | "ready" | "failed"))
+        .unwrap_or("failed")
+        .to_string();
+    let reason = value
+        .get("reason")
+        .and_then(serde_json::Value::as_str)
+        .map(|reason| reason.chars().take(MAX_APPLY_REASON_BYTES).collect());
+    ApplyStatusResponse {
+        state,
+        reason,
+        restored: value.get("restored").and_then(serde_json::Value::as_bool),
+    }
 }
 
 #[derive(Debug, Serialize)]
@@ -182,6 +662,7 @@ struct Capabilities {
     features: &'static [&'static str],
     commands: &'static [&'static str],
     web_compat: u32,
+    authentication: AuthenticationCapability,
     agent_activity: AgentActivityCapability,
     agent_pins: AgentPinsCapability,
     launcher_presets: LauncherPresetsCapability,
@@ -904,7 +1385,7 @@ pub(crate) fn run_command(args: &[String]) -> io::Result<i32> {
         Err(message) => {
             eprintln!("{message}");
             eprintln!(
-                "usage: herdr-world-bridge [--session NAME] [--host HOST] [--port PORT] [--static-dir DIR] [--launcher-presets PATH] [--bridge-label LABEL] [--allow-origin ORIGIN] [--allow-host HOST] [--allow-connect-origin ORIGIN]"
+                "usage: herdr-world-bridge [--session NAME] [--host HOST] [--port PORT] [--static-dir DIR] [--launcher-presets PATH] [--bridge-label LABEL] [--allow-origin ORIGIN] [--allow-host HOST] [--allow-connect-origin ORIGIN] [--password-hash HASH]"
             );
             return Ok(2);
         }
@@ -933,7 +1414,9 @@ fn parse_options(args: &[String]) -> Result<Option<BridgeOptions>, String> {
     let mut launcher_presets_path = None;
     let mut allowed_hosts = Vec::new();
     let mut allowed_origins = Vec::new();
+    let mut allowed_connect_origins = Vec::new();
     let mut allowed_connect_sources = Vec::new();
+    let mut password_hash = None;
     let mut configured_label = None;
     let mut explicit_session = None;
     let mut index = 0;
@@ -1007,7 +1490,17 @@ fn parse_options(args: &[String]) -> Result<Option<BridgeOptions>, String> {
                 let Some(value) = args.get(index + 1) else {
                     return Err("missing value for --allow-connect-origin".into());
                 };
+                let origin = normalize_allowed_origin(value)?;
+                allowed_connect_origins.push(origin);
                 allowed_connect_sources.extend(connect_sources_for_origin(value)?);
+                index += 2;
+            }
+            "--password-hash" => {
+                let Some(value) = args.get(index + 1) else {
+                    return Err("missing value for --password-hash".into());
+                };
+                validate_password_hash(value)?;
+                password_hash = Some(value.clone());
                 index += 2;
             }
             "--bridge-label" => {
@@ -1049,7 +1542,9 @@ fn parse_options(args: &[String]) -> Result<Option<BridgeOptions>, String> {
         launcher_presets_path,
         allowed_hosts,
         allowed_origins,
+        allowed_connect_origins,
         allowed_connect_sources,
+        password_hash,
         configured_label,
     }))
 }
@@ -1071,6 +1566,7 @@ Every admitted browser has terminal-equivalent access; Host and Origin checks ar
 Use --allow-origin http://localhost for bundled Android app access.\n\
 Use --allow-host HOSTNAME to accept that exact DNS hostname in Host headers.\n\
 Use --allow-connect-origin ORIGIN to let the served web app connect to another bridge origin.\n\
+Use --password-hash HASH for the memory-hard Argon2id hash managed by the plugin controller.\n\
 Use --bridge-label LABEL for a bounded diagnostic label; browser host profiles remain authoritative.\n\
 Use --launcher-presets PATH or HERDR_WEB_LAUNCHER_PRESETS to load custom launch presets.\n\
 Uploads default to HERDR_WEB_UPLOAD_DIR, XDG_DATA_HOME/herdr-web/uploads, or ~/.local/share/herdr-web/uploads."
@@ -1097,8 +1593,10 @@ async fn run_server(options: BridgeOptions) -> io::Result<()> {
         bind_port: options.port,
         allowed_hosts: options.allowed_hosts.clone(),
         allowed_origins: options.allowed_origins.clone(),
+        allowed_connect_origins: options.allowed_connect_origins.clone(),
         allowed_connect_sources: options.allowed_connect_sources.clone(),
     };
+    let auth = Arc::new(BridgeAuth::new(options.password_hash.clone()));
     let api = ApiClient::for_socket_path(crate::session::active_api_socket_path());
     let daemon_status = startup_daemon_status(&api)?;
     let daemon_protocol = daemon_status
@@ -1117,6 +1615,8 @@ async fn run_server(options: BridgeOptions) -> io::Result<()> {
         api,
         client_socket_path: crate::session::active_client_socket_path(),
         request_policy: request_policy.clone(),
+        auth,
+        management: management_state_from_environment(),
         terminal_sessions: Arc::new(Mutex::new(TerminalSessions::default())),
         selected_pane_id: Arc::new(Mutex::new(None)),
         agent_activity,
@@ -1210,6 +1710,20 @@ async fn run_server(options: BridgeOptions) -> io::Result<()> {
             get(capabilities_handler).options(preflight_handler),
         )
         .route(
+            "/api/auth/status",
+            get(auth_status_handler).options(preflight_handler),
+        )
+        .route(
+            "/api/auth/session",
+            post(auth_session_handler).options(preflight_handler),
+        )
+        .route(
+            "/api/local/remote-access",
+            get(remote_access_status_handler)
+                .post(remote_access_apply_handler)
+                .options(preflight_handler),
+        )
+        .route(
             "/api/command",
             post(command_handler).options(preflight_handler),
         )
@@ -1230,12 +1744,20 @@ async fn run_server(options: BridgeOptions) -> io::Result<()> {
             request_policy.clone(),
             add_security_headers,
         ))
+        .layer(middleware::from_fn_with_state(
+            state.clone(),
+            bridge_access_middleware,
+        ))
         .layer(DefaultBodyLimit::max(MAX_UPLOAD_BYTES))
         .with_state(state);
     let bind = format!("{}:{}", options.host, options.port);
     let listener = tokio::net::TcpListener::bind(&bind).await?;
     info!(url = %format!("http://{bind}"), "Herdr World bridge listening");
-    axum::serve(listener, app).await
+    axum::serve(
+        listener,
+        app.into_make_service_with_connect_info::<SocketAddr>(),
+    )
+    .await
 }
 
 fn static_routes<S>(static_dir: PathBuf) -> Router<S>
@@ -1330,6 +1852,280 @@ async fn add_security_headers(
     response
 }
 
+async fn bridge_access_middleware(
+    State(state): State<BridgeState>,
+    request: AxumRequest,
+    next: Next,
+) -> Response {
+    let path = request.uri().path();
+    if !(path.starts_with("/api/") || path.starts_with("/ws/")) {
+        return next.run(request).await;
+    }
+
+    if let Err(error) = ensure_allowed_request(request.headers(), &state.request_policy) {
+        return error.into_response();
+    }
+    if request.method() == axum::http::Method::OPTIONS {
+        return next.run(request).await;
+    }
+
+    if !is_public_bootstrap_path(path) {
+        let peer = request
+            .extensions()
+            .get::<ConnectInfo<SocketAddr>>()
+            .map(|info| info.0);
+        if !state.auth.request_is_authorized(request.headers(), peer) {
+            return unauthorized_response();
+        }
+    }
+    next.run(request).await
+}
+
+fn is_public_bootstrap_path(path: &str) -> bool {
+    matches!(
+        path,
+        "/api/capabilities" | "/api/auth/status" | "/api/auth/session" | "/api/local/remote-access"
+    )
+}
+
+fn unauthorized_response() -> Response {
+    let mut response = (
+        StatusCode::UNAUTHORIZED,
+        Json(serde_json::json!({
+            "code": "authentication_required",
+            "error": "password required or rejected",
+        })),
+    )
+        .into_response();
+    response.headers_mut().insert(
+        WWW_AUTHENTICATE,
+        HeaderValue::from_static("Bearer realm=herdr-world"),
+    );
+    response
+}
+
+fn local_management_allowed(
+    headers: &HeaderMap,
+    policy: &RequestPolicy,
+    peer: SocketAddr,
+) -> Result<(), BridgeError> {
+    ensure_allowed_request(headers, policy)?;
+    if !BridgeAuth::local_peer_allowed(Some(peer)) {
+        return Err(BridgeError::Forbidden(
+            "local management requires an actual loopback TCP peer".into(),
+        ));
+    }
+    Ok(())
+}
+
+async fn auth_status_handler(
+    State(state): State<BridgeState>,
+    ConnectInfo(peer): ConnectInfo<SocketAddr>,
+    headers: HeaderMap,
+) -> Result<Json<serde_json::Value>, BridgeError> {
+    ensure_allowed_request(&headers, &state.request_policy)?;
+    Ok(Json(serde_json::json!({
+        "required": state.auth.required(),
+        "authenticated": state.auth.request_is_authorized(&headers, Some(peer)),
+        "local_peer_bypass": BridgeAuth::local_peer_allowed(Some(peer)),
+    })))
+}
+
+async fn auth_session_handler(
+    State(state): State<BridgeState>,
+    ConnectInfo(peer): ConnectInfo<SocketAddr>,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Result<Json<PasswordSessionResponse>, Response> {
+    if let Err(error) = ensure_allowed_request(&headers, &state.request_policy) {
+        return Err(error.into_response());
+    }
+    if body.len() > MAX_PASSWORD_BYTES + 256 {
+        return Err(
+            BridgeError::BadRequest("password request is too large".into()).into_response(),
+        );
+    }
+    let request: PasswordRequest = serde_json::from_slice(&body).map_err(|_| {
+        BridgeError::BadRequest("password request is invalid".into()).into_response()
+    })?;
+    if request.password.as_bytes().len() > MAX_PASSWORD_BYTES {
+        return Err(BridgeError::BadRequest(format!(
+            "password must be at most {MAX_PASSWORD_BYTES} bytes"
+        ))
+        .into_response());
+    }
+    match state
+        .auth
+        .issue_session(Some(peer), &request.password)
+        .await
+    {
+        Ok(token) => Ok(Json(PasswordSessionResponse {
+            authenticated: true,
+            expires_in_seconds: AUTH_SESSION_TTL.as_secs(),
+            token: Some(token),
+        })),
+        Err(AuthFailure::InvalidInput) => Err(BridgeError::BadRequest(format!(
+            "password must be at most {MAX_PASSWORD_BYTES} bytes"
+        ))
+        .into_response()),
+        Err(AuthFailure::NotRequired) => Err(BridgeError::BadRequest(
+            "password protection is not enabled".into(),
+        )
+        .into_response()),
+        Err(AuthFailure::RateLimited) => Err((
+            StatusCode::TOO_MANY_REQUESTS,
+            Json(serde_json::json!({
+                "code": "authentication_rate_limited",
+                "error": "too many password attempts; retry shortly",
+            })),
+        )
+            .into_response()),
+        Err(AuthFailure::Rejected) => Err(unauthorized_response()),
+        Err(AuthFailure::Unavailable) => {
+            Err(BridgeError::Protocol("authentication service unavailable".into()).into_response())
+        }
+    }
+}
+
+async fn remote_access_status_handler(
+    State(state): State<BridgeState>,
+    ConnectInfo(peer): ConnectInfo<SocketAddr>,
+    headers: HeaderMap,
+) -> Result<Json<RemoteAccessStatusResponse>, BridgeError> {
+    local_management_allowed(&headers, &state.request_policy, peer)?;
+    Ok(Json(remote_access_status(&state)))
+}
+
+fn remote_access_status(state: &BridgeState) -> RemoteAccessStatusResponse {
+    let model = current_remote_access_model(&state.request_policy, &state.auth);
+    RemoteAccessStatusResponse {
+        remote_access: model,
+        port: state.request_policy.bind_port,
+        suggestions: detected_access_candidates(&state.request_policy),
+        mutation_allowed: state.management.mutation_reason.is_none()
+            && state
+                .management
+                .config_path
+                .as_ref()
+                .is_some_and(|path| path.parent().is_some_and(Path::is_dir)),
+        mutation_reason: state.management.mutation_reason.clone(),
+        apply: read_apply_status(&state.management),
+    }
+}
+
+async fn remote_access_apply_handler(
+    State(state): State<BridgeState>,
+    ConnectInfo(peer): ConnectInfo<SocketAddr>,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Result<(StatusCode, Json<ApplyStatusResponse>), BridgeError> {
+    local_management_allowed(&headers, &state.request_policy, peer)?;
+    if let Some(reason) = &state.management.mutation_reason {
+        return Err(BridgeError::Forbidden(reason.clone()));
+    }
+    if state.management.config_path.as_ref().map_or(true, |path| {
+        path.parent().map_or(true, |parent| !parent.is_dir())
+    }) {
+        return Err(BridgeError::Forbidden(
+            "remote access configuration storage is unavailable".into(),
+        ));
+    }
+    if body.len() > 64 * 1024 {
+        return Err(BridgeError::BadRequest(
+            "remote access draft is too large".into(),
+        ));
+    }
+    let mut request: RemoteAccessApplyRequest = serde_json::from_slice(&body)
+        .map_err(|_| BridgeError::BadRequest("remote access draft is invalid".into()))?;
+    match request.password_action {
+        PasswordAction::Keep => {
+            request.remote_access.password_hash = state.auth.password_hash();
+            if request.password.is_some() {
+                return Err(BridgeError::BadRequest(
+                    "password is only accepted when setting or changing it".into(),
+                ));
+            }
+        }
+        PasswordAction::Remove => {
+            if request.password.is_some() {
+                return Err(BridgeError::BadRequest(
+                    "password is not accepted when removing protection".into(),
+                ));
+            }
+            request.remote_access.password_hash = None;
+        }
+        PasswordAction::Set => {
+            let password = request
+                .password
+                .as_deref()
+                .ok_or_else(|| BridgeError::BadRequest("a password is required".into()))?;
+            request.remote_access.password_hash =
+                Some(hash_password(password).map_err(BridgeError::BadRequest)?);
+        }
+    }
+    validate_remote_access_draft(&mut request.remote_access)?;
+
+    let Some(state_dir) = state.management.state_dir.as_deref() else {
+        return Err(BridgeError::Forbidden(
+            "remote access mutation is unavailable".into(),
+        ));
+    };
+    let Some(node) = state.management.controller_node.as_deref() else {
+        return Err(BridgeError::Forbidden(
+            "remote access mutation is unavailable".into(),
+        ));
+    };
+    let Some(controller) = state.management.controller_script.as_deref() else {
+        return Err(BridgeError::Forbidden(
+            "remote access mutation is unavailable".into(),
+        ));
+    };
+    std::fs::create_dir_all(state_dir).map_err(BridgeError::Io)?;
+    let request_path = state_dir.join(format!(
+        ".remote-access-request-{}-{}.json",
+        std::process::id(),
+        UPLOAD_TEMP_COUNTER.fetch_add(1, Ordering::AcqRel)
+    ));
+    let content = serde_json::to_vec(&serde_json::json!({
+        "remote_access": request.remote_access,
+    }))
+    .map_err(|error| BridgeError::Protocol(error.to_string()))?;
+    write_restrictive_file(&request_path, &content)?;
+    let spawn_result = Command::new(node)
+        .arg(controller)
+        .arg("apply")
+        .arg(&request_path)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn();
+    if let Err(error) = spawn_result {
+        let _ = std::fs::remove_file(&request_path);
+        return Err(BridgeError::Io(error));
+    }
+    Ok((
+        StatusCode::ACCEPTED,
+        Json(ApplyStatusResponse {
+            state: "applying".into(),
+            reason: Some("settings saved; the managed bridge is restarting".into()),
+            restored: None,
+        }),
+    ))
+}
+
+fn write_restrictive_file(path: &Path, content: &[u8]) -> Result<(), BridgeError> {
+    let mut options = std::fs::OpenOptions::new();
+    options.write(true).create_new(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    let mut file = options.open(path).map_err(BridgeError::Io)?;
+    file.write_all(content).map_err(BridgeError::Io)?;
+    file.flush().map_err(BridgeError::Io)
+}
+
 async fn preflight_handler(
     State(state): State<BridgeState>,
     headers: HeaderMap,
@@ -1383,7 +2179,10 @@ fn insert_cors_headers(headers: &mut HeaderMap, origin: HeaderValue) {
 }
 
 fn is_loopback_bind_host(host: &str) -> bool {
-    matches!(host, "localhost" | "127.0.0.1" | "::1")
+    matches!(
+        host.to_ascii_lowercase().as_str(),
+        "localhost" | "127.0.0.1" | "::1"
+    )
 }
 
 fn default_upload_dir() -> PathBuf {
@@ -1583,8 +2382,14 @@ fn host_authority_allowed(authority: &str, policy: &RequestPolicy) -> bool {
         return false;
     }
 
-    if is_loopback_host(host) {
+    if is_loopback_bind_host(&policy.bind_host) && is_loopback_host(host) {
         return true;
+    }
+
+    // A LAN/VPN listener must never accept a loopback Host value as a shortcut.
+    // The accepted TCP peer is checked separately for local authentication.
+    if is_loopback_host(host) {
+        return false;
     }
 
     if !authority_port_matches(authority, policy.bind_port) {
@@ -1599,7 +2404,7 @@ fn host_authority_allowed(authority: &str, policy: &RequestPolicy) -> bool {
         return true;
     }
 
-    host.eq_ignore_ascii_case(&policy.bind_host)
+    false
 }
 
 fn request_origin_allowed(headers: &HeaderMap, policy: &RequestPolicy) -> bool {
@@ -1675,6 +2480,18 @@ fn content_security_policy(policy: &RequestPolicy) -> HeaderValue {
     HeaderValue::from_str(&value).expect("connect-src sources are validated origins")
 }
 
+fn websocket_auth_protocol(headers: &HeaderMap) -> Option<String> {
+    BridgeAuth::websocket_token(headers).map(|token| format!("herdr-world-auth.{token}"))
+}
+
+fn configure_websocket_protocol(ws: WebSocketUpgrade, headers: &HeaderMap) -> WebSocketUpgrade {
+    if let Some(protocol) = websocket_auth_protocol(headers) {
+        ws.protocols([protocol])
+    } else {
+        ws
+    }
+}
+
 fn normalize_allowed_host(host: &str) -> Result<String, String> {
     let host = host.trim().trim_matches('.');
     if host.is_empty() {
@@ -1693,6 +2510,15 @@ fn normalize_allowed_host(host: &str) -> Result<String, String> {
         return Err("allowed host is not a valid hostname or IP literal".into());
     }
     Ok(host.to_ascii_lowercase())
+}
+
+fn validate_password_hash(hash: &str) -> Result<(), String> {
+    if hash.as_bytes().len() > MAX_REMOTE_ACCESS_VALUE_BYTES || !hash.starts_with("$argon2") {
+        return Err("password hash must be a bounded Argon2 hash".into());
+    }
+    PasswordHash::new(hash)
+        .map(|_| ())
+        .map_err(|_| "password hash is invalid".to_string())
 }
 
 fn normalize_configured_label(label: &str) -> Result<String, String> {
@@ -3167,6 +3993,11 @@ async fn capabilities_handler(
         features: CAPABILITY_FEATURES,
         commands: ALLOWED_COMMANDS,
         web_compat: WEB_COMPAT_VERSION,
+        authentication: AuthenticationCapability {
+            required: state.auth.required(),
+            session: "bearer",
+            local_peer_bypass: true,
+        },
         agent_activity: AgentActivityCapability { version: 1 },
         agent_pins: AgentPinsCapability { version: 1 },
         launcher_presets: LauncherPresetsCapability { version: 1 },
@@ -3462,7 +4293,8 @@ async fn terminal_ws_handler(
     if let Err(err) = ensure_allowed_request(&headers, &state.request_policy) {
         return err.into_response();
     }
-    ws.on_upgrade(move |socket| handle_terminal_socket(socket, state, query))
+    configure_websocket_protocol(ws, &headers)
+        .on_upgrade(move |socket| handle_terminal_socket(socket, state, query))
         .into_response()
 }
 
@@ -3474,7 +4306,8 @@ async fn events_ws_handler(
     if let Err(err) = ensure_allowed_request(&headers, &state.request_policy) {
         return err.into_response();
     }
-    ws.on_upgrade(move |socket| handle_events_socket(socket, state))
+    configure_websocket_protocol(ws, &headers)
+        .on_upgrade(move |socket| handle_events_socket(socket, state))
         .into_response()
 }
 
@@ -3486,7 +4319,8 @@ async fn activity_ws_handler(
     if let Err(err) = ensure_allowed_request(&headers, &state.request_policy) {
         return err.into_response();
     }
-    ws.on_upgrade(move |socket| handle_activity_socket(socket, state))
+    configure_websocket_protocol(ws, &headers)
+        .on_upgrade(move |socket| handle_activity_socket(socket, state))
         .into_response()
 }
 
@@ -3498,7 +4332,8 @@ async fn ui_events_ws_handler(
     if let Err(err) = ensure_allowed_request(&headers, &state.request_policy) {
         return err.into_response();
     }
-    ws.on_upgrade(move |socket| handle_ui_events_socket(socket, state))
+    configure_websocket_protocol(ws, &headers)
+        .on_upgrade(move |socket| handle_ui_events_socket(socket, state))
         .into_response()
 }
 
@@ -6108,6 +6943,7 @@ mod tests {
             bind_port: 4000,
             allowed_hosts: vec!["192.0.2.10".to_string()],
             allowed_origins: vec!["http://192.0.2.10:4000".to_string()],
+            allowed_connect_origins: Vec::new(),
             allowed_connect_sources: Vec::new(),
         };
         assert!(!request_allowed(
@@ -6122,6 +6958,94 @@ mod tests {
             &origin_headers("192.0.2.10:8787", Some("http://192.0.2.10:8787")),
             &policy
         ));
+    }
+
+    #[test]
+    fn remote_peer_cannot_turn_a_lan_request_into_local_access() {
+        let policy = RequestPolicy {
+            bind_host: "0.0.0.0".to_string(),
+            bind_port: 4000,
+            allowed_hosts: vec!["192.0.2.10".to_string()],
+            allowed_origins: vec!["http://192.0.2.10:4000".to_string()],
+            allowed_connect_origins: Vec::new(),
+            allowed_connect_sources: Vec::new(),
+        };
+        let remote_peer = "192.0.2.55:51234".parse().unwrap();
+        let localhost = origin_headers("localhost:4000", None);
+        assert!(!request_allowed(&localhost, &policy));
+        assert!(local_management_allowed(&localhost, &policy, remote_peer).is_err());
+
+        let accepted_host = origin_headers("192.0.2.10:4000", None);
+        assert!(request_allowed(&accepted_host, &policy));
+        assert!(local_management_allowed(&accepted_host, &policy, remote_peer).is_err());
+        let loopback_peer = "127.0.0.1:51234".parse().unwrap();
+        assert!(local_management_allowed(&accepted_host, &policy, loopback_peer).is_ok());
+
+        let auth = BridgeAuth::new(Some("not-a-valid-password-hash".to_string()));
+        assert!(!auth.request_is_authorized(&accepted_host, Some(remote_peer)));
+        assert!(
+            auth.request_is_authorized(&accepted_host, Some("127.0.0.1:51234".parse().unwrap()))
+        );
+    }
+
+    #[tokio::test]
+    async fn password_sessions_are_bounded_delayed_and_expire() {
+        let auth = BridgeAuth::new(Some("not-a-valid-password-hash".to_string()));
+        let peer = Some("192.0.2.55:51234".parse().unwrap());
+        let oversized = "x".repeat(MAX_PASSWORD_BYTES + 1);
+        assert_eq!(
+            auth.issue_session(peer, &oversized).await,
+            Err(AuthFailure::InvalidInput)
+        );
+
+        let started = std::time::Instant::now();
+        assert_eq!(
+            auth.issue_session(peer, "wrong").await,
+            Err(AuthFailure::Rejected)
+        );
+        assert!(started.elapsed() >= AUTH_FAILURE_DELAY);
+        for _ in 1..AUTH_FAILURE_LIMIT {
+            assert_eq!(
+                auth.issue_session(peer, "wrong").await,
+                Err(AuthFailure::Rejected)
+            );
+        }
+        assert_eq!(
+            auth.issue_session(peer, "wrong").await,
+            Err(AuthFailure::RateLimited)
+        );
+
+        let expired = "expired-token".to_string();
+        auth.sessions
+            .lock()
+            .unwrap()
+            .tokens
+            .insert(expired.clone(), Instant::now() - Duration::from_secs(1));
+        assert!(!auth.token_is_valid(&expired));
+    }
+
+    #[test]
+    fn protected_route_inventory_keeps_only_negotiation_bootstrap_public() {
+        assert!(is_public_bootstrap_path("/api/capabilities"));
+        assert!(is_public_bootstrap_path("/api/auth/status"));
+        assert!(is_public_bootstrap_path("/api/auth/session"));
+        assert!(is_public_bootstrap_path("/api/local/remote-access"));
+        for path in [
+            "/api/snapshot",
+            "/api/command",
+            "/api/uploads",
+            "/api/observability/health",
+            "/ws/events",
+            "/ws/activity",
+            "/ws/ui-events",
+            "/ws/terminal",
+            "/ws/extensions/observability",
+        ] {
+            assert!(
+                !is_public_bootstrap_path(path),
+                "{path} must require authentication"
+            );
+        }
     }
 
     #[test]
@@ -6148,6 +7072,7 @@ mod tests {
             bind_port: 4000,
             allowed_hosts: vec!["192.0.2.10".to_string()],
             allowed_origins: vec!["http://localhost".to_string()],
+            allowed_connect_origins: Vec::new(),
             allowed_connect_sources: Vec::new(),
         };
         assert!(request_allowed(
@@ -6206,10 +7131,11 @@ mod tests {
             bind_port: 4000,
             allowed_hosts: vec!["192.0.2.10".to_string()],
             allowed_origins: vec!["http://192.0.2.10:4000".to_string()],
+            allowed_connect_origins: Vec::new(),
             allowed_connect_sources: Vec::new(),
         };
         assert!(host_authority_allowed("192.0.2.10:4000", &lan));
-        assert!(host_authority_allowed("[::1]:5173", &lan));
+        assert!(!host_authority_allowed("[::1]:5173", &lan));
         assert!(!host_authority_allowed("evil.example:4000", &lan));
     }
 
@@ -6220,6 +7146,7 @@ mod tests {
             bind_port: 4000,
             allowed_hosts: vec!["herdr-host.local".to_string()],
             allowed_origins: Vec::new(),
+            allowed_connect_origins: Vec::new(),
             allowed_connect_sources: Vec::new(),
         };
         assert!(host_authority_allowed("herdr-host.local:4000", &policy));
@@ -6235,6 +7162,7 @@ mod tests {
             bind_port: 4000,
             allowed_hosts: vec!["192.0.2.10".to_string()],
             allowed_origins: vec!["http://localhost".to_string()],
+            allowed_connect_origins: Vec::new(),
             allowed_connect_sources: Vec::new(),
         };
         assert_eq!(
@@ -7273,6 +8201,7 @@ mod tests {
             bind_port,
             allowed_hosts: Vec::new(),
             allowed_origins: Vec::new(),
+            allowed_connect_origins: Vec::new(),
             allowed_connect_sources: Vec::new(),
         }
     }

--- a/bridge/src/web_bridge.rs
+++ b/bridge/src/web_bridge.rs
@@ -2,7 +2,7 @@ use std::collections::{HashMap, HashSet, VecDeque};
 use std::env;
 use std::fmt;
 use std::io::{self, ErrorKind, Write};
-use std::net::{IpAddr, SocketAddr};
+use std::net::{IpAddr, Ipv6Addr, SocketAddr};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 #[cfg(test)]
@@ -100,6 +100,7 @@ const TERMINAL_OUTPUT_FRAME_GZIP: u8 = 1;
 const TERMINAL_OUTPUT_GZIP_MIN_BYTES: usize = 256;
 const TERMINAL_OUTPUT_GZIP_ACKNOWLEDGEMENT: &str =
     r#"{"type":"terminal_output_encoding","encoding":"gzip"}"#;
+const TERMINAL_ATTACH_READY: &str = r#"{"type":"attach_ready"}"#;
 const DAEMON_STATUS_TIMEOUT: Duration = Duration::from_secs(5);
 const ACTIVITY_WATCHER_INITIAL_BACKOFF: Duration = Duration::from_secs(1);
 const ACTIVITY_WATCHER_MAX_BACKOFF: Duration = Duration::from_secs(30);
@@ -126,6 +127,10 @@ const AUTH_TOKEN_BYTES: usize = 32;
 const MAX_APPLY_REASON_BYTES: usize = 240;
 static UPLOAD_TEMP_COUNTER: AtomicUsize = AtomicUsize::new(0);
 static CONTROLLER_TEMP_COUNTER: AtomicUsize = AtomicUsize::new(0);
+#[cfg(test)]
+static AUTH_TEST_VERIFICATION_PAUSE: AtomicBool = AtomicBool::new(false);
+#[cfg(test)]
+static AUTH_TEST_VERIFICATION_STARTED: AtomicBool = AtomicBool::new(false);
 
 #[derive(Debug, Clone)]
 struct BridgeOptions {
@@ -253,6 +258,60 @@ struct AuthSessions {
     pending: HashMap<String, usize>,
 }
 
+struct PendingPasswordVerification {
+    sessions: Arc<Mutex<AuthSessions>>,
+    key: String,
+    finished: bool,
+}
+
+impl PendingPasswordVerification {
+    fn new(sessions: Arc<Mutex<AuthSessions>>, key: String) -> Self {
+        Self {
+            sessions,
+            key,
+            finished: false,
+        }
+    }
+
+    fn finish(&mut self, valid: bool) -> Result<(Duration, bool), AuthFailure> {
+        let mut sessions = self.sessions.lock().map_err(|_| AuthFailure::Unavailable)?;
+        decrement_pending_verification(&mut sessions, &self.key);
+        let result = if valid {
+            sessions.failures.remove(&self.key);
+            (Duration::ZERO, true)
+        } else {
+            let failures = sessions.failures.entry(self.key.clone()).or_default();
+            failures.push_back(Instant::now());
+            (
+                AUTH_FAILURE_DELAY.saturating_mul(failures.len() as u32),
+                false,
+            )
+        };
+        self.finished = true;
+        Ok(result)
+    }
+}
+
+impl Drop for PendingPasswordVerification {
+    fn drop(&mut self) {
+        if self.finished {
+            return;
+        }
+        if let Ok(mut sessions) = self.sessions.lock() {
+            decrement_pending_verification(&mut sessions, &self.key);
+        }
+    }
+}
+
+fn decrement_pending_verification(sessions: &mut AuthSessions, key: &str) {
+    if let Some(pending) = sessions.pending.get_mut(key) {
+        *pending = pending.saturating_sub(1);
+        if *pending == 0 {
+            sessions.pending.remove(key);
+        }
+    }
+}
+
 #[derive(Debug, Serialize)]
 struct AuthenticationCapability {
     required: bool,
@@ -293,7 +352,7 @@ impl BridgeAuth {
     fn local_peer_allowed(peer: Option<SocketAddr>) -> bool {
         // This is intentionally based only on the accepted TCP peer address.
         // Host, Origin, and forwarding headers are not authentication input.
-        peer.is_some_and(|address| address.ip().is_loopback())
+        peer.is_some_and(peer_is_loopback)
     }
 
     fn token_is_valid(&self, token: &str) -> bool {
@@ -350,7 +409,7 @@ impl BridgeAuth {
         let Some(expected) = self.password_hash.as_deref() else {
             return Err(AuthFailure::NotRequired);
         };
-        let _verification_permit = self
+        let verification_permit = self
             .verification_slots
             .clone()
             .try_acquire_owned()
@@ -382,30 +441,20 @@ impl BridgeAuth {
 
         let expected = expected.to_owned();
         let password = password.to_owned();
-        let valid = tokio::task::spawn_blocking(move || verify_password(&expected, &password))
-            .await
-            .unwrap_or(false);
-
-        let (delay, authenticated) = {
-            let mut sessions = self.sessions.lock().map_err(|_| AuthFailure::Unavailable)?;
-            if let Some(pending) = sessions.pending.get_mut(&key) {
-                *pending = pending.saturating_sub(1);
-                if *pending == 0 {
-                    sessions.pending.remove(&key);
-                }
-            }
-            if valid {
-                sessions.failures.remove(&key);
-                (Duration::ZERO, true)
-            } else {
-                let failures = sessions.failures.entry(key).or_default();
-                failures.push_back(Instant::now());
-                (
-                    AUTH_FAILURE_DELAY.saturating_mul(failures.len() as u32),
-                    false,
-                )
-            }
-        };
+        let sessions = self.sessions.clone();
+        let key_for_verification = key.clone();
+        let pending = PendingPasswordVerification::new(sessions, key_for_verification);
+        let (delay, authenticated) = tokio::task::spawn_blocking(move || {
+            // Keep both the semaphore permit and the pending-accounting guard
+            // inside the blocking task. Dropping the request future must not
+            // make work look idle while password verification is still running.
+            let _verification_permit = verification_permit;
+            let mut pending = pending;
+            let valid = verify_password(&expected, &password);
+            pending.finish(valid)
+        })
+        .await
+        .map_err(|_| AuthFailure::Unavailable)??;
         if !delay.is_zero() {
             tokio::time::sleep(delay).await;
         }
@@ -468,6 +517,13 @@ async fn hash_password_async(password: &str) -> Result<String, String> {
 }
 
 fn verify_password(encoded: &str, password: &str) -> bool {
+    #[cfg(test)]
+    if password == "wrong-password" && AUTH_TEST_VERIFICATION_PAUSE.load(Ordering::Acquire) {
+        AUTH_TEST_VERIFICATION_STARTED.store(true, Ordering::Release);
+        while AUTH_TEST_VERIFICATION_PAUSE.load(Ordering::Acquire) {
+            thread::yield_now();
+        }
+    }
     let Ok(parsed) = PasswordHash::new(encoded) else {
         return false;
     };
@@ -805,6 +861,8 @@ struct TerminalQuery {
     output_encoding: Option<TerminalOutputWireEncoding>,
     #[serde(default)]
     takeover: bool,
+    #[serde(default)]
+    probe: bool,
 }
 
 #[derive(Debug, Deserialize, PartialEq, Eq)]
@@ -1711,13 +1769,43 @@ async fn run_server(options: BridgeOptions) -> io::Result<()> {
     spawn_agent_activity_watcher(state.clone());
     let app = bridge_router(state, options.static_dir.clone());
     let bind = listener_bind_address(&options.host, options.port);
-    let listener = tokio::net::TcpListener::bind(&bind).await?;
+    let dual_family = dual_family_listener_required(&options.host, &options.allowed_hosts);
+    let listener = if dual_family && is_ipv6_literal(&options.host) {
+        bind_ipv6_only_listener(options.port)?
+    } else {
+        tokio::net::TcpListener::bind(&bind).await?
+    };
+    let secondary_listener = if dual_family {
+        if is_ipv6_literal(&options.host) {
+            Some(
+                tokio::net::TcpListener::bind(format!("0.0.0.0:{}", listener.local_addr()?.port()))
+                    .await?,
+            )
+        } else {
+            Some(bind_ipv6_only_listener(listener.local_addr()?.port())?)
+        }
+    } else {
+        None
+    };
     info!(url = %format!("http://{bind}"), "Herdr World bridge listening");
-    axum::serve(
+    let primary = axum::serve(
         listener,
-        app.into_make_service_with_connect_info::<SocketAddr>(),
-    )
-    .await
+        app.clone()
+            .into_make_service_with_connect_info::<SocketAddr>(),
+    );
+    if let Some(listener) = secondary_listener {
+        let secondary_bind = listener.local_addr()?;
+        info!(url = %format!("http://{secondary_bind}"), "Herdr World bridge listening on the second IP family");
+        tokio::select! {
+            result = primary => result,
+            result = axum::serve(
+                listener,
+                app.into_make_service_with_connect_info::<SocketAddr>(),
+            ) => result,
+        }
+    } else {
+        primary.await
+    }
 }
 
 fn bridge_router(state: BridgeState, static_dir: PathBuf) -> Router {
@@ -1882,6 +1970,51 @@ fn listener_bind_address(host: &str, port: u16) -> String {
     } else {
         format!("{host}:{port}")
     }
+}
+
+fn is_ipv6_literal(host: &str) -> bool {
+    host.trim()
+        .trim_start_matches('[')
+        .trim_end_matches(']')
+        .parse::<IpAddr>()
+        .is_ok_and(|address| address.is_ipv6())
+}
+
+fn dual_family_listener_required(host: &str, allowed_hosts: &[String]) -> bool {
+    let host = host.trim().trim_start_matches('[').trim_end_matches(']');
+    if host != "0.0.0.0" && host != "::" {
+        return false;
+    }
+    let opposite_family = if host == "::" {
+        |address: IpAddr| address.is_ipv4()
+    } else {
+        |address: IpAddr| address.is_ipv6()
+    };
+    allowed_hosts.iter().any(|allowed| {
+        allowed
+            .trim()
+            .trim_start_matches('[')
+            .trim_end_matches(']')
+            .parse::<IpAddr>()
+            .is_ok_and(opposite_family)
+    })
+}
+
+fn bind_ipv6_only_listener(port: u16) -> io::Result<tokio::net::TcpListener> {
+    let socket = socket2::Socket::new(
+        socket2::Domain::IPV6,
+        socket2::Type::STREAM,
+        Some(socket2::Protocol::TCP),
+    )?;
+    socket.set_only_v6(true)?;
+    socket.set_reuse_address(true)?;
+    socket.bind(&socket2::SockAddr::from(SocketAddr::new(
+        IpAddr::V6(Ipv6Addr::UNSPECIFIED),
+        port,
+    )))?;
+    socket.listen(1024)?;
+    socket.set_nonblocking(true)?;
+    tokio::net::TcpListener::from_std(socket.into())
 }
 
 fn is_world_navigation_path(path: &str) -> bool {
@@ -2675,7 +2808,7 @@ fn host_authority_allowed_from_peer(
         return true;
     }
 
-    if peer.is_some_and(|address| address.ip().is_loopback())
+    if peer.is_some_and(peer_is_loopback)
         && is_loopback_host(host)
         && authority_port_matches(authority, policy.bind_port)
     {
@@ -2731,7 +2864,7 @@ fn request_origin_allowed_from_peer(
         .iter()
         .any(|allowed| allowed.eq_ignore_ascii_case(origin));
     if !is_loopback_bind_host(&policy.bind_host)
-        && !(peer.is_some_and(|address| address.ip().is_loopback())
+        && !(peer.is_some_and(peer_is_loopback)
             && is_loopback_authority(origin_authority)
             && is_loopback_authority(host))
     {
@@ -2870,6 +3003,16 @@ fn is_loopback_authority(authority: &str) -> bool {
 
 fn is_loopback_host(host: &str) -> bool {
     host.eq_ignore_ascii_case("localhost") || host == "127.0.0.1" || host == "::1"
+}
+
+fn peer_is_loopback(address: SocketAddr) -> bool {
+    address.ip().is_loopback()
+        || matches!(
+            address.ip(),
+            IpAddr::V6(address) if address
+                .to_ipv4_mapped()
+                .is_some_and(|mapped| mapped.is_loopback())
+        )
 }
 
 fn authority_port_matches(authority: &str, expected_port: u16) -> bool {
@@ -4728,6 +4871,14 @@ async fn handle_terminal_socket(socket: WebSocket, state: BridgeState, query: Te
         }
     };
 
+    if query.probe {
+        let _ = ws_sender
+            .send(Message::Text(TERMINAL_ATTACH_READY.into()))
+            .await;
+        release_terminal_session(&state.terminal_sessions, &terminal_id, &session);
+        return;
+    }
+
     let write_tx = session.write_tx.clone();
     let mut terminal_rx = session.output_tx.subscribe();
     if output_encoding == TerminalOutputWireEncoding::Gzip {
@@ -6371,6 +6522,17 @@ mod tests {
         );
     }
 
+    #[test]
+    fn terminal_probe_query_is_non_mutating_and_has_no_resize_defaults() {
+        let query: TerminalQuery = serde_json::from_str(
+            r#"{"terminal_id":"terminal-test","takeover":false,"probe":true}"#,
+        )
+        .unwrap();
+        assert!(query.probe);
+        assert_eq!(query.cols, None);
+        assert_eq!(query.rows, None);
+    }
+
     fn test_terminal_writer() -> (TerminalWriter, mpsc::Receiver<ClientMessage>) {
         let (tx, rx) = mpsc::channel();
         (
@@ -7284,6 +7446,50 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn cancelling_password_verification_cleans_pending_state_and_releases_capacity() {
+        AUTH_TEST_VERIFICATION_STARTED.store(false, Ordering::Release);
+        AUTH_TEST_VERIFICATION_PAUSE.store(true, Ordering::Release);
+        let auth = Arc::new(BridgeAuth::new(Some(
+            hash_password("synthetic-password").unwrap(),
+        )));
+        let peer = "192.0.2.56:51234".parse().unwrap();
+        let task_auth = auth.clone();
+        let task =
+            tokio::spawn(
+                async move { task_auth.issue_session(Some(peer), "wrong-password").await },
+            );
+
+        let mut verification_started = false;
+        for _ in 0..100 {
+            verification_started = AUTH_TEST_VERIFICATION_STARTED.load(Ordering::Acquire);
+            if verification_started {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+        assert!(
+            verification_started,
+            "password verification did not become in-flight"
+        );
+        task.abort();
+        AUTH_TEST_VERIFICATION_PAUSE.store(false, Ordering::Release);
+        let _ = task.await;
+
+        for _ in 0..100 {
+            let pending = auth.sessions.lock().unwrap().pending.len();
+            if pending == 0 {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+        assert!(auth.sessions.lock().unwrap().pending.is_empty());
+        assert_eq!(
+            auth.verification_slots.available_permits(),
+            MAX_PASSWORD_VERIFICATIONS
+        );
+    }
+
+    #[tokio::test]
     async fn password_session_transport_rejects_oversized_streams_before_body_extraction() {
         let handler_called = Arc::new(AtomicBool::new(false));
         let handler_called_for_route = handler_called.clone();
@@ -7490,13 +7696,14 @@ mod tests {
         };
 
         spawn_management_controller(&management, &request).unwrap();
-        for _ in 0..20 {
-            if marker.is_file() {
+        let mut process_group = String::new();
+        for _ in 0..200 {
+            process_group = std::fs::read_to_string(&marker).unwrap_or_default();
+            if !process_group.trim().is_empty() {
                 break;
             }
             std::thread::sleep(Duration::from_millis(25));
         }
-        let process_group = std::fs::read_to_string(&marker).unwrap();
         let parent_group = unsafe { libc::getpgrp() }.to_string();
         assert!(!process_group.trim().is_empty());
         assert_ne!(process_group.trim(), parent_group);
@@ -8022,6 +8229,32 @@ mod tests {
                 .local_addr()
                 .expect("IPv6 listener address")
                 .is_ipv6());
+        }
+    }
+
+    #[tokio::test]
+    async fn mixed_ip_profiles_request_dual_family_listeners_and_map_loopback_peers() {
+        assert!(dual_family_listener_required(
+            "0.0.0.0",
+            &["2001:db8::20".to_string()]
+        ));
+        assert!(dual_family_listener_required(
+            "::",
+            &["192.0.2.20".to_string()]
+        ));
+        assert!(!dual_family_listener_required(
+            "0.0.0.0",
+            &["192.0.2.20".to_string()]
+        ));
+        assert!(peer_is_loopback(
+            "[::ffff:127.0.0.1]:51234".parse().unwrap()
+        ));
+        if let Ok(ipv4_listener) = std::net::TcpListener::bind("0.0.0.0:0") {
+            let port = ipv4_listener.local_addr().unwrap().port();
+            if let Ok(ipv6_listener) = bind_ipv6_only_listener(port) {
+                assert_eq!(ipv6_listener.local_addr().unwrap().port(), port);
+                assert!(ipv6_listener.local_addr().unwrap().is_ipv6());
+            }
         }
     }
 

--- a/bridge/src/web_bridge.rs
+++ b/bridge/src/web_bridge.rs
@@ -716,11 +716,6 @@ fn validate_remote_access_draft(draft: &mut RemoteAccessDraft) -> Result<(), Bri
             "remote access needs at least one accepted address".into(),
         ));
     }
-    if draft.enabled && page_origins.is_empty() {
-        return Err(BridgeError::BadRequest(
-            "remote access needs at least one allowed page origin".into(),
-        ));
-    }
     if let Some(hash) = &draft.password_hash {
         if hash.as_bytes().len() > MAX_REMOTE_ACCESS_VALUE_BYTES || !hash.starts_with("$argon2") {
             return Err(BridgeError::BadRequest("password hash is invalid".into()));
@@ -1671,11 +1666,6 @@ fn parse_options(args: &[String]) -> Result<Option<BridgeOptions>, String> {
                 "non-loopback binding requires at least one explicit --allow-host value".into(),
             );
         }
-        if allowed_origins.is_empty() {
-            return Err(
-                "non-loopback binding requires at least one explicit --allow-origin value".into(),
-            );
-        }
     }
 
     if let Some(name) = explicit_session {
@@ -1709,9 +1699,10 @@ Usage: herdr-world-bridge [--session NAME] [--host HOST] [--port PORT] [--static
 Runs the local HTTP/WebSocket bridge for Herdr World.\n\
 Defaults to the active Herdr daemon sockets and 127.0.0.1:8787.\n\
 Use --session NAME to target a named Herdr session and ignore HERDR_SOCKET_PATH.\n\
-Non-loopback --host values require explicit --allow-host and --allow-origin values.\n\
+Non-loopback --host values require an explicit --allow-host value.\n\
 Every admitted browser has terminal-equivalent access; Host and Origin checks are not authentication.\n\
-Use --allow-origin http://localhost for bundled Android app access.\n\
+Same-origin pages matching an allowed Host are admitted automatically.\n\
+Use --allow-origin http://localhost for additional clients such as the bundled Android app.\n\
 Use --allow-host HOSTNAME to accept that exact DNS hostname in Host headers.\n\
 Use --allow-connect-origin ORIGIN to let the served web app connect to another bridge origin.\n\
 Use --password-hash HASH for the memory-hard Argon2id hash managed by the plugin controller.\n\
@@ -2882,7 +2873,7 @@ fn request_origin_allowed_from_peer(
             && is_loopback_authority(origin_authority)
             && is_loopback_authority(host))
     {
-        return explicitly_allowed;
+        return same_authority(origin_authority, host) || explicitly_allowed;
     }
 
     same_authority(origin_authority, host)
@@ -7783,7 +7774,7 @@ mod tests {
     }
 
     #[test]
-    fn request_gate_allows_configured_android_origin() {
+    fn request_gate_allows_same_origin_and_configured_android_origin() {
         let policy = RequestPolicy {
             bind_host: "0.0.0.0".to_string(),
             bind_port: 4000,
@@ -7794,6 +7785,10 @@ mod tests {
         };
         assert!(request_allowed(
             &origin_headers("192.0.2.10:4000", Some("http://localhost")),
+            &policy
+        ));
+        assert!(request_allowed(
+            &origin_headers("192.0.2.10:4000", Some("http://192.0.2.10:4000")),
             &policy
         ));
         assert!(!request_allowed(
@@ -8829,7 +8824,7 @@ mod tests {
     }
 
     #[test]
-    fn non_loopback_options_require_explicit_host_and_origin() {
+    fn non_loopback_options_require_explicit_host_but_allow_same_origin_by_default() {
         let host_only = vec!["--host".to_string(), "0.0.0.0".to_string()];
         assert!(parse_options(&host_only)
             .unwrap_err()
@@ -8841,9 +8836,9 @@ mod tests {
             "--allow-host".to_string(),
             "192.0.2.10".to_string(),
         ];
-        assert!(parse_options(&without_origin)
-            .unwrap_err()
-            .contains("--allow-origin"));
+        let same_origin_only = parse_options(&without_origin).unwrap().unwrap();
+        assert_eq!(same_origin_only.allowed_hosts, vec!["192.0.2.10"]);
+        assert!(same_origin_only.allowed_origins.is_empty());
 
         let explicit = vec![
             "--host".to_string(),

--- a/bridge/src/web_bridge.rs
+++ b/bridge/src/web_bridge.rs
@@ -2,7 +2,7 @@ use std::collections::{HashMap, HashSet, VecDeque};
 use std::env;
 use std::fmt;
 use std::io::{self, ErrorKind, Write};
-use std::net::{IpAddr, Ipv6Addr, SocketAddr};
+use std::net::{IpAddr, Ipv6Addr, SocketAddr, UdpSocket};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 #[cfg(test)]
@@ -597,34 +597,47 @@ fn is_link_local(address: IpAddr) -> bool {
     }
 }
 
+fn add_access_candidate(candidates: &mut Vec<String>, raw: &str) {
+    let value = raw.trim().trim_matches('.');
+    if value.is_empty() || value.eq_ignore_ascii_case("localhost") {
+        return;
+    }
+    let valid = normalize_allowed_host(value).ok().filter(|host| {
+        host.parse::<IpAddr>()
+            .map(|address| {
+                !address.is_loopback() && !address.is_unspecified() && !is_link_local(address)
+            })
+            .unwrap_or(true)
+    });
+    if let Some(value) = valid {
+        if !candidates
+            .iter()
+            .any(|item| item.eq_ignore_ascii_case(&value))
+        {
+            candidates.push(value);
+        }
+    }
+}
+
+fn route_selected_address(bind: &str, destination: &str) -> Option<String> {
+    let socket = UdpSocket::bind(bind).ok()?;
+    socket.connect(destination).ok()?;
+    Some(socket.local_addr().ok()?.ip().to_string())
+}
+
 fn detected_access_candidates(policy: &RequestPolicy) -> Vec<String> {
     let mut candidates: Vec<String> = Vec::new();
-    let mut add = |value: &str| {
-        let value = value.trim().trim_matches('.');
-        if value.is_empty() || value.eq_ignore_ascii_case("localhost") {
-            return;
-        }
-        let valid = normalize_allowed_host(value).ok().filter(|host| {
-            host.parse::<IpAddr>()
-                .map(|address| {
-                    !address.is_loopback() && !address.is_unspecified() && !is_link_local(address)
-                })
-                .unwrap_or(true)
-        });
-        if let Some(value) = valid {
-            if !candidates
-                .iter()
-                .any(|item: &String| item.eq_ignore_ascii_case(&value))
-            {
-                candidates.push(value);
-            }
-        }
-    };
     if !is_loopback_bind_host(&policy.bind_host) {
-        add(&policy.bind_host);
+        add_access_candidate(&mut candidates, &policy.bind_host);
+    }
+    if let Some(address) = route_selected_address("0.0.0.0:0", "192.0.2.1:9") {
+        add_access_candidate(&mut candidates, &address);
+    }
+    if let Some(address) = route_selected_address("[::]:0", "[2001:db8::1]:9") {
+        add_access_candidate(&mut candidates, &address);
     }
     if let Ok(hostname) = env::var("HOSTNAME") {
-        add(&hostname);
+        add_access_candidate(&mut candidates, &hostname);
     }
     candidates.truncate(8);
     candidates
@@ -2159,6 +2172,7 @@ const CONTROLLER_ENVIRONMENT: &[&str] = &[
     "TMPDIR",
     "LANG",
     "LC_ALL",
+    "HOSTNAME",
     "PATH",
     "HERDR_PLUGIN_CONFIG_DIR",
     "HERDR_PLUGIN_STATE_DIR",
@@ -7336,6 +7350,23 @@ mod tests {
             &origin_headers("127.0.0.1:5173", Some("http://127.0.0.1:5173")),
             &policy
         ));
+    }
+
+    #[test]
+    fn access_candidates_keep_only_usable_machine_addresses() {
+        let mut candidates = Vec::new();
+        for value in [
+            "127.0.0.1",
+            "0.0.0.0",
+            "fe80::1",
+            "192.0.2.20",
+            "192.0.2.20",
+            "workstation.local.",
+        ] {
+            add_access_candidate(&mut candidates, value);
+        }
+
+        assert_eq!(candidates, ["192.0.2.20", "workstation.local"]);
     }
 
     #[test]

--- a/bridge/src/web_bridge.rs
+++ b/bridge/src/web_bridge.rs
@@ -228,6 +228,7 @@ struct RemoteAccessStatusResponse {
 
 #[derive(Debug, Clone, Serialize)]
 struct ApplyStatusResponse {
+    id: Option<String>,
     state: String,
     reason: Option<String>,
     restored: Option<bool>,
@@ -730,6 +731,7 @@ fn validate_remote_access_draft(draft: &mut RemoteAccessDraft) -> Result<(), Bri
 fn read_apply_status(management: &ManagementState) -> ApplyStatusResponse {
     let Some(state_dir) = management.state_dir.as_deref() else {
         return ApplyStatusResponse {
+            id: None,
             state: "ready".into(),
             reason: None,
             restored: None,
@@ -738,6 +740,7 @@ fn read_apply_status(management: &ManagementState) -> ApplyStatusResponse {
     let path = state_dir.join("remote-access-apply.json");
     let Ok(bytes) = std::fs::read(path) else {
         return ApplyStatusResponse {
+            id: None,
             state: "ready".into(),
             reason: None,
             restored: None,
@@ -745,6 +748,7 @@ fn read_apply_status(management: &ManagementState) -> ApplyStatusResponse {
     };
     let Ok(value) = serde_json::from_slice::<serde_json::Value>(&bytes) else {
         return ApplyStatusResponse {
+            id: None,
             state: "failed".into(),
             reason: Some("controller status is unavailable".into()),
             restored: None,
@@ -761,6 +765,17 @@ fn read_apply_status(management: &ManagementState) -> ApplyStatusResponse {
         .and_then(serde_json::Value::as_str)
         .map(|reason| reason.chars().take(MAX_APPLY_REASON_BYTES).collect());
     ApplyStatusResponse {
+        id: value
+            .get("id")
+            .and_then(serde_json::Value::as_str)
+            .filter(|id| {
+                !id.is_empty()
+                    && id.len() <= 128
+                    && id
+                        .bytes()
+                        .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'-'))
+            })
+            .map(str::to_string),
         state,
         reason,
         restored: value.get("restored").and_then(serde_json::Value::as_bool),
@@ -2481,12 +2496,11 @@ async fn remote_access_apply_handler(
         ));
     };
     std::fs::create_dir_all(state_dir).map_err(BridgeError::Io)?;
-    let request_path = state_dir.join(format!(
-        ".remote-access-request-{}-{}.json",
-        std::process::id(),
-        UPLOAD_TEMP_COUNTER.fetch_add(1, Ordering::AcqRel)
-    ));
+    let sequence = UPLOAD_TEMP_COUNTER.fetch_add(1, Ordering::AcqRel);
+    let apply_id = format!("{}-{sequence}", std::process::id());
+    let request_path = state_dir.join(format!(".remote-access-request-{apply_id}.json"));
     let content = serde_json::to_vec(&serde_json::json!({
+        "apply_id": apply_id,
         "remote_access": request.remote_access,
     }))
     .map_err(|error| BridgeError::Protocol(error.to_string()))?;
@@ -2498,6 +2512,7 @@ async fn remote_access_apply_handler(
     Ok((
         StatusCode::ACCEPTED,
         Json(ApplyStatusResponse {
+            id: Some(apply_id),
             state: "applying".into(),
             reason: Some("settings saved; the managed bridge is restarting".into()),
             restored: None,
@@ -7663,6 +7678,9 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(response.status(), StatusCode::ACCEPTED);
+        let accepted = response.json::<serde_json::Value>().await.unwrap();
+        let apply_id = accepted["id"].as_str().unwrap();
+        assert!(!apply_id.is_empty());
 
         for _ in 0..40 {
             if marker.is_file() {
@@ -7677,6 +7695,7 @@ mod tests {
         )
         .unwrap();
         assert_eq!(request["remote_access"]["enabled"], true);
+        assert_eq!(request["apply_id"], apply_id);
 
         server.abort();
         let _ = server.await;

--- a/bridge/src/web_bridge.rs
+++ b/bridge/src/web_bridge.rs
@@ -5,10 +5,15 @@ use std::io::{self, ErrorKind, Write};
 use std::net::{IpAddr, SocketAddr};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
+#[cfg(test)]
+use std::sync::atomic::AtomicBool;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{mpsc, Arc, Condvar, Mutex};
 use std::thread;
 use std::time::Duration;
+
+#[cfg(unix)]
+use std::os::unix::process::CommandExt;
 
 use argon2::password_hash::{
     rand_core::OsRng as PasswordOsRng, PasswordHash, PasswordHasher, PasswordVerifier, SaltString,
@@ -33,6 +38,7 @@ use futures_util::{SinkExt, StreamExt};
 use herdr_compat::TryClone as _;
 use rand::{rngs::OsRng as TokenOsRng, RngCore};
 use serde::{Deserialize, Serialize};
+use tokio::sync::Semaphore;
 use tokio::time::Instant;
 use tower::{ServiceBuilder, ServiceExt};
 use tower_http::compression::CompressionLayer;
@@ -105,15 +111,21 @@ const MANAGED_AGENT_SHELL_READY_TIMEOUT: Duration = Duration::from_secs(3);
 const MANAGED_AGENT_START_TIMEOUT: Duration = Duration::from_secs(30);
 const MANAGED_AGENT_POLL_INTERVAL: Duration = Duration::from_millis(100);
 const MAX_PASSWORD_BYTES: usize = 1024;
+const MAX_PASSWORD_REQUEST_BYTES: usize = 2048;
+const MAX_REMOTE_ACCESS_REQUEST_BYTES: usize = 64 * 1024;
 const MAX_REMOTE_ACCESS_ITEMS: usize = 32;
 const MAX_REMOTE_ACCESS_VALUE_BYTES: usize = 512;
 const AUTH_SESSION_TTL: Duration = Duration::from_secs(60 * 60);
 const AUTH_FAILURE_WINDOW: Duration = Duration::from_secs(60);
 const AUTH_FAILURE_LIMIT: usize = 5;
 const AUTH_FAILURE_DELAY: Duration = Duration::from_millis(250);
+const MAX_AUTH_FAILURE_PEERS: usize = 1024;
+const MAX_PASSWORD_VERIFICATIONS: usize = 4;
+const CONTROLLER_HANDOFF_GRACE_MS: &str = "1000";
 const AUTH_TOKEN_BYTES: usize = 32;
 const MAX_APPLY_REASON_BYTES: usize = 240;
 static UPLOAD_TEMP_COUNTER: AtomicUsize = AtomicUsize::new(0);
+static CONTROLLER_TEMP_COUNTER: AtomicUsize = AtomicUsize::new(0);
 
 #[derive(Debug, Clone)]
 struct BridgeOptions {
@@ -222,6 +234,8 @@ struct ManagementState {
     state_dir: Option<PathBuf>,
     controller_node: Option<PathBuf>,
     controller_script: Option<PathBuf>,
+    controller_mode: Option<String>,
+    controller_launcher: Option<PathBuf>,
     mutation_reason: Option<String>,
 }
 
@@ -229,12 +243,14 @@ struct ManagementState {
 struct BridgeAuth {
     password_hash: Option<String>,
     sessions: Arc<Mutex<AuthSessions>>,
+    verification_slots: Arc<Semaphore>,
 }
 
 #[derive(Debug, Default)]
 struct AuthSessions {
     tokens: HashMap<String, Instant>,
     failures: HashMap<String, VecDeque<Instant>>,
+    pending: HashMap<String, usize>,
 }
 
 #[derive(Debug, Serialize)]
@@ -262,6 +278,7 @@ impl BridgeAuth {
         Self {
             password_hash,
             sessions: Arc::new(Mutex::new(AuthSessions::default())),
+            verification_slots: Arc::new(Semaphore::new(MAX_PASSWORD_VERIFICATIONS)),
         }
     }
 
@@ -333,37 +350,66 @@ impl BridgeAuth {
         let Some(expected) = self.password_hash.as_deref() else {
             return Err(AuthFailure::NotRequired);
         };
+        let _verification_permit = self
+            .verification_slots
+            .clone()
+            .try_acquire_owned()
+            .map_err(|_| AuthFailure::RateLimited)?;
         let key = peer
             .map(|address| address.ip().to_string())
             .unwrap_or_else(|| "unknown-peer".to_string());
         let now = Instant::now();
-        let (attempts, delay) = {
+        {
             let mut sessions = self.sessions.lock().map_err(|_| AuthFailure::Unavailable)?;
-            let failures = sessions.failures.entry(key.clone()).or_default();
-            failures
-                .retain(|started| now.saturating_duration_since(*started) < AUTH_FAILURE_WINDOW);
-            if failures.len() >= AUTH_FAILURE_LIMIT {
+            sessions.failures.retain(|_, failures| {
+                failures.retain(|started| {
+                    now.saturating_duration_since(*started) < AUTH_FAILURE_WINDOW
+                });
+                !failures.is_empty()
+            });
+            let failures = sessions.failures.get(&key).map_or(0, VecDeque::len);
+            let pending = sessions.pending.get(&key).copied().unwrap_or(0);
+            if failures + pending >= AUTH_FAILURE_LIMIT {
                 return Err(AuthFailure::RateLimited);
             }
-            let valid = verify_password(expected, password);
-            if !valid {
-                failures.push_back(now);
+            if !sessions.failures.contains_key(&key)
+                && sessions.failures.len() >= MAX_AUTH_FAILURE_PEERS
+            {
+                return Err(AuthFailure::RateLimited);
             }
-            let attempts = failures.len();
-            let delay = if valid {
-                Duration::ZERO
-            } else {
-                AUTH_FAILURE_DELAY.saturating_mul(attempts as u32)
-            };
+            *sessions.pending.entry(key.clone()).or_default() += 1;
+        }
+
+        let expected = expected.to_owned();
+        let password = password.to_owned();
+        let valid = tokio::task::spawn_blocking(move || verify_password(&expected, &password))
+            .await
+            .unwrap_or(false);
+
+        let (delay, authenticated) = {
+            let mut sessions = self.sessions.lock().map_err(|_| AuthFailure::Unavailable)?;
+            if let Some(pending) = sessions.pending.get_mut(&key) {
+                *pending = pending.saturating_sub(1);
+                if *pending == 0 {
+                    sessions.pending.remove(&key);
+                }
+            }
             if valid {
                 sessions.failures.remove(&key);
+                (Duration::ZERO, true)
+            } else {
+                let failures = sessions.failures.entry(key).or_default();
+                failures.push_back(Instant::now());
+                (
+                    AUTH_FAILURE_DELAY.saturating_mul(failures.len() as u32),
+                    false,
+                )
             }
-            (valid, delay)
         };
         if !delay.is_zero() {
             tokio::time::sleep(delay).await;
         }
-        if !attempts {
+        if !authenticated {
             return Err(AuthFailure::Rejected);
         }
 
@@ -406,6 +452,21 @@ fn hash_password(password: &str) -> Result<String, String> {
         .map_err(|_| "could not hash password".to_string())
 }
 
+async fn hash_password_async(password: &str) -> Result<String, String> {
+    if password.as_bytes().len() > MAX_PASSWORD_BYTES {
+        return Err(format!(
+            "password must be at most {MAX_PASSWORD_BYTES} bytes"
+        ));
+    }
+    if password.is_empty() {
+        return Err("password must not be empty".into());
+    }
+    let password = password.to_owned();
+    tokio::task::spawn_blocking(move || hash_password(&password))
+        .await
+        .map_err(|_| "password hashing task failed".to_string())?
+}
+
 fn verify_password(encoded: &str, password: &str) -> bool {
     let Ok(parsed) = PasswordHash::new(encoded) else {
         return false;
@@ -422,10 +483,21 @@ fn management_state_from_environment() -> ManagementState {
     let state_dir = env::var("HERDR_PLUGIN_STATE_DIR").ok().map(PathBuf::from);
     let controller_node = env::var("HERDR_WORLD_NODE_PATH").ok().map(PathBuf::from);
     let controller_script = env::var("HERDR_WORLD_CONTROLLER").ok().map(PathBuf::from);
+    let controller_mode = env::var("HERDR_WORLD_CONTROLLER_MODE").ok();
+    let controller_launcher = match controller_mode.as_deref() {
+        Some("systemd-user") => env::var("HERDR_WORLD_SYSTEMD_RUN").ok().map(PathBuf::from),
+        Some("launchd") => env::var("HERDR_WORLD_LAUNCHCTL").ok().map(PathBuf::from),
+        _ => None,
+    };
     let mutation_reason = if config_path.is_none() || state_dir.is_none() {
         Some("Remote access is read-only for this standalone or development launch; use the plugin-managed launch to apply settings safely.".to_string())
     } else if controller_node.is_none() || controller_script.is_none() {
         Some("This bridge has no controller-owned restart boundary, so settings mutation is disabled for safety.".to_string())
+    } else if !matches!(
+        controller_mode.as_deref(),
+        Some("systemd-user" | "launchd" | "fallback")
+    ) {
+        Some("This bridge does not have a supervisor-owned controller boundary, so settings mutation is disabled for safety.".to_string())
     } else if !controller_node
         .as_ref()
         .is_some_and(|path| path.is_absolute())
@@ -440,6 +512,14 @@ fn management_state_from_environment() -> ManagementState {
             .is_some_and(|path| path.is_file())
     {
         Some("The controller restart boundary is unavailable; settings mutation is disabled until the managed launch is repaired.".to_string())
+    } else if matches!(controller_mode.as_deref(), Some("systemd-user" | "launchd"))
+        && !controller_launcher
+            .as_ref()
+            .is_some_and(|path| path.is_absolute() && path.is_file())
+    {
+        Some("The supervisor controller launcher is unavailable; settings mutation is disabled until the managed launch is repaired.".to_string())
+    } else if controller_mode.as_deref() == Some("fallback") && cfg!(not(unix)) {
+        Some("This fallback launch cannot establish an independent controller process on this platform; settings mutation is disabled.".to_string())
     } else {
         None
     };
@@ -448,6 +528,8 @@ fn management_state_from_environment() -> ManagementState {
         state_dir,
         controller_node,
         controller_script,
+        controller_mode,
+        controller_launcher,
         mutation_reason,
     }
 }
@@ -1271,7 +1353,6 @@ pub(crate) enum BridgeError {
 enum UploadError {
     BadRequest(String),
     Conflict { name: String, path: String },
-    Forbidden(String),
     TooLarge,
     Io(io::Error),
 }
@@ -1351,10 +1432,6 @@ impl IntoResponse for UploadError {
                     "name": name,
                     "path": path,
                 }),
-            ),
-            Self::Forbidden(message) => (
-                StatusCode::FORBIDDEN,
-                serde_json::json!({ "error": message }),
             ),
             Self::TooLarge => (
                 StatusCode::PAYLOAD_TOO_LARGE,
@@ -1632,6 +1709,19 @@ async fn run_server(options: BridgeOptions) -> io::Result<()> {
         configured_label: options.configured_label.clone(),
     };
     spawn_agent_activity_watcher(state.clone());
+    let app = bridge_router(state, options.static_dir.clone());
+    let bind = listener_bind_address(&options.host, options.port);
+    let listener = tokio::net::TcpListener::bind(&bind).await?;
+    info!(url = %format!("http://{bind}"), "Herdr World bridge listening");
+    axum::serve(
+        listener,
+        app.into_make_service_with_connect_info::<SocketAddr>(),
+    )
+    .await
+}
+
+fn bridge_router(state: BridgeState, static_dir: PathBuf) -> Router {
+    let request_policy = state.request_policy.clone();
     let agent_activity_routes = Router::new().route(
         "/api/agent-activity",
         get(agent_activity_list_handler).options(preflight_handler),
@@ -1690,11 +1780,14 @@ async fn run_server(options: BridgeOptions) -> io::Result<()> {
             "/api/launcher-presets/launch",
             post(launcher_preset_launch_handler).options(preflight_handler),
         );
+    let auth_session_route = post(auth_session_handler)
+        .options(preflight_handler)
+        .layer(DefaultBodyLimit::max(MAX_PASSWORD_REQUEST_BYTES));
     let observability_routes = crate::observability_http::routes(
         state.request_policy.clone(),
         state.observability.clone(),
     );
-    let static_routes = static_routes(options.static_dir.clone());
+    let static_routes = static_routes(static_dir);
     let app = Router::new()
         .merge(agent_activity_routes)
         .merge(agent_pins_routes)
@@ -1713,15 +1806,13 @@ async fn run_server(options: BridgeOptions) -> io::Result<()> {
             "/api/auth/status",
             get(auth_status_handler).options(preflight_handler),
         )
-        .route(
-            "/api/auth/session",
-            post(auth_session_handler).options(preflight_handler),
-        )
+        .route("/api/auth/session", auth_session_route)
         .route(
             "/api/local/remote-access",
             get(remote_access_status_handler)
                 .post(remote_access_apply_handler)
-                .options(preflight_handler),
+                .options(preflight_handler)
+                .layer(DefaultBodyLimit::max(MAX_REMOTE_ACCESS_REQUEST_BYTES)),
         )
         .route(
             "/api/command",
@@ -1741,23 +1832,16 @@ async fn run_server(options: BridgeOptions) -> io::Result<()> {
         .route("/ws/terminal", get(terminal_ws_handler))
         .merge(static_routes)
         .layer(middleware::from_fn_with_state(
-            request_policy.clone(),
-            add_security_headers,
-        ))
-        .layer(middleware::from_fn_with_state(
             state.clone(),
             bridge_access_middleware,
         ))
+        .layer(middleware::from_fn_with_state(
+            request_policy.clone(),
+            add_security_headers,
+        ))
         .layer(DefaultBodyLimit::max(MAX_UPLOAD_BYTES))
         .with_state(state);
-    let bind = format!("{}:{}", options.host, options.port);
-    let listener = tokio::net::TcpListener::bind(&bind).await?;
-    info!(url = %format!("http://{bind}"), "Herdr World bridge listening");
-    axum::serve(
-        listener,
-        app.into_make_service_with_connect_info::<SocketAddr>(),
-    )
-    .await
+    app
 }
 
 fn static_routes<S>(static_dir: PathBuf) -> Router<S>
@@ -1789,6 +1873,15 @@ where
                 .service(ServeDir::new(static_dir).fallback(navigation_fallback)),
         )
         .layer(middleware::from_fn(add_static_cache_headers))
+}
+
+fn listener_bind_address(host: &str, port: u16) -> String {
+    let host = host.trim().trim_start_matches('[').trim_end_matches(']');
+    if host.contains(':') {
+        format!("[{host}]:{port}")
+    } else {
+        format!("{host}:{port}")
+    }
 }
 
 fn is_world_navigation_path(path: &str) -> bool {
@@ -1835,7 +1928,11 @@ async fn add_security_headers(
     request: AxumRequest,
     next: Next,
 ) -> Response {
-    let cors_origin = cors_origin_header(request.headers(), &policy);
+    let peer = request
+        .extensions()
+        .get::<ConnectInfo<SocketAddr>>()
+        .map(|info| info.0);
+    let cors_origin = cors_origin_header_from_peer(request.headers(), &policy, peer);
     let mut response = next.run(request).await;
     let headers = response.headers_mut();
     headers.insert(
@@ -1862,7 +1959,13 @@ async fn bridge_access_middleware(
         return next.run(request).await;
     }
 
-    if let Err(error) = ensure_allowed_request(request.headers(), &state.request_policy) {
+    let peer = request
+        .extensions()
+        .get::<ConnectInfo<SocketAddr>>()
+        .map(|info| info.0);
+    if let Err(error) =
+        ensure_allowed_request_from_peer(request.headers(), &state.request_policy, peer)
+    {
         return error.into_response();
     }
     if request.method() == axum::http::Method::OPTIONS {
@@ -1870,10 +1973,6 @@ async fn bridge_access_middleware(
     }
 
     if !is_public_bootstrap_path(path) {
-        let peer = request
-            .extensions()
-            .get::<ConnectInfo<SocketAddr>>()
-            .map(|info| info.0);
         if !state.auth.request_is_authorized(request.headers(), peer) {
             return unauthorized_response();
         }
@@ -1909,7 +2008,7 @@ fn local_management_allowed(
     policy: &RequestPolicy,
     peer: SocketAddr,
 ) -> Result<(), BridgeError> {
-    ensure_allowed_request(headers, policy)?;
+    ensure_allowed_request_from_peer(headers, policy, Some(peer))?;
     if !BridgeAuth::local_peer_allowed(Some(peer)) {
         return Err(BridgeError::Forbidden(
             "local management requires an actual loopback TCP peer".into(),
@@ -1918,12 +2017,180 @@ fn local_management_allowed(
     Ok(())
 }
 
+const CONTROLLER_ENVIRONMENT: &[&str] = &[
+    "HOME",
+    "XDG_CONFIG_HOME",
+    "XDG_DATA_HOME",
+    "XDG_STATE_HOME",
+    "HERDR_CONFIG_PATH",
+    "TMPDIR",
+    "LANG",
+    "LC_ALL",
+    "PATH",
+    "HERDR_PLUGIN_CONFIG_DIR",
+    "HERDR_PLUGIN_STATE_DIR",
+    "HERDR_SOCKET_PATH",
+    "HERDR_BIN_PATH",
+    "HERDR_WORLD_SETUP",
+    "HERDR_WORLD_PLUGIN_SERVICE_ID",
+    "HERDR_WORLD_CONTROLLER",
+    "HERDR_WORLD_NODE_PATH",
+    "HERDR_WORLD_CONTROLLER_MODE",
+    "HERDR_WORLD_SYSTEMCTL",
+    "HERDR_WORLD_LAUNCHCTL",
+    "HERDR_WORLD_SYSTEMD_RUN",
+];
+
+fn controller_environment_arguments() -> Vec<String> {
+    CONTROLLER_ENVIRONMENT
+        .iter()
+        .filter_map(|name| env::var(name).ok().map(|value| format!("{name}={value}")))
+        .collect()
+}
+
+fn apply_controller_environment(command: &mut Command) {
+    command.env_clear();
+    for value in controller_environment_arguments() {
+        if let Some((name, value)) = value.split_once('=') {
+            command.env(name, value);
+        }
+    }
+}
+
+fn spawn_management_controller(
+    management: &ManagementState,
+    request_path: &Path,
+) -> io::Result<()> {
+    let node = management
+        .controller_node
+        .as_deref()
+        .ok_or_else(|| io::Error::new(ErrorKind::NotFound, "controller node is unavailable"))?;
+    let controller = management
+        .controller_script
+        .as_deref()
+        .ok_or_else(|| io::Error::new(ErrorKind::NotFound, "controller script is unavailable"))?;
+    let mode = management.controller_mode.as_deref().unwrap_or_default();
+    let sequence = CONTROLLER_TEMP_COUNTER.fetch_add(1, Ordering::AcqRel);
+    match mode {
+        "systemd-user" => {
+            let launcher = management
+                .controller_launcher
+                .as_deref()
+                .ok_or_else(|| io::Error::new(ErrorKind::NotFound, "systemd-run is unavailable"))?;
+            let unit = format!(
+                "herdr-world-apply-{}-{sequence}.service",
+                std::process::id()
+            );
+            let mut command = Command::new(launcher);
+            command
+                .arg("--user")
+                .arg("--unit")
+                .arg(unit)
+                .arg("--collect")
+                .arg("--no-block");
+            for value in controller_environment_arguments() {
+                command.arg("--setenv").arg(value);
+            }
+            command.arg("--setenv").arg(format!(
+                "HERDR_WORLD_APPLY_GRACE_MS={CONTROLLER_HANDOFF_GRACE_MS}"
+            ));
+            command
+                .arg("--")
+                .arg(node)
+                .arg(controller)
+                .arg("apply")
+                .arg(request_path)
+                .stdin(Stdio::null())
+                .stdout(Stdio::null())
+                .stderr(Stdio::null());
+            let mut child = command.spawn()?;
+            let status = child.wait()?;
+            if status.success() {
+                Ok(())
+            } else {
+                Err(io::Error::new(
+                    ErrorKind::Other,
+                    "systemd-run did not start the controller",
+                ))
+            }
+        }
+        "launchd" => {
+            let launcher = management
+                .controller_launcher
+                .as_deref()
+                .ok_or_else(|| io::Error::new(ErrorKind::NotFound, "launchctl is unavailable"))?;
+            let label = format!(
+                "io.ivoryheart.herdr-world.apply.{}-{sequence}",
+                std::process::id()
+            );
+            let mut command = Command::new(launcher);
+            command
+                .arg("submit")
+                .arg("-l")
+                .arg(label)
+                .arg("--")
+                .arg("/usr/bin/env");
+            for value in controller_environment_arguments() {
+                command.arg(value);
+            }
+            command.arg(format!(
+                "HERDR_WORLD_APPLY_GRACE_MS={CONTROLLER_HANDOFF_GRACE_MS}"
+            ));
+            command
+                .arg(node)
+                .arg(controller)
+                .arg("apply")
+                .arg(request_path)
+                .stdin(Stdio::null())
+                .stdout(Stdio::null())
+                .stderr(Stdio::null());
+            let mut child = command.spawn()?;
+            let status = child.wait()?;
+            if status.success() {
+                Ok(())
+            } else {
+                Err(io::Error::new(
+                    ErrorKind::Other,
+                    "launchctl did not submit the controller",
+                ))
+            }
+        }
+        "fallback" => {
+            let mut command = Command::new(node);
+            apply_controller_environment(&mut command);
+            command.env("HERDR_WORLD_APPLY_GRACE_MS", CONTROLLER_HANDOFF_GRACE_MS);
+            command
+                .arg(controller)
+                .arg("apply")
+                .arg(request_path)
+                .stdin(Stdio::null())
+                .stdout(Stdio::null())
+                .stderr(Stdio::null());
+            #[cfg(unix)]
+            unsafe {
+                command.pre_exec(|| {
+                    if libc::setsid() == -1 {
+                        Err(io::Error::last_os_error())
+                    } else {
+                        Ok(())
+                    }
+                });
+            }
+            command.spawn().map(|_| ())
+        }
+        _ => Err(io::Error::new(
+            ErrorKind::PermissionDenied,
+            "controller supervisor boundary is unavailable",
+        )),
+    }
+}
+
 async fn auth_status_handler(
     State(state): State<BridgeState>,
     ConnectInfo(peer): ConnectInfo<SocketAddr>,
     headers: HeaderMap,
 ) -> Result<Json<serde_json::Value>, BridgeError> {
-    ensure_allowed_request(&headers, &state.request_policy)?;
+    ensure_allowed_request_from_peer(&headers, &state.request_policy, Some(peer))?;
     Ok(Json(serde_json::json!({
         "required": state.auth.required(),
         "authenticated": state.auth.request_is_authorized(&headers, Some(peer)),
@@ -1937,10 +2204,12 @@ async fn auth_session_handler(
     headers: HeaderMap,
     body: Bytes,
 ) -> Result<Json<PasswordSessionResponse>, Response> {
-    if let Err(error) = ensure_allowed_request(&headers, &state.request_policy) {
+    if let Err(error) =
+        ensure_allowed_request_from_peer(&headers, &state.request_policy, Some(peer))
+    {
         return Err(error.into_response());
     }
-    if body.len() > MAX_PASSWORD_BYTES + 256 {
+    if body.len() > MAX_PASSWORD_REQUEST_BYTES {
         return Err(
             BridgeError::BadRequest("password request is too large".into()).into_response(),
         );
@@ -2059,23 +2328,16 @@ async fn remote_access_apply_handler(
                 .password
                 .as_deref()
                 .ok_or_else(|| BridgeError::BadRequest("a password is required".into()))?;
-            request.remote_access.password_hash =
-                Some(hash_password(password).map_err(BridgeError::BadRequest)?);
+            request.remote_access.password_hash = Some(
+                hash_password_async(password)
+                    .await
+                    .map_err(BridgeError::BadRequest)?,
+            );
         }
     }
     validate_remote_access_draft(&mut request.remote_access)?;
 
     let Some(state_dir) = state.management.state_dir.as_deref() else {
-        return Err(BridgeError::Forbidden(
-            "remote access mutation is unavailable".into(),
-        ));
-    };
-    let Some(node) = state.management.controller_node.as_deref() else {
-        return Err(BridgeError::Forbidden(
-            "remote access mutation is unavailable".into(),
-        ));
-    };
-    let Some(controller) = state.management.controller_script.as_deref() else {
         return Err(BridgeError::Forbidden(
             "remote access mutation is unavailable".into(),
         ));
@@ -2091,15 +2353,7 @@ async fn remote_access_apply_handler(
     }))
     .map_err(|error| BridgeError::Protocol(error.to_string()))?;
     write_restrictive_file(&request_path, &content)?;
-    let spawn_result = Command::new(node)
-        .arg(controller)
-        .arg("apply")
-        .arg(&request_path)
-        .stdin(Stdio::null())
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .spawn();
-    if let Err(error) = spawn_result {
+    if let Err(error) = spawn_management_controller(&state.management, &request_path) {
         let _ = std::fs::remove_file(&request_path);
         return Err(BridgeError::Io(error));
     }
@@ -2128,17 +2382,19 @@ fn write_restrictive_file(path: &Path, content: &[u8]) -> Result<(), BridgeError
 
 async fn preflight_handler(
     State(state): State<BridgeState>,
+    ConnectInfo(peer): ConnectInfo<SocketAddr>,
     headers: HeaderMap,
 ) -> Result<Response, BridgeError> {
-    preflight_response(&headers, &state.request_policy)
+    preflight_response_from_peer(&headers, &state.request_policy, Some(peer))
 }
 
-pub(crate) fn preflight_response(
+pub(crate) fn preflight_response_from_peer(
     headers: &HeaderMap,
     policy: &RequestPolicy,
+    peer: Option<SocketAddr>,
 ) -> Result<Response, BridgeError> {
-    ensure_allowed_request(headers, policy)?;
-    let Some(origin) = cors_origin_header(headers, policy) else {
+    ensure_allowed_request_from_peer(headers, policy, peer)?;
+    let Some(origin) = cors_origin_header_from_peer(headers, policy, peer) else {
         return Err(BridgeError::Forbidden(
             "cross-origin requests are not allowed".to_string(),
         ));
@@ -2153,9 +2409,18 @@ pub(crate) fn preflight_response(
     Ok(response)
 }
 
+#[cfg(test)]
 fn cors_origin_header(headers: &HeaderMap, policy: &RequestPolicy) -> Option<HeaderValue> {
+    cors_origin_header_from_peer(headers, policy, None)
+}
+
+fn cors_origin_header_from_peer(
+    headers: &HeaderMap,
+    policy: &RequestPolicy,
+    peer: Option<SocketAddr>,
+) -> Option<HeaderValue> {
     let origin = headers.get(ORIGIN)?;
-    if request_allowed(headers, policy) {
+    if request_allowed_from_peer(headers, policy, peer) {
         Some(origin.clone())
     } else {
         None
@@ -2353,11 +2618,12 @@ const CAPABILITY_FEATURES: &[&str] = &[
     "observability_extension",
 ];
 
-pub(crate) fn ensure_allowed_request(
+fn ensure_allowed_request_from_peer(
     headers: &HeaderMap,
     policy: &RequestPolicy,
+    peer: Option<SocketAddr>,
 ) -> Result<(), BridgeError> {
-    if request_allowed(headers, policy) {
+    if request_allowed_from_peer(headers, policy, peer) {
         return Ok(());
     }
     Err(BridgeError::Forbidden(
@@ -2365,24 +2631,54 @@ pub(crate) fn ensure_allowed_request(
     ))
 }
 
+#[cfg(test)]
 fn request_allowed(headers: &HeaderMap, policy: &RequestPolicy) -> bool {
-    request_host_allowed(headers, policy) && request_origin_allowed(headers, policy)
+    request_allowed_from_peer(headers, policy, None)
 }
 
-fn request_host_allowed(headers: &HeaderMap, policy: &RequestPolicy) -> bool {
+fn request_allowed_from_peer(
+    headers: &HeaderMap,
+    policy: &RequestPolicy,
+    peer: Option<SocketAddr>,
+) -> bool {
+    request_host_allowed_from_peer(headers, policy, peer)
+        && request_origin_allowed_from_peer(headers, policy, peer)
+}
+
+fn request_host_allowed_from_peer(
+    headers: &HeaderMap,
+    policy: &RequestPolicy,
+    peer: Option<SocketAddr>,
+) -> bool {
     let Some(host) = headers.get(HOST).and_then(|host| host.to_str().ok()) else {
         return false;
     };
-    host_authority_allowed(host, policy)
+    host_authority_allowed_from_peer(host, policy, peer)
 }
 
+#[cfg(test)]
 fn host_authority_allowed(authority: &str, policy: &RequestPolicy) -> bool {
+    host_authority_allowed_from_peer(authority, policy, None)
+}
+
+fn host_authority_allowed_from_peer(
+    authority: &str,
+    policy: &RequestPolicy,
+    peer: Option<SocketAddr>,
+) -> bool {
     let host = host_part(authority);
     if host.is_empty() {
         return false;
     }
 
     if is_loopback_bind_host(&policy.bind_host) && is_loopback_host(host) {
+        return true;
+    }
+
+    if peer.is_some_and(|address| address.ip().is_loopback())
+        && is_loopback_host(host)
+        && authority_port_matches(authority, policy.bind_port)
+    {
         return true;
     }
 
@@ -2407,7 +2703,16 @@ fn host_authority_allowed(authority: &str, policy: &RequestPolicy) -> bool {
     false
 }
 
+#[cfg(test)]
 fn request_origin_allowed(headers: &HeaderMap, policy: &RequestPolicy) -> bool {
+    request_origin_allowed_from_peer(headers, policy, None)
+}
+
+fn request_origin_allowed_from_peer(
+    headers: &HeaderMap,
+    policy: &RequestPolicy,
+    peer: Option<SocketAddr>,
+) -> bool {
     let Some(origin) = headers.get(ORIGIN) else {
         return true;
     };
@@ -2425,7 +2730,11 @@ fn request_origin_allowed(headers: &HeaderMap, policy: &RequestPolicy) -> bool {
         .allowed_origins
         .iter()
         .any(|allowed| allowed.eq_ignore_ascii_case(origin));
-    if !is_loopback_bind_host(&policy.bind_host) {
+    if !is_loopback_bind_host(&policy.bind_host)
+        && !(peer.is_some_and(|address| address.ip().is_loopback())
+            && is_loopback_authority(origin_authority)
+            && is_loopback_authority(host))
+    {
         return explicitly_allowed;
     }
 
@@ -2859,15 +3168,6 @@ impl LauncherPresetError {
         }
     }
 
-    fn forbidden(message: impl Into<String>) -> Self {
-        Self {
-            status: StatusCode::FORBIDDEN,
-            code: "forbidden",
-            message: message.into(),
-            herdr_code: None,
-        }
-    }
-
     fn not_found(message: impl Into<String>) -> Self {
         Self {
             status: StatusCode::NOT_FOUND,
@@ -2903,14 +3203,6 @@ impl LauncherPresetError {
             herdr_code: Some(code),
         }
     }
-
-    fn from_request_policy_error(err: BridgeError) -> Self {
-        match err {
-            BridgeError::Forbidden(message) => Self::forbidden(message),
-            BridgeError::BadRequest(message) => Self::invalid(message),
-            other => Self::invalid(other.to_string()),
-        }
-    }
 }
 
 impl IntoResponse for LauncherPresetError {
@@ -2928,10 +3220,8 @@ impl IntoResponse for LauncherPresetError {
 
 async fn command_handler(
     State(state): State<BridgeState>,
-    headers: HeaderMap,
     Json(body): Json<CommandRequest>,
 ) -> Result<Json<serde_json::Value>, BridgeError> {
-    ensure_allowed_request(&headers, &state.request_policy)?;
     if !ALLOWED_COMMANDS.contains(&body.method.as_str()) {
         return Err(BridgeError::Forbidden(format!(
             "command not allowed: {}",
@@ -2989,19 +3279,14 @@ async fn command_handler(
 
 async fn launcher_presets_handler(
     State(state): State<BridgeState>,
-    headers: HeaderMap,
 ) -> Result<Json<crate::launcher_presets::LauncherPresetsResponse>, BridgeError> {
-    ensure_allowed_request(&headers, &state.request_policy)?;
     Ok(Json(state.launcher_presets.response()))
 }
 
 async fn launcher_preset_launch_handler(
     State(state): State<BridgeState>,
-    headers: HeaderMap,
     body: Bytes,
 ) -> Result<Json<LauncherPresetLaunchResponse>, LauncherPresetError> {
-    ensure_allowed_request(&headers, &state.request_policy)
-        .map_err(LauncherPresetError::from_request_policy_error)?;
     let body = parse_launcher_preset_launch_request(&body)?;
     let preset = state
         .launcher_presets
@@ -3741,10 +4026,8 @@ fn default_workspace_label_from_panes<'a>(
 
 async fn selection_handler(
     State(state): State<BridgeState>,
-    headers: HeaderMap,
     Json(body): Json<SelectionRequest>,
 ) -> Result<Json<serde_json::Value>, BridgeError> {
-    ensure_allowed_request(&headers, &state.request_policy)?;
     let pane_id = body.pane_id.trim();
     if pane_id.is_empty() {
         return Err(BridgeError::BadRequest("missing pane_id".to_string()));
@@ -3779,8 +4062,6 @@ async fn upload_handler(
     headers: HeaderMap,
     body: Bytes,
 ) -> Result<Json<UploadResponse>, UploadError> {
-    ensure_allowed_request(&headers, &state.request_policy)
-        .map_err(|err| UploadError::Forbidden(err.to_string()))?;
     if body.len() > MAX_UPLOAD_BYTES {
         return Err(UploadError::TooLarge);
     }
@@ -3874,11 +4155,7 @@ async fn upload_handler(
     Ok(Json(response))
 }
 
-async fn snapshot_handler(
-    State(state): State<BridgeState>,
-    headers: HeaderMap,
-) -> Result<Json<Snapshot>, BridgeError> {
-    ensure_allowed_request(&headers, &state.request_policy)?;
+async fn snapshot_handler(State(state): State<BridgeState>) -> Result<Json<Snapshot>, BridgeError> {
     let api_state = state.clone();
     let session_snapshot = tokio::task::spawn_blocking(move || {
         match api_request(
@@ -3977,9 +4254,7 @@ fn is_default_tab_label(label: &str) -> bool {
 
 async fn capabilities_handler(
     State(state): State<BridgeState>,
-    headers: HeaderMap,
 ) -> Result<Json<Capabilities>, BridgeError> {
-    ensure_allowed_request(&headers, &state.request_policy)?;
     let observability = state
         .observability
         .descriptor()
@@ -4012,9 +4287,7 @@ async fn capabilities_handler(
 
 async fn agent_activity_list_handler(
     State(state): State<BridgeState>,
-    headers: HeaderMap,
 ) -> Result<Json<AgentActivityListResponse>, BridgeError> {
-    ensure_allowed_request(&headers, &state.request_policy)?;
     let list_state = state.clone();
     let response = tokio::task::spawn_blocking(move || {
         let panes = current_panes(&list_state.api)?;
@@ -4028,9 +4301,7 @@ async fn agent_activity_list_handler(
 
 async fn agent_pins_list_handler(
     State(state): State<BridgeState>,
-    headers: HeaderMap,
 ) -> Result<Json<AgentPinsListResponse>, BridgeError> {
-    ensure_allowed_request(&headers, &state.request_policy)?;
     Ok(Json(
         run_store_task(state, move |state| {
             let panes = current_panes(&state.api)?;
@@ -4043,9 +4314,7 @@ async fn agent_pins_list_handler(
 async fn agent_pins_pin_handler(
     State(state): State<BridgeState>,
     AxumPath(pane_id): AxumPath<String>,
-    headers: HeaderMap,
 ) -> Result<Json<AgentPinsListResponse>, BridgeError> {
-    ensure_allowed_request(&headers, &state.request_policy)?;
     let event_pane_id = pane_id.clone();
     let response = run_store_task(state.clone(), move |state| {
         let panes = current_panes(&state.api)?;
@@ -4059,9 +4328,7 @@ async fn agent_pins_pin_handler(
 async fn agent_pins_unpin_handler(
     State(state): State<BridgeState>,
     AxumPath(pane_id): AxumPath<String>,
-    headers: HeaderMap,
 ) -> Result<Json<AgentPinsListResponse>, BridgeError> {
-    ensure_allowed_request(&headers, &state.request_policy)?;
     let event_pane_id = pane_id.clone();
     let response = run_store_task(state.clone(), move |state| {
         let panes = current_panes(&state.api)?;
@@ -4075,9 +4342,7 @@ async fn agent_pins_unpin_handler(
 async fn notes_list_handler(
     State(state): State<BridgeState>,
     Query(query): Query<NotesListQuery>,
-    headers: HeaderMap,
 ) -> Result<Json<NotesListResponse>, BridgeError> {
-    ensure_allowed_request(&headers, &state.request_policy)?;
     Ok(Json(
         run_store_task(state, move |state| {
             let panes = current_panes(&state.api)?;
@@ -4089,10 +4354,8 @@ async fn notes_list_handler(
 
 async fn notes_create_handler(
     State(state): State<BridgeState>,
-    headers: HeaderMap,
     Json(body): Json<CreateNoteRequest>,
 ) -> Result<Json<NoteResponse>, BridgeError> {
-    ensure_allowed_request(&headers, &state.request_policy)?;
     let note = run_store_task(state.clone(), move |state| {
         let panes = current_panes(&state.api)?;
         Ok(state.notes.create(body, &panes)?)
@@ -4105,10 +4368,8 @@ async fn notes_create_handler(
 async fn notes_update_handler(
     State(state): State<BridgeState>,
     AxumPath(note_id): AxumPath<String>,
-    headers: HeaderMap,
     Json(body): Json<UpdateNoteRequest>,
 ) -> Result<Json<NoteResponse>, BridgeError> {
-    ensure_allowed_request(&headers, &state.request_policy)?;
     let note = run_store_task(state.clone(), move |state| {
         let panes = current_panes(&state.api)?;
         Ok(state.notes.update(&note_id, body, &panes)?)
@@ -4121,10 +4382,8 @@ async fn notes_update_handler(
 async fn notes_attach_handler(
     State(state): State<BridgeState>,
     AxumPath(note_id): AxumPath<String>,
-    headers: HeaderMap,
     Json(body): Json<AttachNoteRequest>,
 ) -> Result<Json<NoteResponse>, BridgeError> {
-    ensure_allowed_request(&headers, &state.request_policy)?;
     let note = run_store_task(state.clone(), move |state| {
         let panes = current_panes(&state.api)?;
         Ok(state.notes.attach(&note_id, body, &panes)?)
@@ -4137,10 +4396,8 @@ async fn notes_attach_handler(
 async fn notes_detach_handler(
     State(state): State<BridgeState>,
     AxumPath(note_id): AxumPath<String>,
-    headers: HeaderMap,
     Json(body): Json<RevisionRequest>,
 ) -> Result<Json<NoteResponse>, BridgeError> {
-    ensure_allowed_request(&headers, &state.request_policy)?;
     let note = run_store_task(state.clone(), move |state| {
         let panes = current_panes(&state.api)?;
         Ok(state.notes.detach(&note_id, body, &panes)?)
@@ -4153,10 +4410,8 @@ async fn notes_detach_handler(
 async fn notes_archive_handler(
     State(state): State<BridgeState>,
     AxumPath(note_id): AxumPath<String>,
-    headers: HeaderMap,
     Json(body): Json<RevisionRequest>,
 ) -> Result<Json<NoteResponse>, BridgeError> {
-    ensure_allowed_request(&headers, &state.request_policy)?;
     let note = run_store_task(state.clone(), move |state| {
         let panes = current_panes(&state.api)?;
         Ok(state.notes.archive(&note_id, body, &panes)?)
@@ -4169,10 +4424,8 @@ async fn notes_archive_handler(
 async fn notes_restore_handler(
     State(state): State<BridgeState>,
     AxumPath(note_id): AxumPath<String>,
-    headers: HeaderMap,
     Json(body): Json<RevisionRequest>,
 ) -> Result<Json<NoteResponse>, BridgeError> {
-    ensure_allowed_request(&headers, &state.request_policy)?;
     let note = run_store_task(state.clone(), move |state| {
         let panes = current_panes(&state.api)?;
         Ok(state.notes.restore(&note_id, body, &panes)?)
@@ -4185,10 +4438,8 @@ async fn notes_restore_handler(
 async fn notes_delete_handler(
     State(state): State<BridgeState>,
     AxumPath(note_id): AxumPath<String>,
-    headers: HeaderMap,
     Json(body): Json<RevisionRequest>,
 ) -> Result<Json<NoteResponse>, BridgeError> {
-    ensure_allowed_request(&headers, &state.request_policy)?;
     let note = run_store_task(state.clone(), move |state| {
         let panes = current_panes(&state.api)?;
         Ok(state.notes.delete(&note_id, body, &panes)?)
@@ -4290,9 +4541,6 @@ async fn terminal_ws_handler(
     Query(query): Query<TerminalQuery>,
     headers: HeaderMap,
 ) -> Response {
-    if let Err(err) = ensure_allowed_request(&headers, &state.request_policy) {
-        return err.into_response();
-    }
     configure_websocket_protocol(ws, &headers)
         .on_upgrade(move |socket| handle_terminal_socket(socket, state, query))
         .into_response()
@@ -4303,9 +4551,6 @@ async fn events_ws_handler(
     State(state): State<BridgeState>,
     headers: HeaderMap,
 ) -> Response {
-    if let Err(err) = ensure_allowed_request(&headers, &state.request_policy) {
-        return err.into_response();
-    }
     configure_websocket_protocol(ws, &headers)
         .on_upgrade(move |socket| handle_events_socket(socket, state))
         .into_response()
@@ -4316,9 +4561,6 @@ async fn activity_ws_handler(
     State(state): State<BridgeState>,
     headers: HeaderMap,
 ) -> Response {
-    if let Err(err) = ensure_allowed_request(&headers, &state.request_policy) {
-        return err.into_response();
-    }
     configure_websocket_protocol(ws, &headers)
         .on_upgrade(move |socket| handle_activity_socket(socket, state))
         .into_response()
@@ -4329,9 +4571,6 @@ async fn ui_events_ws_handler(
     State(state): State<BridgeState>,
     headers: HeaderMap,
 ) -> Response {
-    if let Err(err) = ensure_allowed_request(&headers, &state.request_policy) {
-        return err.into_response();
-    }
     configure_websocket_protocol(ws, &headers)
         .on_upgrade(move |socket| handle_ui_events_socket(socket, state))
         .into_response()
@@ -5617,6 +5856,7 @@ mod tests {
     use axum::body::Body;
     use axum::http::Request as HttpRequest;
     use flate2::read::GzDecoder;
+    use std::future::IntoFuture;
     use std::io::Read;
     use tower::ServiceExt;
 
@@ -6973,12 +7213,31 @@ mod tests {
         let remote_peer = "192.0.2.55:51234".parse().unwrap();
         let localhost = origin_headers("localhost:4000", None);
         assert!(!request_allowed(&localhost, &policy));
+        assert!(!request_allowed_from_peer(
+            &localhost,
+            &policy,
+            Some(remote_peer)
+        ));
         assert!(local_management_allowed(&localhost, &policy, remote_peer).is_err());
+        let loopback_peer = "127.0.0.1:51234".parse().unwrap();
+        assert!(request_allowed_from_peer(
+            &localhost,
+            &policy,
+            Some(loopback_peer)
+        ));
+        assert!(local_management_allowed(&localhost, &policy, loopback_peer).is_ok());
+
+        let mut forwarded = localhost.clone();
+        forwarded.insert("x-forwarded-for", "127.0.0.1".parse().unwrap());
+        assert!(!request_allowed_from_peer(
+            &forwarded,
+            &policy,
+            Some(remote_peer)
+        ));
 
         let accepted_host = origin_headers("192.0.2.10:4000", None);
         assert!(request_allowed(&accepted_host, &policy));
         assert!(local_management_allowed(&accepted_host, &policy, remote_peer).is_err());
-        let loopback_peer = "127.0.0.1:51234".parse().unwrap();
         assert!(local_management_allowed(&accepted_host, &policy, loopback_peer).is_ok());
 
         let auth = BridgeAuth::new(Some("not-a-valid-password-hash".to_string()));
@@ -7022,6 +7281,226 @@ mod tests {
             .tokens
             .insert(expired.clone(), Instant::now() - Duration::from_secs(1));
         assert!(!auth.token_is_valid(&expired));
+    }
+
+    #[tokio::test]
+    async fn password_session_transport_rejects_oversized_streams_before_body_extraction() {
+        let handler_called = Arc::new(AtomicBool::new(false));
+        let handler_called_for_route = handler_called.clone();
+        let app = Router::new().route(
+            "/api/auth/session",
+            post(move |_: Bytes| async move {
+                handler_called_for_route.store(true, Ordering::Release);
+                StatusCode::OK
+            })
+            .layer(DefaultBodyLimit::max(MAX_PASSWORD_REQUEST_BYTES)),
+        );
+        let request = HttpRequest::builder()
+            .method("POST")
+            .uri("/api/auth/session")
+            .header("content-type", "application/json")
+            .body(Body::from(vec![b'x'; MAX_PASSWORD_REQUEST_BYTES + 1]))
+            .unwrap();
+        let response = app.oneshot(request).await.unwrap();
+
+        assert_eq!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
+        assert!(!handler_called.load(Ordering::Acquire));
+    }
+
+    #[tokio::test]
+    async fn authentication_errors_keep_the_allowed_cross_origin_headers() {
+        let policy = RequestPolicy {
+            bind_host: "0.0.0.0".into(),
+            bind_port: 4000,
+            allowed_hosts: vec!["192.0.2.10".into()],
+            allowed_origins: vec!["https://world.example.test".into()],
+            allowed_connect_origins: Vec::new(),
+            allowed_connect_sources: Vec::new(),
+        };
+        let app = Router::new()
+            .route("/api/protected", get(|| async { unauthorized_response() }))
+            .layer(middleware::from_fn_with_state(policy, add_security_headers));
+        let request = HttpRequest::builder()
+            .uri("/api/protected")
+            .header(HOST, "192.0.2.10:4000")
+            .header(ORIGIN, "https://world.example.test")
+            .body(Body::empty())
+            .unwrap();
+
+        let response = app.oneshot(request).await.unwrap();
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+        assert_eq!(
+            response
+                .headers()
+                .get(ACCESS_CONTROL_ALLOW_ORIGIN)
+                .and_then(|value| value.to_str().ok()),
+            Some("https://world.example.test")
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn running_bridge_management_endpoint_hands_off_to_an_independent_controller() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let root = std::env::temp_dir().join(format!(
+            "herdr-world-management-http-test-{}",
+            CONTROLLER_TEMP_COUNTER.fetch_add(1, Ordering::AcqRel)
+        ));
+        let config_dir = root.join("config");
+        let state_dir = root.join("state");
+        let notes_dir = root.join("notes");
+        let pins_dir = root.join("pins");
+        let upload_dir = root.join("uploads");
+        let controller = root.join("controller.sh");
+        let marker = root.join("controller.marker");
+        std::fs::create_dir_all(&config_dir).unwrap();
+        std::fs::create_dir_all(&state_dir).unwrap();
+        std::fs::write(
+            &controller,
+            format!("#!/bin/sh\nprintf '%s' \"$2\" > '{}'\n", marker.display()),
+        )
+        .unwrap();
+        std::fs::set_permissions(&controller, std::fs::Permissions::from_mode(0o700)).unwrap();
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let policy = RequestPolicy {
+            bind_host: "127.0.0.1".into(),
+            bind_port: address.port(),
+            allowed_hosts: Vec::new(),
+            allowed_origins: Vec::new(),
+            allowed_connect_origins: Vec::new(),
+            allowed_connect_sources: Vec::new(),
+        };
+        let (ui_event_tx, _) = tokio::sync::broadcast::channel(8);
+        let (activity_tx, _) = tokio::sync::broadcast::channel(8);
+        let state = BridgeState {
+            api: ApiClient::for_socket_path(root.join("unused-herdr.sock")),
+            client_socket_path: root.join("unused-client.sock"),
+            request_policy: policy,
+            auth: Arc::new(BridgeAuth::new(None)),
+            management: ManagementState {
+                config_path: Some(config_dir.join("config.json")),
+                state_dir: Some(state_dir.clone()),
+                controller_node: Some(PathBuf::from("/bin/sh")),
+                controller_script: Some(controller),
+                controller_mode: Some("fallback".into()),
+                controller_launcher: None,
+                mutation_reason: None,
+            },
+            terminal_sessions: Arc::new(Mutex::new(TerminalSessions::default())),
+            selected_pane_id: Arc::new(Mutex::new(None)),
+            agent_activity: Arc::new(AgentActivityManager::new()),
+            agent_pins: Arc::new(AgentPinsManager::for_test(pins_dir, "session:test").unwrap()),
+            launcher_presets: Arc::new(LauncherPresetStore::load(None).unwrap()),
+            notes: Arc::new(NotesManager::for_test(notes_dir, "session:test").unwrap()),
+            observability: ObservabilityState::unavailable(),
+            ui_event_tx,
+            activity_tx,
+            upload_dir,
+            herdr_version: "0.8.2".into(),
+            terminal_protocol: PROTOCOL_VERSION,
+            configured_label: None,
+        };
+        let server = tokio::spawn(
+            axum::serve(
+                listener,
+                bridge_router(
+                    state,
+                    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../web"),
+                )
+                .into_make_service_with_connect_info::<SocketAddr>(),
+            )
+            .into_future(),
+        );
+
+        let response = reqwest::Client::new()
+            .post(format!(
+                "http://127.0.0.1:{}/api/local/remote-access",
+                address.port()
+            ))
+            .header(HOST, format!("127.0.0.1:{}", address.port()))
+            .json(&serde_json::json!({
+                "remote_access": {
+                    "enabled": true,
+                    "accepted_hosts": ["198.51.100.20"],
+                    "allowed_page_origins": ["https://world.example.test"],
+                    "allowed_bridge_origins": []
+                },
+                "password_action": "keep"
+            }))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::ACCEPTED);
+
+        for _ in 0..40 {
+            if marker.is_file() {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+        assert!(marker.is_file(), "controller did not receive the handoff");
+        let request_path = std::fs::read_to_string(&marker).unwrap();
+        let request = serde_json::from_str::<serde_json::Value>(
+            &std::fs::read_to_string(request_path).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(request["remote_access"]["enabled"], true);
+
+        server.abort();
+        let _ = server.await;
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn fallback_management_controller_has_an_independent_process_group() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let root = std::env::temp_dir().join(format!(
+            "herdr-world-controller-test-{}",
+            CONTROLLER_TEMP_COUNTER.fetch_add(1, Ordering::AcqRel)
+        ));
+        std::fs::create_dir_all(&root).unwrap();
+        let controller = root.join("controller.sh");
+        let marker = root.join("process-group");
+        let request = root.join("request.json");
+        std::fs::write(
+            &controller,
+            format!(
+                "#!/bin/sh\nps -o pgid= -p $$ | tr -d ' ' > {}\nprintf '%s' \"$2\" > {}\n",
+                marker.display(),
+                request.display()
+            ),
+        )
+        .unwrap();
+        std::fs::set_permissions(&controller, std::fs::Permissions::from_mode(0o700)).unwrap();
+        std::fs::write(&request, "{}").unwrap();
+        let management = ManagementState {
+            config_path: None,
+            state_dir: None,
+            controller_node: Some(PathBuf::from("/bin/sh")),
+            controller_script: Some(controller),
+            controller_mode: Some("fallback".into()),
+            controller_launcher: None,
+            mutation_reason: None,
+        };
+
+        spawn_management_controller(&management, &request).unwrap();
+        for _ in 0..20 {
+            if marker.is_file() {
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(25));
+        }
+        let process_group = std::fs::read_to_string(&marker).unwrap();
+        let parent_group = unsafe { libc::getpgrp() }.to_string();
+        assert!(!process_group.trim().is_empty());
+        assert_ne!(process_group.trim(), parent_group);
+        let _ = std::fs::remove_dir_all(root);
     }
 
     #[test]
@@ -7530,6 +8009,20 @@ mod tests {
         assert!(is_loopback_bind_host("localhost"));
         assert!(!is_loopback_bind_host("0.0.0.0"));
         assert!(!is_loopback_bind_host("192.0.2.10"));
+    }
+
+    #[test]
+    fn ipv6_listener_bind_address_uses_a_real_ipv6_socket_authority() {
+        assert_eq!(listener_bind_address("::", 8787), "[::]:8787");
+        assert_eq!(listener_bind_address("[::1]", 8787), "[::1]:8787");
+        assert_eq!(listener_bind_address("192.0.2.10", 8787), "192.0.2.10:8787");
+
+        if let Ok(listener) = std::net::TcpListener::bind(listener_bind_address("::1", 0)) {
+            assert!(listener
+                .local_addr()
+                .expect("IPv6 listener address")
+                .is_ipv6());
+        }
     }
 
     #[test]

--- a/docs/federation.md
+++ b/docs/federation.md
@@ -47,12 +47,12 @@ HOST=0.0.0.0 scripts/run-bridge.sh \
   --allow-origin http://host-a:8787
 ```
 
-Add `http://host-b:8787` in Settings → Bridge in the browser. `--allow-origin` on B authorizes the
+Add `http://host-b:8787` in Settings → Bridges in the browser. `--allow-origin` on B authorizes the
 page origin to call B. `--allow-connect-origin` on A adds B's HTTP and WebSocket origins to the CSP
 of the page A serves. Neither option is authentication. Never expose this configuration to an
 untrusted network.
 
-In Settings → Bridge, `Enable all` and `Disable all` are convenience actions for the saved browser
+In Settings → Bridges, `Enable all` and `Disable all` are convenience actions for the saved browser
 profiles. They only change which directly reachable profiles are admitted to the current Office
 view; each bridge still has its own capability probe, connection state, origin policy, and failure
 boundary. This is a downstream coordination affordance, not a fleet gateway or authentication
@@ -119,7 +119,7 @@ asset service or central gateway.
 ## Verification checklist
 
 - Load two compatible host profiles in one browser and confirm both appear in All-host scope.
-- Use Settings → Bridge → Enable all and confirm every saved profile is admitted, then disable one
+- Use Settings → Bridges → Enable all and confirm every saved profile is admitted, then disable one
   profile and confirm the remaining host stays navigable.
 - Type, send control input, resize/refit, and create/rename/move/close on each owning host.
 - Exercise desktop IME composition and cancellation, dismiss a menu/dialog to

--- a/docs/federation.md
+++ b/docs/federation.md
@@ -1,8 +1,9 @@
 # Operating federated Herdr World
 
 Herdr World uses one host-local bridge per Herdr runtime and direct browser federation. It has no
-central gateway, fleet controller, SSH manager, authentication layer, or RBAC. Every browser that a
-bridge admits has terminal-equivalent access to that Herdr runtime.
+central gateway, fleet controller, SSH manager, or RBAC. Each bridge can require its own optional
+password and issues bounded in-memory sessions. Every browser session that a bridge admits has
+terminal-equivalent access to that Herdr runtime.
 
 ## One host on loopback
 
@@ -37,7 +38,6 @@ Suppose the page is opened from `http://host-a:8787` and the browser must also c
 HOST=0.0.0.0 scripts/run-bridge.sh \
   --bridge-label "Host A" \
   --allow-host host-a \
-  --allow-origin http://host-a:8787 \
   --allow-connect-origin http://host-b:8787
 
 # host B: admits direct calls from the page served by host A
@@ -47,25 +47,26 @@ HOST=0.0.0.0 scripts/run-bridge.sh \
   --allow-origin http://host-a:8787
 ```
 
-Add `http://host-b:8787` in Settings → Bridges in the browser. `--allow-origin` on B authorizes the
-page origin to call B. `--allow-connect-origin` on A adds B's HTTP and WebSocket origins to the CSP
-of the page A serves. Neither option is authentication. Never expose this configuration to an
-untrusted network.
+Add `http://host-b:8787` in Settings → Network → Connections in the browser. `--allow-origin` on B
+authorizes the page origin to call B. `--allow-connect-origin` on A adds B's HTTP and WebSocket
+origins to the CSP of the page A serves. Neither option is authentication; configure password
+protection separately under Network → Allow connections. Never expose direct HTTP connections to
+an untrusted network.
 
-In Settings → Bridges, `Enable all` and `Disable all` are convenience actions for the saved browser
-profiles. They only change which directly reachable profiles are admitted to the current Office
-view; each bridge still has its own capability probe, connection state, origin policy, and failure
-boundary. This is a downstream coordination affordance, not a fleet gateway or authentication
-system.
+Settings → Network → Connections lists saved browser profiles. Each connection can be connected or
+disconnected independently and retains its own capability probe, connection state, origin policy,
+and failure boundary. This is a downstream coordination affordance, not a fleet gateway or
+authentication system.
 
 The Origin check is a browser cross-site-request guard, not a client identity check. Browsers send
 Origin for the cross-origin requests this policy is designed to constrain, while non-browser clients
-may omit the header and are admitted. Require authentication at an operator-managed VPN or reverse
-proxy if non-browser access must be restricted.
+may omit the header and are admitted. Enable the bridge password and use a trusted LAN or VPN;
+direct HTTP does not protect the password or session traffic from observation or modification.
+Use TLS, SSH, or an authenticated reverse proxy for an untrusted network.
 
-Non-loopback startup fails unless both an explicit `--allow-host` and `--allow-origin` are present.
-Add each exact hostname and origin that is required; avoid permissive DNS, wildcard proxy, or CSP
-configuration.
+Non-loopback startup requires an explicit `--allow-host`. A page served by that bridge at the exact
+accepted address is admitted as same-origin. Add `--allow-origin` only for browser pages served from
+another exact origin; avoid permissive DNS, wildcard proxy, or CSP configuration.
 
 ## Operator-managed SSH forwarding
 
@@ -119,8 +120,8 @@ asset service or central gateway.
 ## Verification checklist
 
 - Load two compatible host profiles in one browser and confirm both appear in All-host scope.
-- Use Settings → Bridges → Enable all and confirm every saved profile is admitted, then disable one
-  profile and confirm the remaining host stays navigable.
+- Use Settings → Network → Connections to connect the saved profiles, then disconnect one and
+  confirm the remaining Herdr stays navigable.
 - Type, send control input, resize/refit, and create/rename/move/close on each owning host.
 - Exercise desktop IME composition and cancellation, dismiss a menu/dialog to
   confirm focus returns to its actual trigger, and verify the optional

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -54,6 +54,11 @@ status action showing that target is not running. Repeat this for every managed 
 uninstalling. Stopping the bridge disconnects browser clients but does not stop Herdr or its panes.
 The plugin and the standalone distributions below are independent install paths.
 
+Host-side direct network access is managed from Herdr World Settings → Remote access. The
+plugin-managed launch applies its normalized host policies through the owned supervisor and waits
+for bridge readiness; development and standalone launches report read-only status when they do not
+have that controller boundary. Client bridge URLs remain in the existing Settings → Bridge store.
+
 ## Release Artifacts
 
 Recommended GitHub release assets:

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -54,10 +54,11 @@ status action showing that target is not running. Repeat this for every managed 
 uninstalling. Stopping the bridge disconnects browser clients but does not stop Herdr or its panes.
 The plugin and the standalone distributions below are independent install paths.
 
-Host-side direct network access is managed from Herdr World Settings → Remote access. The
+Host-side direct network access is managed from Herdr World Settings → Share this machine. The
 plugin-managed launch applies its normalized host policies through the owned supervisor and waits
 for bridge readiness; development and standalone launches report read-only status when they do not
-have that controller boundary. Client bridge URLs remain in the existing Settings → Bridge store.
+have that controller boundary. Other machines are added under Settings → Bridges, which also owns
+the page-serving bridge's outbound browser destination permissions.
 
 ## Release Artifacts
 

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -54,11 +54,11 @@ status action showing that target is not running. Repeat this for every managed 
 uninstalling. Stopping the bridge disconnects browser clients but does not stop Herdr or its panes.
 The plugin and the standalone distributions below are independent install paths.
 
-Host-side direct network access is managed from Herdr World Settings → Share this machine. The
-plugin-managed launch applies its normalized host policies through the owned supervisor and waits
-for bridge readiness; development and standalone launches report read-only status when they do not
-have that controller boundary. Other machines are added under Settings → Bridges, which also owns
-the page-serving bridge's outbound browser destination permissions.
+Inbound direct network access is managed from Herdr World Settings → Network → Allow connections.
+The plugin-managed launch applies its normalized host policies through the owned supervisor and
+waits for bridge readiness; development and standalone launches report read-only status when they
+do not have that controller boundary. Other Herdr instances are added under Network → Connections,
+which also owns the page-serving bridge's outbound browser destination permissions.
 
 ## Release Artifacts
 

--- a/docs/specs/019-remote-bridge-access-ux-spec.md
+++ b/docs/specs/019-remote-bridge-access-ux-spec.md
@@ -16,12 +16,13 @@ expose a bridge beyond loopback. The configuration contains low-level bind,
 Host, browser-origin, and bridge-connect settings that users should not need to
 understand.
 
-This specification defines a small UI-managed access flow:
+This specification defines two deliberately separate UI-managed flows:
 
-1. a host-side Remote access area, described in the UI as direct network access
-   for LAN/VPN use, controls whether this bridge accepts remote connections and
-   which bridge addresses it accepts; and
-2. the existing client-side Bridges area stores and enables bridge URLs.
+1. `Share this machine` controls whether the bridge on this machine accepts
+   connections from other devices, the addresses by which it can be reached,
+   and its password; and
+2. `Bridges` stores and enables other bridge URLs and controls which of those
+   destinations the current browser page may contact.
 
 The observable outcome is that a user can enable access on one machine and add
 that machine from another without editing JSON, while the bridge continues to
@@ -32,15 +33,15 @@ changes.
 
 | Concern | Decision |
 | --- | --- |
-| Host UI | Add a Remote access settings area modeled on the existing Bridges settings UI. |
-| Client UI | Keep the existing Bridges UI and saved-profile behavior. |
-| Mode naming | Describe the first mode as `Direct network access` or `LAN/VPN access`; if the section remains `Remote access`, its helper text must not imply secure Internet exposure. |
-| Remote toggle | `Allow direct network connections` is off by default and preserves accepted addresses when disabled. |
-| Accepted addresses | Hostnames or IP literals that clients may use in the bridge URL; they are not source-IP authentication. |
-| Browser policy | Keep accepted bridge hosts, allowed page origins, and allowed bridge destinations as separate high-level lists because they control different request directions. |
-| Suggestions | Show detected non-loopback addresses as unchecked suggestions. |
+| Host UI | Add `Share this machine` for inbound access to the bridge running here. |
+| Client UI | Keep bridge profiles and outbound browser destination permissions together under `Bridges`. |
+| Mode naming | Avoid `Remote access` because it obscures which machine and direction are being configured. |
+| Sharing toggle | `Allow other devices to connect` is off by default and preserves sharing settings when disabled. |
+| Machine addresses | Hostnames or IP literals that another device may use in this bridge's URL; they are not source-IP authentication. |
+| Browser policy | Keep inbound client web app origins and outbound bridge destinations as separate low-level policies, but place each only under its owning flow's Advanced browser permissions. |
+| Suggestions | Show detected non-loopback addresses and select the first usable one on first enable. |
 | Password | Optional per-bridge password; `null` means no password. |
-| Local access | A verified local UI may bypass the optional remote password; loopback appearance alone never does. |
+| Local access | Owner-approved initial implementation treats the actual loopback TCP peer as local. Proper SSH bridging remains future work. |
 | Persistence | Host settings persist in the plugin configuration; client profiles persist in browser/native client storage. |
 | Restart | Saving host settings applies them through the local controller and safely restarts the managed bridge. |
 | Transport | Use the existing direct HTTP/WebSocket bridge for this feature. Do not introduce a generic transport abstraction until a second concrete transport exists. |
@@ -49,16 +50,16 @@ changes.
 
 This feature includes:
 
-- a host-side Remote access settings area;
-- an explicit remote-access toggle;
-- accepted-address editing with detected unchecked suggestions;
+- a host-side Share this machine settings area;
+- an explicit sharing toggle;
+- machine-address editing with detected suggestions and a usable default;
 - a copyable bridge address and current access status;
 - optional password setup, change, removal, and local reset;
 - persistence of host settings without user-facing JSON editing;
 - a local-only management path for validating, persisting, and applying settings;
 - safe restart and rollback behavior when applying settings;
 - automatic derivation of low-level bind, Host, Origin, and CSP settings from
-  separate high-level policy lists;
+  the two directional flows;
 - authentication covering HTTP APIs and all WebSocket routes when a password is set;
 - actionable status and connection errors in the existing Bridges test flow; and
 - direct use of the existing HTTP/WebSocket bridge transport.
@@ -72,8 +73,8 @@ This feature does not:
 - implement source-IP allowlists or claim that accepted addresses authenticate a client;
 - add user accounts, roles, multi-factor authentication, or a shared identity system;
 - add QR codes, automatic LAN discovery, pairing codes, or a bridge registry;
-- replace the existing client-side Bridges settings UI;
-- expose raw `allowed_origins` or `allowed_connect_origins` fields to users;
+- replace the existing client-side Bridges profile model;
+- expose raw `allowed_origins` or `allowed_connect_origins` configuration names to users;
 - permit a remote browser to change host-side access settings;
 - change the Herdr protocol; or
 - preempt or duplicate main Herdr's future native remote-host protocol.
@@ -84,41 +85,50 @@ This feature does not:
 | --- | --- |
 | Host | The machine running the Herdr World bridge being configured. |
 | Client | A browser or native app using a bridge profile to connect to a host bridge. |
-| Accepted address | A hostname or IP literal that the host bridge accepts in the request Host header and advertises as a usable bridge URL. |
-| Remote access | A host bridge bound beyond loopback and admitting configured remote bridge requests. |
+| Machine address | A hostname or IP literal that this bridge accepts in the request Host header and advertises as a usable bridge URL. |
+| Sharing | A host bridge bound beyond loopback and admitting configured connections from other devices. |
 | Local access | A connection whose peer is loopback and which uses the host's local UI path. |
 | Host settings | Server-owned access settings persisted with the plugin configuration. |
 | Bridge profile | Client-owned URL, label, color, and enabled state persisted by the current Bridges UI. |
 
-An accepted address identifies how the bridge may be reached. It does not
+A machine address identifies how the bridge may be reached. It does not
 identify the source machine and is not an authentication boundary. A client
-that can reach an accepted address may attempt to connect; the optional
+that can reach a configured machine address may attempt to connect; the optional
 password is the basic access-control layer in this feature.
 
 ## 6. User experience
 
 ### 6.1 Host-side settings
 
-The Settings dialog SHALL add a Remote access area with the same interaction
-patterns as the current Bridges area.
+The Settings dialog SHALL add a `Share this machine` area. It configures only
+inbound connections to the bridge running on the current machine.
 
-When remote access is disabled, the area SHALL show:
+When sharing is disabled, the area SHALL show:
 
 - the disabled toggle;
-- the retained accepted-address list, if any; and
+- the retained machine-address list, if any; and
 - a short explanation that the bridge is available only locally.
 
-When remote access is enabled, it SHALL show:
+When sharing is enabled, it SHALL show:
 
 - the enabled toggle;
-- accepted addresses as removable rows;
-- detected non-loopback address suggestions as unchecked rows;
+- this machine's usable addresses as removable rows;
+- detected non-loopback address suggestions, selecting the first usable
+  suggestion when no saved address exists;
 - an `Add address` control for a hostname or IP literal;
-- a compact browser-permissions section for page origins allowed to call this
-  bridge and bridge origins that the page served here may call;
-- the connection URL for the selected address with a copy action;
+- a copyable Bridge URL for other devices;
 - password state: `Not set` or `Protected`, with set/change/remove actions; and
 - apply status: applying, ready, or failed with a bounded reason.
+
+The normal flow SHALL say explicitly that machine addresses belong to the
+machine being shared, not the connecting devices. It SHALL say that the
+password protects this bridge and that passwords for other bridges are asked
+for when the client connects.
+
+An `Advanced browser permissions` disclosure SHALL contain only `Client web
+app origins`: the exact page origins permitted to call this bridge. The UI
+SHALL seed standard local Herdr World origins when sharing is first enabled and
+the list is empty. Non-standard client origins remain explicit operator input.
 
 The UI SHALL not expose bind flags, generated origins, CSP sources, supervisor
 names, service labels, or raw configuration paths in the normal flow.
@@ -126,7 +136,8 @@ names, service labels, or raw configuration paths in the normal flow.
 The primary action SHALL be `Save` or `Apply`. Applying settings MAY briefly
 disconnect the current browser because the bridge process may restart. The UI
 SHALL explain this before or during the transition and SHALL reconnect when the
-new service is ready.
+new service is ready. Because the loaded document retains its original browser
+policy, a successful apply SHALL reload the page after readiness.
 
 ### 6.2 Address suggestions
 
@@ -135,25 +146,17 @@ candidate MAY include the machine hostname and usable non-loopback interface
 addresses. Loopback, link-local, container-only, and otherwise unusable
 interfaces SHOULD be omitted unless the user adds them manually.
 
-Suggestions SHALL be unchecked by default. Selecting a suggestion adds it to
-the accepted-address draft; it does not apply the setting until the user saves.
+Suggestions SHALL be unchecked until selected manually, except that enabling
+sharing with no saved machine address selects the first usable suggestion. A
+selection changes only the draft until the user applies it.
 
 The user MAY enter a hostname or IP literal manually. The field SHALL reject a
 scheme, path, query, fragment, credentials, or port because the bridge port is
 configured separately.
 
-The browser-permissions section SHALL keep these directional policies separate:
-
-- `Allowed page origins`: exact page origins permitted to call this bridge;
-- `Allowed bridge destinations`: exact bridge origins that the page served by
-  this bridge may call.
-
-The UI SHALL explain that the first protects this bridge's inbound browser
-requests and the second controls the page's outbound HTTP/WebSocket CSP. It
-SHALL offer bounded suggestions from the current page origin, supported local
-app origins, and saved client bridge profiles, all unchecked until selected.
-The user MAY add an origin manually, but the field SHALL accept only a complete
-HTTP(S) origin without credentials, path, query, fragment, or wildcard.
+The user MAY add a client web app origin manually under Advanced browser
+permissions. The field SHALL accept only a complete HTTP(S) origin without
+credentials, path, query, fragment, or wildcard.
 
 When a tested bridge is missing a reciprocal page-origin or destination policy,
 the UI SHOULD show a short setup hint identifying which host-side permission is
@@ -165,12 +168,18 @@ documentation, test fixtures, or other repository content.
 
 ### 6.3 Client-side bridge profiles
 
-The existing Bridges area SHALL remain the client configuration surface. A
-client user continues to add a bridge URL, test it, save it, and enable it.
-When the current page is served by a managed local bridge, a saved bridge
-profile MAY be offered as an `Allowed bridge destination` suggestion in that
-host's Remote access area. The client profile store remains independent and is
-not itself authoritative for the host's CSP.
+The existing area SHALL be labeled `Bridges` and remain the client
+configuration surface. A client user continues to add, save, test, and enable
+bridge URLs. When the current page is served by a managed local bridge, saving
+a profile SHALL add its exact origin to that page-serving bridge's outbound
+destination policy, wait for restart readiness, and reload the page so the new
+CSP is active. Existing profiles missing that permission SHALL be repairable
+with one `Allow saved bridges & reload` action.
+
+An `Advanced browser permissions` disclosure in Bridges SHALL own only the
+exact bridge destinations that the current page may contact. The client profile
+store remains independent and is not itself authoritative for the host's CSP;
+removing a profile does not silently remove an explicitly saved destination.
 
 When a password-protected bridge is tested or first used, the client SHALL ask
 for the password in a masked field. The password SHALL not be placed in a URL,
@@ -231,13 +240,13 @@ host UI. The plugin-owned controller SHALL own configuration writes and
 supervisor operations. The public bridge SHALL not expose privileged management
 routes.
 
-The local UI SHALL invoke the controller through a separate unforgeable local
-capability or an OS-level IPC/controller boundary. A loopback HTTP listener,
-the request Host header, or an ordinary Origin check alone is insufficient:
-SSH forwards and same-host reverse proxies can make remote traffic appear to
-come from loopback. If an environment cannot establish this local boundary,
-remote settings mutation and the local password bypass SHALL remain disabled
-there rather than falling back to loopback trust.
+The owner-approved initial implementation MAY use the actual loopback TCP peer
+as its local-management boundary. Host, Origin, and forwarding headers MUST NOT
+turn a non-loopback peer into a local one. This deliberately basic boundary
+means an operator-created SSH forward or reverse proxy terminating on loopback
+inherits local access; deployments MUST NOT expose such a proxy to untrusted
+clients. A later SSH bridge SHALL replace this limitation rather than adding a
+generic transport abstraction here.
 
 The management path SHALL support:
 
@@ -268,8 +277,9 @@ configuration and service state. The UI SHALL report the bounded failure and
 offer retry; it SHALL not leave the user guessing whether the service is still
 running.
 
-The browser reloads its own connection after a successful apply. A page reload
-alone is not considered a bridge restart.
+After the controller reports ready, the browser reloads the page so any changed
+Content Security Policy applies to the new document. A page reload alone is not
+considered a bridge restart.
 
 ## 9. Access behavior
 
@@ -296,11 +306,11 @@ For a page served from bridge A to call bridge B directly, A's
 origin such as `http://localhost` is another explicit page-origin candidate;
 it is not implied by the bridge address.
 
-The direct two-host setup therefore has two host-side saves: the page-serving
-host permits the other bridge as a destination, and the target host permits the
-page origin. Adding a URL in the client Bridges area does not silently change
-either host's policy; it can only provide a local suggestion for the destination
-list.
+The direct two-host setup therefore has two directional settings: adding B
+under Bridges on page-serving host A applies B as A's outbound destination,
+while Share this machine on target B permits A's exact page origin as an
+inbound client web app origin. The first is part of the client Bridge flow; the
+second remains an advanced sharing setting on B.
 
 ### 9.2 Optional password
 
@@ -310,10 +320,11 @@ anyone able to reach an accepted address may connect.
 
 When a password is configured:
 
-- loopback connections MAY bypass password authentication only after the same
-  unforgeable local capability or IPC/controller check used for management;
-- a forwarded or reverse-proxied connection that merely appears to be loopback
-  SHALL still require the password;
+- connections whose accepted TCP peer is loopback MAY bypass password
+  authentication under the owner-approved initial local boundary;
+- operators MUST treat SSH forwards and reverse proxies terminating on
+  loopback as trusted local access and MUST NOT expose them without their own
+  authentication;
 - non-loopback HTTP requests SHALL authenticate before receiving protected data;
 - all event, activity, UI-event, and terminal WebSockets SHALL authenticate
   before sending events or terminal bytes;
@@ -349,7 +360,7 @@ The diagnostic response MAY be composed by the client from staged requests or
 returned as a bounded structured capability result. It SHALL not expose raw
 server paths, environment variables, credentials, or unbounded process output.
 
-The host Remote access area SHALL distinguish:
+The Share this machine area SHALL distinguish:
 
 - settings saved but not yet applied;
 - service restarting;
@@ -388,30 +399,31 @@ introducing a generic transport abstraction here.
 - **THEN** the same-origin UI and terminal work without a password or remote
   settings setup
 
-### Scenario: The host enables remote access
+### Scenario: The host enables sharing
 
-- **GIVEN** the local user opens Remote access
-- **WHEN** they enable the toggle, select one suggested address, and save
+- **GIVEN** the local user opens Share this machine
+- **WHEN** they enable the toggle and apply the detected address
 - **THEN** the host settings persist, the owned service restarts, and the UI
   reports the selected connection URL as ready
 
-### Scenario: Accepted addresses remain disabled without being lost
+### Scenario: Machine addresses remain saved while sharing is disabled
 
-- **GIVEN** a host has saved accepted addresses
-- **WHEN** the user disables remote access and later reopens settings
+- **GIVEN** a host has saved machine addresses
+- **WHEN** the user disables sharing and later reopens settings
 - **THEN** the addresses remain available as the next draft but the bridge is
   loopback-only
 
 ### Scenario: A client adds a host
 
-- **GIVEN** a host is enabled and reachable at an accepted address
-- **WHEN** a client adds that URL, tests it, saves it, and enables it
-- **THEN** the existing Bridges UI shows the enabled bridge and runtime data,
-  events, and terminal output become available
+- **GIVEN** a host is enabled and reachable at a configured machine address
+- **WHEN** a client saves and enables that URL under Bridges
+- **THEN** the page-serving bridge permits the destination, the page reloads,
+  the client asks for the target bridge's password when configured, and runtime
+  data, events, and terminal output become available
 
 ### Scenario: An unaccepted address is rejected
 
-- **GIVEN** remote access is enabled with a bounded accepted-address list
+- **GIVEN** sharing is enabled with a bounded machine-address list
 - **WHEN** a client targets another Host value on the bridge port
 - **THEN** the capability test and WebSocket paths fail with a specific bounded
   policy error
@@ -423,19 +435,19 @@ introducing a generic transport abstraction here.
 - **THEN** protected APIs and every WebSocket route reject the request without
   returning snapshot, event, or terminal data
 
-### Scenario: Local access bypasses the password safely
+### Scenario: Local access uses the approved basic loopback boundary
 
 - **GIVEN** remote access is enabled with a password
-- **WHEN** the local UI connects through the loopback path with the local
-  capability or IPC proof
+- **WHEN** the local UI connects with an actual loopback TCP peer
 - **THEN** it remains usable without a password
 
-### Scenario: A forwarded loopback connection does not bypass the password
+### Scenario: A forwarded loopback connection is treated as trusted local access
 
 - **GIVEN** remote access is enabled with a password
 - **WHEN** a browser reaches the bridge through an SSH forward or reverse proxy
   that terminates on loopback without the local capability
-- **THEN** it still must authenticate
+- **THEN** the bridge treats the accepted loopback peer as local, so the
+  operator-provided tunnel or proxy must supply the missing trust boundary
 
 ### Scenario: Applying settings fails safely
 
@@ -458,8 +470,8 @@ The implementation SHALL include:
 - migration tests for existing loopback and non-loopback configurations;
 - policy tests proving accepted hosts, allowed page origins, and allowed bridge
   destinations remain directional and are not inferred from one another;
-- management-path tests proving remote requests cannot mutate host settings and
-  loopback appearance alone cannot satisfy the local boundary;
+- management-path tests proving non-loopback requests cannot mutate host
+  settings and forwarding headers cannot manufacture a loopback TCP peer;
 - supervisor/restart tests covering success, readiness failure, rollback, and
   lost runtime records;
 - password tests covering null, valid, invalid, rate-limited, loopback, HTTP,
@@ -472,18 +484,16 @@ The implementation SHALL include:
 - available web, bridge, plugin, packaging, and end-to-end checks in proportion
   to the changed layers.
 
-## 14. Open implementation notes
+## 14. Implementation notes
 
-The implementation plan SHALL resolve these technical details without changing
-the user-facing decisions above:
-
-- which existing plugin/controller boundary owns the local management path;
-- how the local capability or IPC proof is minted and verified without making
-  it available to forwarded browsers;
-- how a managed service restart reports readiness to the browser;
-- the exact password hash and session-ticket libraries already compatible with
-  the bridge build;
-- how the bridge obtains peer address information for diagnostics after the
-  capability check; and
-- how the UI presents separate page-origin and bridge-destination policy
-  without exposing raw runtime flags.
+- The existing plugin controller owns configuration writes and service
+  reconciliation.
+- The initial local boundary is the accepted TCP peer's loopback address, as
+  explicitly approved by the owner; forwarded loopback access inherits that
+  trust.
+- The browser polls bounded apply status until ready and then reloads so the
+  new document receives the current CSP.
+- Passwords use the bridge's bounded Argon2 hash and in-memory session token
+  implementation.
+- Share this machine owns inbound client web app origins; Bridges owns outbound
+  bridge destinations. Both remain exact-origin advanced settings.

--- a/docs/specs/019-remote-bridge-access-ux-spec.md
+++ b/docs/specs/019-remote-bridge-access-ux-spec.md
@@ -185,9 +185,11 @@ When a password-protected bridge is tested or first used, the client SHALL ask
 for the password in a masked field. The password SHALL not be placed in a URL,
 browser history entry, log, exported profile, or persistent client profile.
 
-The initial implementation SHALL retain the authenticated session only for the
-current client runtime. A future explicit “remember” choice may use a platform
-secure store, but is not part of this feature.
+The initial implementation SHALL retain only the bearer session token in
+tab-scoped browser session storage so refreshes do not require another password.
+The password itself SHALL not be stored. The token SHALL be discarded when the
+tab session ends or the bridge rejects it; persistence across browser sessions
+and a future explicit “remember” choice are not part of this feature.
 
 ## 7. Host configuration and persistence
 
@@ -493,7 +495,8 @@ The implementation SHALL include:
   trust.
 - The browser polls bounded apply status until ready and then reloads so the
   new document receives the current CSP.
-- Passwords use the bridge's bounded Argon2 hash and in-memory session token
-  implementation.
+- Passwords use the bridge's bounded Argon2 hash. The password is never stored
+  client-side; only its bearer session token is retained for the current browser
+  tab so it survives a page reload.
 - Share this machine owns inbound client web app origins; Bridges owns outbound
   bridge destinations. Both remain exact-origin advanced settings.

--- a/docs/specs/019-remote-bridge-access-ux-spec.md
+++ b/docs/specs/019-remote-bridge-access-ux-spec.md
@@ -1,4 +1,4 @@
-# UI-managed remote bridge access
+# UI-managed Herdr network connections
 
 - **Spec ID:** `019-remote-bridge-access-ux`
 - **Status:** Draft
@@ -11,49 +11,51 @@
 
 ## 1. Purpose
 
-Herdr World currently requires users to edit the plugin's `config.json` to
-expose a bridge beyond loopback. The configuration contains low-level bind,
-Host, browser-origin, and bridge-connect settings that users should not need to
-understand.
+Herdr World's networking UI should let users connect Herdr instances without
+requiring them to understand the underlying bridge protocol, bind addresses,
+HTTP Host checks, browser origins, or Content Security Policy.
 
-This specification defines two deliberately separate UI-managed flows:
+The Settings dialog therefore exposes one `Network` area with two deliberately
+directional flows:
 
-1. `Share this machine` controls whether the bridge on this machine accepts
-   connections from other devices, the addresses by which it can be reached,
-   and its password; and
-2. `Bridges` stores and enables other bridge URLs and controls which of those
-   destinations the current browser page may contact.
+1. `Connections` connects this Herdr World page to another Herdr instance; and
+2. `Allow connections` lets Herdr World elsewhere connect to this Herdr instance.
 
-The observable outcome is that a user can enable access on one machine and add
-that machine from another without editing JSON, while the bridge continues to
-apply exact Host/Origin policy and safely restarts when its service definition
-changes.
+The transport remains browser-direct: the loaded Herdr World page talks to
+each target bridge. The user-facing Herdr-to-Herdr model is accurate for normal
+use, while the browser-specific origin and destination restrictions remain
+available through progressive disclosure. The observable outcome is that a
+user can allow access on one Herdr and add its address from another without
+editing JSON or learning protocol terminology.
 
 ## 2. Decisions
 
 | Concern | Decision |
 | --- | --- |
-| Host UI | Add `Share this machine` for inbound access to the bridge running here. |
-| Client UI | Keep bridge profiles and outbound browser destination permissions together under `Bridges`. |
-| Mode naming | Avoid `Remote access` because it obscures which machine and direction are being configured. |
-| Sharing toggle | `Allow other devices to connect` is off by default and preserves sharing settings when disabled. |
-| Machine addresses | Hostnames or IP literals that another device may use in this bridge's URL; they are not source-IP authentication. |
-| Browser policy | Keep additional inbound client page origins and outbound bridge destinations as separate low-level policies, but place each only under its owning flow's Advanced browser permissions. |
+| Top-level UI | Use one `Network` area containing `Connections` and `Allow connections`. |
+| Outbound UI | `Connections` lists saved Herdr connections and provides `Add connection`. |
+| Inbound UI | `Allow connections` controls whether this Herdr accepts connections from elsewhere. |
+| Normal connection form | Require only `Herdr address`; ask for authentication when the target requires it. Keep optional name and color under `Customize connection`. |
+| Allow toggle | `Allow connections to this Herdr` is off by default and preserves settings when disabled. |
+| Herdr addresses | Hostnames or IP literals by which this Herdr can be reached; they are not source-IP authentication. |
+| Browser policy | Keep additional inbound page origins and outbound destinations as separate exact-origin policies under `Advanced network permissions`. |
 | Suggestions | Show detected non-loopback addresses and select the first usable one on first enable. |
-| Password | Optional per-bridge password; `null` means no password. |
+| Password | Optional per-Herdr password; `null` means no password. Passwords are prompted for when needed and are not stored client-side. |
 | Local access | Owner-approved initial implementation treats the actual loopback TCP peer as local. Proper SSH bridging remains future work. |
-| Persistence | Host settings persist in the plugin configuration; client profiles persist in browser/native client storage. |
-| Restart | Saving host settings applies them through the local controller and safely restarts the managed bridge. |
+| Persistence | Inbound settings persist in the plugin configuration; connections persist in browser/native client storage. |
+| Restart | Applying inbound settings safely restarts the managed service. Server-side authentication sessions are intentionally lost, so remote pages may ask for the password again. |
 | Transport | Use the existing direct HTTP/WebSocket bridge for this feature. Do not introduce a generic transport abstraction until a second concrete transport exists. |
 
 ## 3. Scope
 
 This feature includes:
 
-- a host-side Share this machine settings area;
-- an explicit sharing toggle;
-- machine-address editing with detected suggestions and a usable default;
-- a copyable bridge address and current access status;
+- one Network area with directional Connections and Allow connections views;
+- a simple connection list with connected, connecting, offline, and off status;
+- an Add connection flow requiring only the Herdr address by default;
+- an explicit allow-connections toggle;
+- Herdr-address editing with detected suggestions and a usable default;
+- a copyable address and current access status;
 - optional password setup, change, removal, and local reset;
 - persistence of host settings without user-facing JSON editing;
 - a local-only management path for validating, persisting, and applying settings;
@@ -61,7 +63,7 @@ This feature includes:
 - automatic derivation of low-level bind, Host, Origin, and CSP settings from
   the two directional flows;
 - authentication covering HTTP APIs and all WebSocket routes when a password is set;
-- actionable status and connection errors in the existing Bridges test flow; and
+- actionable status and connection errors in the Connections test flow; and
 - direct use of the existing HTTP/WebSocket bridge transport.
 
 ## 4. Non-goals
@@ -73,7 +75,7 @@ This feature does not:
 - implement source-IP allowlists or claim that accepted addresses authenticate a client;
 - add user accounts, roles, multi-factor authentication, or a shared identity system;
 - add QR codes, automatic LAN discovery, pairing codes, or a bridge registry;
-- replace the existing client-side Bridges profile model;
+- replace the existing client-side connection profile model;
 - expose raw `allowed_origins` or `allowed_connect_origins` configuration names to users;
 - permit a remote browser to change host-side access settings;
 - change the Herdr protocol; or
@@ -83,116 +85,128 @@ This feature does not:
 
 | Term | Meaning in this specification |
 | --- | --- |
-| Host | The machine running the Herdr World bridge being configured. |
-| Client | A browser or native app using a bridge profile to connect to a host bridge. |
-| Machine address | A hostname or IP literal that this bridge accepts in the request Host header and advertises as a usable bridge URL. |
-| Sharing | A host bridge bound beyond loopback and admitting configured connections from other devices. |
-| Local access | A connection whose peer is loopback and which uses the host's local UI path. |
-| Host settings | Server-owned access settings persisted with the plugin configuration. |
-| Bridge profile | Client-owned URL, label, color, and enabled state persisted by the current Bridges UI. |
+| Herdr instance | A Herdr runtime, whether it runs on a laptop, VM, server, container, or other environment. |
+| Connection | A client-owned saved address, optional label/color, and enabled state used by Herdr World to reach a Herdr instance. Internally this is a bridge profile. |
+| Herdr address | A hostname or IP literal that the bridge accepts in the request Host header and advertises as a usable URL. |
+| Allow connections | Bind beyond loopback and admit configured Herdr World pages from elsewhere. |
+| Local access | A connection whose accepted TCP peer is loopback and which uses the local UI path. |
+| Inbound settings | Server-owned access settings persisted with the plugin configuration. |
 
-A machine address identifies how the bridge may be reached. It does not
-identify the source machine and is not an authentication boundary. A client
-that can reach a configured machine address may attempt to connect; the optional
+A Herdr address identifies how the instance may be reached. It does not
+identify the connecting device and is not an authentication boundary. A client
+that can reach a configured address may attempt to connect; the optional
 password is the basic access-control layer in this feature.
 
 ## 6. User experience
 
-### 6.1 Host-side settings
+### 6.1 Network navigation
 
-The Settings dialog SHALL add a `Share this machine` area. It configures only
-inbound connections to the bridge running on the current machine.
+The Settings dialog SHALL expose one top-level `Network` area. When local
+management is available it SHALL contain `Connections` and `Allow connections`
+subviews. A browser-only launch that cannot manage the serving instance MAY
+show only `Connections`.
 
-When sharing is disabled, the area SHALL show:
+The normal UI SHALL use Herdr and connection terminology. `Bridge` remains an
+internal protocol and developer term and MAY appear in diagnostics whose
+meaning depends on that protocol.
 
-- the disabled toggle;
-- the retained machine-address list, if any; and
-- a short explanation that the bridge is available only locally.
+### 6.2 Allow connections
 
-When sharing is enabled, it SHALL show:
+`Allow connections` configures only inbound connections to the Herdr instance
+serving the current page. Its normal view SHALL show:
 
-- the enabled toggle;
-- this machine's usable addresses as removable rows;
-- detected non-loopback address suggestions, selecting the first usable
-  suggestion when no saved address exists;
-- an `Add address` control for a hostname or IP literal;
-- a copyable Bridge URL for other devices;
-- password state: `Not set` or `Protected`, with set/change/remove actions; and
+- `Allow connections to this Herdr`, off by default;
+- when enabled, one usable `Address` with a `Copy address` action;
+- password state and set/change/remove actions; and
 - apply status: applying, ready, or failed with a bounded reason.
 
-The normal flow SHALL say explicitly that machine addresses belong to the
-machine being shared, not the connecting devices. It SHALL say that the
-password protects this bridge and that passwords for other bridges are asked
-for when the client connects.
+If no usable address exists, the normal view SHALL ask for one. Detected
+non-loopback suggestions and multiple accepted addresses SHALL remain available
+under `Advanced network permissions`.
 
-An `Advanced browser permissions` disclosure SHALL contain only `Additional
-client page origins`: exact origins for Herdr World pages served somewhere else
-that need to call this bridge. A page loaded directly from this bridge is
-inherently admitted when its Origin exactly matches the already accepted Host
-and bridge port. The UI SHALL seed standard local Herdr World origins when
-sharing is first enabled and the list is empty for development and Android
-clients. Other client origins remain explicit operator input.
+That advanced disclosure SHALL contain:
+
+- `Addresses this Herdr responds to`, backed by exact accepted Host values; and
+- `Web pages allowed to connect`, backed by exact additional browser origins.
+
+The advanced copy SHALL make clear that these are routing and browser-security
+restrictions, not an allowlist of connecting client IP addresses. A page loaded
+directly from this Herdr is inherently admitted when its Origin exactly matches
+the already accepted Host and port, so an additional page-origin entry is not
+required. The UI MAY seed standard local Herdr World origins when first enabled
+for development and Android clients; other origins remain explicit input.
 
 The UI SHALL not expose bind flags, generated origins, CSP sources, supervisor
 names, service labels, or raw configuration paths in the normal flow.
 
-The primary action SHALL be `Save` or `Apply`. Applying settings MAY briefly
+The primary action SHALL be `Apply changes`. Applying settings MAY briefly
 disconnect the current browser because the bridge process may restart. The UI
-SHALL explain this before or during the transition and SHALL reconnect when the
-new service is ready. Because the loaded document retains its original browser
-policy, a successful apply SHALL reload the page after readiness.
+SHALL explain this before the transition and SHALL reconnect when the new
+service is ready. Because the loaded document retains its original browser
+policy, a successful apply SHALL reload the page after readiness. A restart
+invalidates the service's in-memory authentication sessions, so other pages MAY
+ask for the password again.
 
-### 6.2 Address suggestions
+### 6.3 Address suggestions
 
-The host-side controller SHALL return a bounded set of detected candidates. A
-candidate MAY include the machine hostname and usable non-loopback interface
+The local controller SHALL return a bounded set of detected candidates. A
+candidate MAY include the instance hostname and usable non-loopback interface
 addresses. Loopback, link-local, container-only, and otherwise unusable
 interfaces SHOULD be omitted unless the user adds them manually.
 
 Suggestions SHALL be unchecked until selected manually, except that enabling
-sharing with no saved machine address selects the first usable suggestion. A
+connections with no saved Herdr address selects the first usable suggestion. A
 selection changes only the draft until the user applies it.
 
 The user MAY enter a hostname or IP literal manually. The field SHALL reject a
 scheme, path, query, fragment, credentials, or port because the bridge port is
 configured separately.
 
-The user MAY add a client web app origin manually under Advanced browser
+The user MAY add a client web app origin manually under Advanced network
 permissions. The field SHALL accept only a complete HTTP(S) origin without
 credentials, path, query, fragment, or wildcard.
 
-When a tested bridge is missing a reciprocal page-origin or destination policy,
-the UI SHOULD show a short setup hint identifying which host-side permission is
+When a tested connection is missing a reciprocal page-origin or destination policy,
+the UI SHOULD show a short setup hint identifying which target permission is
 missing. It MUST not silently broaden either list.
 
 The UI MAY display real addresses to the local operator because they are the
 subject of the setting. It MUST NOT write them to logs, telemetry, generated
 documentation, test fixtures, or other repository content.
 
-### 6.3 Client-side bridge profiles
+### 6.4 Connections
 
-The existing area SHALL be labeled `Bridges` and remain the client
-configuration surface. A client user continues to add, save, test, and enable
-bridge URLs. When the current page is served by a managed local bridge, saving
-a profile SHALL add its exact origin to that page-serving bridge's outbound
-destination policy, wait for restart readiness, and reload the page so the new
-CSP is active. Existing profiles missing that permission SHALL be repairable
-with one `Allow saved bridges & reload` action.
+`Connections` is the client configuration surface. It SHALL list the current
+same-origin and saved connections with simple `Connected`, `Connecting`,
+`Offline`, or `Off` status. It SHALL provide `Add connection` as the primary
+creation action.
 
-An `Advanced browser permissions` disclosure in Bridges SHALL own only the
-exact bridge destinations that the current page may contact. The client profile
-store remains independent and is not itself authoritative for the host's CSP;
-removing a profile does not silently remove an explicitly saved destination.
+A new connection SHALL require only `Herdr address` in the normal flow. Pressing
+`Connect` SHALL save and enable it. Optional name and color fields SHALL remain
+under `Customize connection`. Existing connections MAY be enabled, disabled,
+edited, deleted, and tested.
 
-When a password-protected bridge is tested or first used, the client SHALL ask
+When the current page is served by a managed local bridge, saving a connection
+SHALL add its exact origin to that page-serving bridge's outbound destination
+policy, wait for restart readiness, and reload the page so the new CSP is
+active. Existing connections missing that permission SHALL be repairable with
+one `Allow saved connections & reload` action.
+
+An `Advanced network permissions` disclosure in Connections SHALL own only the
+exact `Herdrs this page may connect to`. The connection store remains
+independent and is not itself authoritative for the serving bridge's CSP;
+removing a connection does not silently remove an explicitly saved destination.
+
+When a password-protected Herdr is tested or first used, the client SHALL ask
 for the password in a masked field. The password SHALL not be placed in a URL,
-browser history entry, log, exported profile, or persistent client profile.
+browser history entry, log, exported connection, or persistent client profile.
 
 The initial implementation SHALL retain only the bearer session token in
-tab-scoped browser session storage so refreshes do not require another password.
-The password itself SHALL not be stored. The token SHALL be discarded when the
-tab session ends or the bridge rejects it; persistence across browser sessions
-and a future explicit “remember” choice are not part of this feature.
+tab-scoped browser session storage so ordinary refreshes do not require another
+password. The password itself SHALL not be stored. The token SHALL be discarded
+when the tab session ends or the target Herdr rejects it, including after a
+target service restart. Persistence across browser sessions and a future
+explicit “remember” choice are not part of this feature.
 
 ## 7. Host configuration and persistence
 
@@ -233,7 +247,7 @@ Host settings SHALL be written atomically with restrictive permissions. A
 partial write or invalid setting SHALL leave the previous valid configuration
 intact.
 
-The client-side bridge profile store remains independent. It continues to own
+The client-side connection store remains independent. It continues to own
 URLs, labels, colors, enabled IDs, and selection state in browser storage or
 the native preferences store. It MUST NOT be used as the host configuration
 store.
@@ -313,11 +327,11 @@ For a page served from bridge A to call bridge B directly, A's
 origin such as `http://localhost` is another explicit page-origin candidate;
 it is not implied by the bridge address.
 
-The direct two-host setup therefore has two directional settings: adding B
-under Bridges on page-serving host A applies B as A's outbound destination,
-while Share this machine on target B permits A's exact page origin as an
-inbound client web app origin. The first is part of the client Bridge flow; the
-second remains an advanced sharing setting on B.
+The direct two-instance setup therefore has two directional settings: adding B
+under Connections on page-serving instance A applies B as A's outbound
+destination, while Allow connections on target B permits A's exact page origin
+as an advanced inbound permission. Neither direction silently broadens the
+other.
 
 ### 9.2 Optional password
 
@@ -343,7 +357,7 @@ When a password is configured:
 The authentication session mechanism SHALL not put a password in a URL. It MAY
 use an in-memory bearer/session credential for HTTP and a corresponding
 authenticated WebSocket handshake or first-message ticket. It MUST work for
-cross-origin bridge profiles without requiring insecure wildcard CORS.
+cross-origin connections without requiring insecure wildcard CORS.
 
 The password is defense-in-depth against casual access. Over cleartext HTTP it
 does not provide transport confidentiality, integrity, or server
@@ -353,8 +367,7 @@ observer and recommend TLS, VPN, or SSH for untrusted networks.
 
 ## 10. Diagnostics
 
-The existing client `Test` action SHALL retain its current layout and controls.
-Its result SHALL distinguish at least:
+The `Test connection` action SHALL distinguish at least:
 
 - address/network failure;
 - Host or Origin policy rejection;
@@ -367,11 +380,11 @@ The diagnostic response MAY be composed by the client from staged requests or
 returned as a bounded structured capability result. It SHALL not expose raw
 server paths, environment variables, credentials, or unbounded process output.
 
-The Share this machine area SHALL distinguish:
+The Allow connections view SHALL distinguish:
 
 - settings saved but not yet applied;
 - service restarting;
-- bridge ready;
+- network ready;
 - configuration rejected; and
 - service failed to become ready and previous settings restored.
 
@@ -385,7 +398,7 @@ common requirements are known.
 
 ### Future SSH direction (informative, not part of this specification)
 
-A later desktop-oriented Bridges flow MAY offer two connection modes:
+A later desktop-oriented Connections flow MAY offer two connection modes:
 
 - `SSH` (recommended): use system OpenSSH, the user's SSH config,
   `known_hosts`, and `ssh-agent`, while keeping the remote World bridge
@@ -406,31 +419,31 @@ introducing a generic transport abstraction here.
 - **THEN** the same-origin UI and terminal work without a password or remote
   settings setup
 
-### Scenario: The host enables sharing
+### Scenario: An instance allows connections
 
-- **GIVEN** the local user opens Share this machine
+- **GIVEN** the local user opens Network → Allow connections
 - **WHEN** they enable the toggle and apply the detected address
-- **THEN** the host settings persist, the owned service restarts, and the UI
-  reports the selected connection URL as ready
+- **THEN** the inbound settings persist, the owned service restarts, and the UI
+  reports the selected address as ready
 
-### Scenario: Machine addresses remain saved while sharing is disabled
+### Scenario: Herdr addresses remain saved while connections are disabled
 
-- **GIVEN** a host has saved machine addresses
-- **WHEN** the user disables sharing and later reopens settings
+- **GIVEN** a Herdr has saved addresses
+- **WHEN** the user disables incoming connections and later reopens settings
 - **THEN** the addresses remain available as the next draft but the bridge is
   loopback-only
 
-### Scenario: A client adds a host
+### Scenario: A user adds a connection
 
-- **GIVEN** a host is enabled and reachable at a configured machine address
-- **WHEN** a client saves and enables that URL under Bridges
+- **GIVEN** another Herdr is reachable at a configured address
+- **WHEN** the user enters that address under Network → Connections and selects Connect
 - **THEN** the page-serving bridge permits the destination, the page reloads,
-  the client asks for the target bridge's password when configured, and runtime
+  the client asks for the target Herdr's password when configured, and runtime
   data, events, and terminal output become available
 
 ### Scenario: An unaccepted address is rejected
 
-- **GIVEN** sharing is enabled with a bounded machine-address list
+- **GIVEN** incoming connections are enabled with a bounded address list
 - **WHEN** a client targets another Host value on the bridge port
 - **THEN** the capability test and WebSocket paths fail with a specific bounded
   policy error
@@ -441,6 +454,12 @@ introducing a generic transport abstraction here.
 - **WHEN** a remote client connects without a valid session
 - **THEN** protected APIs and every WebSocket route reject the request without
   returning snapshot, event, or terminal data
+
+### Scenario: A target restart requires authentication again
+
+- **GIVEN** the current browser tab has an authenticated session for another Herdr
+- **WHEN** that target Herdr restarts and invalidates its in-memory sessions
+- **THEN** Herdr World asks for the password again instead of storing or replaying it
 
 ### Scenario: Local access uses the approved basic loopback boundary
 
@@ -463,11 +482,11 @@ introducing a generic transport abstraction here.
 - **THEN** the previous configuration and service remain or are restored, and
   the UI reports the bounded failure with a retry path
 
-### Scenario: Existing client profiles survive host changes
+### Scenario: Existing connections survive inbound-setting changes
 
-- **GIVEN** the client has saved bridge profiles in its current store
-- **WHEN** a host changes remote-access settings
-- **THEN** the client profiles remain unchanged and can be retested or edited
+- **GIVEN** the client has saved connections in its current store
+- **WHEN** an instance changes its inbound settings
+- **THEN** the saved connections remain unchanged and can be retested or edited
 
 ## 13. Validation
 
@@ -486,7 +505,7 @@ The implementation SHALL include:
   and every WebSocket route;
 - browser tests for suggestions, draft/save behavior, restart status, and
   bounded diagnostics;
-- regression coverage proving existing Bridges storage and UI behavior remains;
+- regression coverage proving connection storage and the simplified UI behavior remain;
 - privacy-audit coverage for documentation, fixtures, logs, and generated
   output; and
 - available web, bridge, plugin, packaging, and end-to-end checks in proportion
@@ -504,6 +523,6 @@ The implementation SHALL include:
 - Passwords use the bridge's bounded Argon2 hash. The password is never stored
   client-side; only its bearer session token is retained for the current browser
   tab so it survives a page reload.
-- Share this machine owns additional inbound client page origins; Bridges owns
-  outbound bridge destinations. Both remain exact-origin advanced settings;
+- Allow connections owns additional inbound client page origins; Connections
+  owns outbound bridge destinations. Both remain exact-origin advanced settings;
   the bridge's own served origin does not require duplicate configuration.

--- a/docs/specs/019-remote-bridge-access-ux-spec.md
+++ b/docs/specs/019-remote-bridge-access-ux-spec.md
@@ -38,7 +38,7 @@ changes.
 | Mode naming | Avoid `Remote access` because it obscures which machine and direction are being configured. |
 | Sharing toggle | `Allow other devices to connect` is off by default and preserves sharing settings when disabled. |
 | Machine addresses | Hostnames or IP literals that another device may use in this bridge's URL; they are not source-IP authentication. |
-| Browser policy | Keep inbound client web app origins and outbound bridge destinations as separate low-level policies, but place each only under its owning flow's Advanced browser permissions. |
+| Browser policy | Keep additional inbound client page origins and outbound bridge destinations as separate low-level policies, but place each only under its owning flow's Advanced browser permissions. |
 | Suggestions | Show detected non-loopback addresses and select the first usable one on first enable. |
 | Password | Optional per-bridge password; `null` means no password. |
 | Local access | Owner-approved initial implementation treats the actual loopback TCP peer as local. Proper SSH bridging remains future work. |
@@ -125,10 +125,13 @@ machine being shared, not the connecting devices. It SHALL say that the
 password protects this bridge and that passwords for other bridges are asked
 for when the client connects.
 
-An `Advanced browser permissions` disclosure SHALL contain only `Client web
-app origins`: the exact page origins permitted to call this bridge. The UI
-SHALL seed standard local Herdr World origins when sharing is first enabled and
-the list is empty. Non-standard client origins remain explicit operator input.
+An `Advanced browser permissions` disclosure SHALL contain only `Additional
+client page origins`: exact origins for Herdr World pages served somewhere else
+that need to call this bridge. A page loaded directly from this bridge is
+inherently admitted when its Origin exactly matches the already accepted Host
+and bridge port. The UI SHALL seed standard local Herdr World origins when
+sharing is first enabled and the list is empty for development and Android
+clients. Other client origins remain explicit operator input.
 
 The UI SHALL not expose bind flags, generated origins, CSP sources, supervisor
 names, service labels, or raw configuration paths in the normal flow.
@@ -297,9 +300,11 @@ checks, but the UI SHALL warn that this is not a network firewall or source-IP
 allowlist.
 
 The plugin SHALL continue to reject malformed, unconfigured, or wrong-port
-Host values. The bridge SHALL continue to enforce exact browser Origin policy
-from `allowed_page_origins`, and CSP connect sources from
-`allowed_bridge_origins`. Neither list SHALL be inferred from
+Host values. The bridge SHALL inherently admit an exact same-origin request
+whose authority matches the request's already accepted Host and bridge port.
+It SHALL continue to enforce exact additional browser Origin policy from
+`allowed_page_origins`, and CSP connect sources from
+`allowed_bridge_origins`. Neither configured list SHALL be inferred from
 `accepted_hosts` alone.
 
 For a page served from bridge A to call bridge B directly, A's
@@ -470,8 +475,9 @@ The implementation SHALL include:
 
 - unit tests for high-level configuration validation and low-level derivation;
 - migration tests for existing loopback and non-loopback configurations;
-- policy tests proving accepted hosts, allowed page origins, and allowed bridge
-  destinations remain directional and are not inferred from one another;
+- policy tests proving accepted hosts, additional page origins, and allowed
+  bridge destinations remain directional and are not inferred from one another,
+  while the exact served origin works without duplicate configuration;
 - management-path tests proving non-loopback requests cannot mutate host
   settings and forwarding headers cannot manufacture a loopback TCP peer;
 - supervisor/restart tests covering success, readiness failure, rollback, and
@@ -498,5 +504,6 @@ The implementation SHALL include:
 - Passwords use the bridge's bounded Argon2 hash. The password is never stored
   client-side; only its bearer session token is retained for the current browser
   tab so it survives a page reload.
-- Share this machine owns inbound client web app origins; Bridges owns outbound
-  bridge destinations. Both remain exact-origin advanced settings.
+- Share this machine owns additional inbound client page origins; Bridges owns
+  outbound bridge destinations. Both remain exact-origin advanced settings;
+  the bridge's own served origin does not require duplicate configuration.

--- a/scripts/e2e-fixture.mjs
+++ b/scripts/e2e-fixture.mjs
@@ -96,6 +96,40 @@ async function startFixture(fixture) {
       json(response, 200, { sent });
       return;
     }
+    if (url.pathname === "/api/local/remote-access") {
+      const state = fixtureStates.get(fixture.id);
+      if (!state?.remoteAccess) {
+        json(response, 404, { error: "not found" });
+        return;
+      }
+      if (request.method === "POST") {
+        const body = await readJson(request);
+        if (!body || typeof body.remote_access !== "object") {
+          json(response, 400, { error: "invalid remote access draft" });
+          return;
+        }
+        const remoteAccess = {
+          ...state.remoteAccess,
+          ...body.remote_access,
+          password_configured: body.password_action === "set"
+            ? true
+            : body.password_action === "remove"
+              ? false
+              : state.remoteAccess.password_configured,
+        };
+        fixtureStates.set(fixture.id, { ...state, remoteAccess });
+        json(response, 202, { state: "applying", reason: "settings saved; restarting", restored: null });
+        return;
+      }
+      json(response, 200, {
+        remote_access: state.remoteAccess,
+        port: fixture.port,
+        suggestions: ["bridge.example.test"],
+        mutation_allowed: true,
+        apply: { state: "ready", reason: null, restored: null },
+      });
+      return;
+    }
     if (url.pathname === "/api/capabilities") {
       logs.get(fixture.id).capabilityRequests += 1;
       if (fixture.variant === "malformed") {
@@ -299,6 +333,13 @@ function defaultFixtureState() {
     commands: null,
     launchCreatesSeat: false,
     launchedSeat: false,
+    remoteAccess: {
+      enabled: false,
+      accepted_hosts: [],
+      allowed_page_origins: ["http://127.0.0.1:4173"],
+      allowed_bridge_origins: [],
+      password_configured: false,
+    },
   };
 }
 
@@ -333,6 +374,7 @@ function setFixtureState(hostId, value) {
     commands,
     launchCreatesSeat,
     launchedSeat: current.launchedSeat,
+    remoteAccess: current.remoteAccess,
   });
   return true;
 }

--- a/scripts/e2e-fixture.mjs
+++ b/scripts/e2e-fixture.mjs
@@ -12,6 +12,8 @@ const logs = new Map();
 const fixtureStates = new Map();
 const fixtureSockets = new Map();
 const servers = [];
+const FIXTURE_PASSWORD = "fixture-only-password";
+const FIXTURE_SESSION_TOKEN = "fixture-session-token";
 
 const fixtures = [
   {
@@ -51,12 +53,13 @@ for (const signal of ["SIGINT", "SIGTERM"]) {
 async function startFixture(fixture) {
   const webSockets = new WebSocketServer({ noServer: true });
   const server = createServer(async (request, response) => {
-    setCorsHeaders(request, response);
+    setCorsHeaders(fixture, request, response);
     if (request.method === "OPTIONS") {
       response.writeHead(204).end();
       return;
     }
     const url = new URL(request.url ?? "/", `http://127.0.0.1:${fixture.port}`);
+    const state = fixtureStates.get(fixture.id);
     if (url.pathname === "/__fixture/requests") {
       json(response, 200, Object.fromEntries(logs));
       return;
@@ -97,7 +100,6 @@ async function startFixture(fixture) {
       return;
     }
     if (url.pathname === "/api/local/remote-access") {
-      const state = fixtureStates.get(fixture.id);
       if (!state?.remoteAccess) {
         json(response, 404, { error: "not found" });
         return;
@@ -128,6 +130,31 @@ async function startFixture(fixture) {
         mutation_allowed: true,
         apply: { state: "ready", reason: null, restored: null },
       });
+      return;
+    }
+    if (url.pathname === "/api/auth/status") {
+      json(response, 200, {
+        required: state?.remoteAccess?.password_configured === true,
+        authenticated: request.headers.authorization === `Bearer ${FIXTURE_SESSION_TOKEN}`,
+        local_peer_bypass: false,
+      });
+      return;
+    }
+    if (url.pathname === "/api/auth/session" && request.method === "POST") {
+      const body = await readJson(request);
+      if (body?.password !== FIXTURE_PASSWORD) {
+        json(response, 401, { error: "password required or rejected" });
+        return;
+      }
+      json(response, 200, { token: FIXTURE_SESSION_TOKEN.padEnd(32, "x") });
+      return;
+    }
+    if (
+      state?.remoteAccess?.password_configured === true &&
+      url.pathname !== "/api/capabilities" &&
+      request.headers.authorization !== `Bearer ${FIXTURE_SESSION_TOKEN.padEnd(32, "x")}`
+    ) {
+      json(response, 401, { error: "password required or rejected" });
       return;
     }
     if (url.pathname === "/api/capabilities") {
@@ -213,6 +240,15 @@ async function startFixture(fixture) {
   server.on("upgrade", (request, socket, head) => {
     const url = new URL(request.url ?? "/", `http://127.0.0.1:${fixture.port}`);
     if (!url.pathname.startsWith("/ws/")) {
+      socket.destroy();
+      return;
+    }
+    const state = fixtureStates.get(fixture.id);
+    if (
+      state?.remoteAccess?.password_configured === true &&
+      request.headers["sec-websocket-protocol"] !== `herdr-world-auth.${FIXTURE_SESSION_TOKEN.padEnd(32, "x")}`
+    ) {
+      socket.write("HTTP/1.1 401 Unauthorized\r\nConnection: close\r\n\r\n");
       socket.destroy();
       return;
     }
@@ -354,6 +390,7 @@ function setFixtureState(hostId, value) {
   const features = value.features ?? current.features;
   const commands = value.commands ?? current.commands;
   const launchCreatesSeat = value.launchCreatesSeat ?? current.launchCreatesSeat;
+  const passwordConfigured = value.passwordConfigured ?? current.remoteAccess.password_configured;
   if (
     !["ready", "offline", "malformed"].includes(snapshotMode) ||
     !["default", "empty", "empty-shell", "large", "idle-desk", "long-title", "showcase"].includes(snapshotVariant) ||
@@ -362,7 +399,8 @@ function setFixtureState(hostId, value) {
       (!Array.isArray(features) || features.some((feature) => typeof feature !== "string"))) ||
     (commands !== null &&
       (!Array.isArray(commands) || commands.some((command) => typeof command !== "string"))) ||
-    typeof launchCreatesSeat !== "boolean"
+    typeof launchCreatesSeat !== "boolean" ||
+    typeof passwordConfigured !== "boolean"
   ) {
     return false;
   }
@@ -374,7 +412,7 @@ function setFixtureState(hostId, value) {
     commands,
     launchCreatesSeat,
     launchedSeat: current.launchedSeat,
-    remoteAccess: current.remoteAccess,
+    remoteAccess: { ...current.remoteAccess, password_configured: passwordConfigured },
   });
   return true;
 }
@@ -698,14 +736,15 @@ function largePane(index, status, tabId, focused = false) {
   };
 }
 
-function setCorsHeaders(request, response) {
+function setCorsHeaders(fixture, request, response) {
   const origin = request.headers.origin;
-  if (origin) {
+  const state = fixtureStates.get(fixture.id);
+  if (origin && state?.remoteAccess?.allowed_page_origins.includes(origin)) {
     response.setHeader("access-control-allow-origin", origin);
     response.setHeader("vary", "Origin");
   }
   response.setHeader("access-control-allow-methods", "GET, POST, OPTIONS");
-  response.setHeader("access-control-allow-headers", "content-type");
+  response.setHeader("access-control-allow-headers", "content-type, authorization");
 }
 
 function json(response, status, value) {

--- a/scripts/e2e-fixture.mjs
+++ b/scripts/e2e-fixture.mjs
@@ -136,7 +136,7 @@ async function startFixture(fixture) {
       json(response, 200, {
         required: state?.remoteAccess?.password_configured === true,
         authenticated: request.headers.authorization === `Bearer ${FIXTURE_SESSION_TOKEN}`,
-        local_peer_bypass: false,
+        local_peer_bypass: fixture.serveStatic,
       });
       return;
     }
@@ -151,6 +151,7 @@ async function startFixture(fixture) {
     }
     if (
       state?.remoteAccess?.password_configured === true &&
+      !fixture.serveStatic &&
       url.pathname !== "/api/capabilities" &&
       request.headers.authorization !== `Bearer ${FIXTURE_SESSION_TOKEN.padEnd(32, "x")}`
     ) {
@@ -246,6 +247,7 @@ async function startFixture(fixture) {
     const state = fixtureStates.get(fixture.id);
     if (
       state?.remoteAccess?.password_configured === true &&
+      !fixture.serveStatic &&
       request.headers["sec-websocket-protocol"] !== `herdr-world-auth.${FIXTURE_SESSION_TOKEN.padEnd(32, "x")}`
     ) {
       socket.write("HTTP/1.1 401 Unauthorized\r\nConnection: close\r\n\r\n");

--- a/scripts/e2e-fixture.mjs
+++ b/scripts/e2e-fixture.mjs
@@ -270,6 +270,10 @@ async function startFixture(fixture) {
     log.connections += 1;
     const state = fixtureStates.get(fixture.id);
     const terminalId = url.searchParams.get("terminal_id") || "terminal";
+    if (url.searchParams.get("probe") === "true") {
+      webSocket.send(JSON.stringify({ type: "attach_ready" }));
+      return;
+    }
     webSocket.send(
       Buffer.from(
         state?.snapshotVariant === "showcase"

--- a/scripts/e2e-fixture.mjs
+++ b/scripts/e2e-fixture.mjs
@@ -135,7 +135,8 @@ async function startFixture(fixture) {
     if (url.pathname === "/api/auth/status") {
       json(response, 200, {
         required: state?.remoteAccess?.password_configured === true,
-        authenticated: request.headers.authorization === `Bearer ${FIXTURE_SESSION_TOKEN}`,
+        authenticated:
+          request.headers.authorization === `Bearer ${FIXTURE_SESSION_TOKEN.padEnd(32, "x")}`,
         local_peer_bypass: fixture.serveStatic,
       });
       return;

--- a/scripts/e2e-fixture.mjs
+++ b/scripts/e2e-fixture.mjs
@@ -14,6 +14,7 @@ const fixtureSockets = new Map();
 const servers = [];
 const FIXTURE_PASSWORD = "fixture-only-password";
 const FIXTURE_SESSION_TOKEN = "fixture-session-token";
+let remoteAccessApplySequence = 0;
 
 const fixtures = [
   {
@@ -119,8 +120,13 @@ async function startFixture(fixture) {
               ? false
               : state.remoteAccess.password_configured,
         };
-        fixtureStates.set(fixture.id, { ...state, remoteAccess });
-        json(response, 202, { state: "applying", reason: "settings saved; restarting", restored: null });
+        const applyId = `fixture-${remoteAccessApplySequence += 1}`;
+        fixtureStates.set(fixture.id, {
+          ...state,
+          remoteAccess,
+          remoteAccessApply: { id: applyId, state: "ready", reason: null, restored: false },
+        });
+        json(response, 202, { id: applyId, state: "applying", reason: "settings saved; restarting", restored: null });
         return;
       }
       json(response, 200, {
@@ -128,7 +134,7 @@ async function startFixture(fixture) {
         port: fixture.port,
         suggestions: ["bridge.example.test"],
         mutation_allowed: true,
-        apply: { state: "ready", reason: null, restored: null },
+        apply: state.remoteAccessApply,
       });
       return;
     }
@@ -383,6 +389,7 @@ function defaultFixtureState() {
       allowed_bridge_origins: [],
       password_configured: false,
     },
+    remoteAccessApply: { id: null, state: "ready", reason: null, restored: null },
   };
 }
 
@@ -420,6 +427,7 @@ function setFixtureState(hostId, value) {
     launchCreatesSeat,
     launchedSeat: current.launchedSeat,
     remoteAccess: { ...current.remoteAccess, password_configured: passwordConfigured },
+    remoteAccessApply: current.remoteAccessApply,
   });
   return true;
 }

--- a/scripts/herdr-world-plugin.mjs
+++ b/scripts/herdr-world-plugin.mjs
@@ -480,7 +480,17 @@ export function loadConfig(configDir) {
   } catch (error) {
     throw new PluginError(`could not parse ${configPath}: ${error.message}`);
   }
-  return validateConfig({ ...parsed, port_was_explicit: Object.hasOwn(parsed, "port") });
+  const portWasExplicit = Object.hasOwn(parsed, "port_was_explicit")
+    ? parsed.port_was_explicit === true
+    : Object.hasOwn(parsed, "port");
+  return validateConfig({ ...parsed, port_was_explicit: portWasExplicit });
+}
+
+function persistedConfig(config) {
+  const persisted = { ...config };
+  delete persisted.port_was_explicit;
+  if (config.port_was_explicit !== true) delete persisted.port;
+  return persisted;
 }
 
 function isLoopbackHost(host) {
@@ -1894,7 +1904,7 @@ function applyStatusPath(stateDir) {
   return path.join(stateDir, APPLY_STATUS_FILE);
 }
 
-function writeApplyStatus(stateDir, state, reason = null, restored = null) {
+function writeApplyStatus(stateDir, applyId, state, reason = null, restored = null) {
   const boundedReason = typeof reason === "string" && reason.trim()
     ? reason
       .replace(/[\r\n]+/g, " ")
@@ -1903,6 +1913,7 @@ function writeApplyStatus(stateDir, state, reason = null, restored = null) {
       .slice(0, 240)
     : null;
   atomicWrite(applyStatusPath(stateDir), `${JSON.stringify({
+    id: applyId,
     state,
     reason: boundedReason,
     restored,
@@ -1928,10 +1939,15 @@ function readRemoteAccessRequest(draftPath) {
   } catch (error) {
     throw new PluginError(`could not read remote access draft: ${error.message}`);
   }
-  if (!isObject(parsed) || !isObject(parsed.remote_access)) {
+  if (!isObject(parsed) || !isObject(parsed.remote_access) ||
+      (parsed.apply_id !== undefined &&
+        (typeof parsed.apply_id !== "string" || !/^[A-Za-z0-9_-]{1,128}$/.test(parsed.apply_id)))) {
     throw new PluginError("remote access draft is invalid");
   }
-  return normalizeRemoteAccess(parsed);
+  return {
+    applyId: parsed.apply_id ?? null,
+    remoteAccess: normalizeRemoteAccess(parsed),
+  };
 }
 
 export async function applyRemoteAccessAction({
@@ -1944,6 +1960,12 @@ export async function applyRemoteAccessAction({
 } = {}) {
   const handoffGraceMs = Number(env.HERDR_WORLD_APPLY_GRACE_MS ?? 0);
   const lockContext = runtimeContext(env);
+  let applyId = null;
+  try {
+    applyId = readRemoteAccessRequest(draftPath).applyId;
+  } catch {
+    // The locked apply path below reports the bounded validation failure.
+  }
 
   const execute = async () => {
     let context;
@@ -1953,7 +1975,7 @@ export async function applyRemoteAccessAction({
     let previousActive = false;
     let baselineCaptured = false;
 
-    writeApplyStatus(lockContext.stateDir, "applying", "settings saved; reconciling the managed bridge", null);
+    writeApplyStatus(lockContext.stateDir, applyId, "applying", "settings saved; reconciling the managed bridge", null);
     try {
       if (Number.isFinite(handoffGraceMs) && handoffGraceMs > 0) {
         await new Promise((resolve) => setTimeout(resolve, Math.min(handoffGraceMs, 1000)));
@@ -1966,7 +1988,9 @@ export async function applyRemoteAccessAction({
       previousText = existsSync(configPath) ? readFileSync(configPath, "utf8") : null;
       previousConfig = context.config;
       baselineCaptured = true;
-      const remoteAccess = readRemoteAccessRequest(draftPath);
+      const request = readRemoteAccessRequest(draftPath);
+      applyId = request.applyId;
+      const remoteAccess = request.remoteAccess;
       const nextConfig = configWithRemoteAccess(previousConfig, remoteAccess);
       const recordPath = targetRecordPath(context.stateDir, context.target.identity);
       const record = readRecord(recordPath);
@@ -1985,13 +2009,13 @@ export async function applyRemoteAccessAction({
           throw new PluginError("fallback bridge service ownership could not be verified because its runtime record is missing; run the plugin stop and start actions before applying settings");
         }
       }
-      atomicWrite(configPath, `${JSON.stringify(nextConfig, null, 2)}\n`);
+      atomicWrite(configPath, `${JSON.stringify(persistedConfig(nextConfig), null, 2)}\n`);
       if (previousActive) {
         const plan = prepareStart({ root, env, platform, arch, glibcVersion, configOverride: nextConfig });
         await startPrepared(plan, { lockHeld: true });
-        writeApplyStatus(context.stateDir, "ready", "bridge ready after applying settings", false);
+        writeApplyStatus(context.stateDir, applyId, "ready", "bridge ready after applying settings", false);
       } else {
-        writeApplyStatus(context.stateDir, "ready", "settings saved; the managed bridge was not running", false);
+        writeApplyStatus(context.stateDir, applyId, "ready", "settings saved; the managed bridge was not running", false);
       }
       return nextConfig;
     } catch (error) {
@@ -2007,6 +2031,7 @@ export async function applyRemoteAccessAction({
         } catch (restoreError) {
           writeApplyStatus(
             lockContext.stateDir,
+            applyId,
             "failed",
             `settings apply failed and recovery could not be verified: ${restoreError.message}`,
             false,
@@ -2014,7 +2039,7 @@ export async function applyRemoteAccessAction({
           throw error;
         }
       }
-      writeApplyStatus(lockContext.stateDir, "failed", error instanceof Error ? error.message : String(error), restored);
+      writeApplyStatus(lockContext.stateDir, applyId, "failed", error instanceof Error ? error.message : String(error), restored);
       throw error;
     } finally {
       rmSync(draftPath, { force: true });

--- a/scripts/herdr-world-plugin.mjs
+++ b/scripts/herdr-world-plugin.mjs
@@ -401,8 +401,8 @@ export function normalizeRemoteAccess(input) {
   const allowed_page_origins = validStringArray(source.allowed_page_origins, validOrigin, "remote_access.allowed_page_origins (legacy allowed_origins)");
   const allowed_bridge_origins = validStringArray(source.allowed_bridge_origins, validOrigin, "remote_access.allowed_bridge_origins");
   if (!validPasswordHash(source.password_hash ?? null)) throw new PluginError("remote_access.password_hash must be null or a bounded Argon2 hash");
-  if (source.enabled && (accepted_hosts.length === 0 || allowed_page_origins.length === 0)) {
-    throw new PluginError("enabled remote access requires accepted_hosts and allowed_page_origins; legacy allowed_hosts and allowed_origins must not be empty");
+  if (source.enabled && accepted_hosts.length === 0) {
+    throw new PluginError("enabled remote access requires accepted_hosts; legacy allowed_hosts must not be empty");
   }
   return {
     enabled: source.enabled,
@@ -465,8 +465,8 @@ export function validateConfig(input) {
   if (config.bridge_label !== null && (typeof config.bridge_label !== "string" || config.bridge_label.length === 0 || config.bridge_label.length > 80 || /[\0\r\n]/.test(config.bridge_label))) {
     throw new PluginError("config bridge_label must be 1-80 characters without control characters");
   }
-  if (!isLoopbackHost(config.host) && (config.allowed_hosts.length === 0 || config.allowed_origins.length === 0)) {
-    throw new PluginError("non-loopback binding requires explicit allowed_hosts and allowed_origins configuration");
+  if (!isLoopbackHost(config.host) && config.allowed_hosts.length === 0) {
+    throw new PluginError("non-loopback binding requires explicit allowed_hosts configuration");
   }
   return config;
 }

--- a/scripts/herdr-world-plugin.mjs
+++ b/scripts/herdr-world-plugin.mjs
@@ -418,7 +418,9 @@ export function configWithRemoteAccess(config, remoteAccess) {
   return validateConfig({
     ...config,
     remote_access,
-    host: remote_access.enabled ? "0.0.0.0" : "127.0.0.1",
+    host: remote_access.enabled
+      ? remoteBindHost(config.host, remote_access)
+      : loopbackBindHost(config.host),
     allowed_hosts: remote_access.accepted_hosts,
     allowed_origins: remote_access.allowed_page_origins,
     allowed_connect_origins: remote_access.allowed_bridge_origins,
@@ -432,7 +434,9 @@ export function validateConfig(input) {
   const remote_access = normalizeRemoteAccess(input);
   config.remote_access = remote_access;
   config.host = isObject(input.remote_access)
-    ? (remote_access.enabled ? "0.0.0.0" : "127.0.0.1")
+    ? (remote_access.enabled
+      ? remoteBindHost(config.host, remote_access)
+      : loopbackBindHost(config.host))
     : config.host;
   config.allowed_hosts = remote_access.accepted_hosts;
   config.allowed_origins = remote_access.allowed_page_origins;
@@ -480,9 +484,26 @@ export function loadConfig(configDir) {
 }
 
 function isLoopbackHost(host) {
-  if (host === "localhost") return true;
-  const version = net.isIP(host);
-  return version === 4 ? host.split(".")[0] === "127" : version === 6 && host === "::1";
+  const normalized = unbracketedHost(host).toLowerCase();
+  if (normalized === "localhost") return true;
+  const version = net.isIP(normalized);
+  return version === 4 ? normalized.split(".")[0] === "127" : version === 6 && normalized === "::1";
+}
+
+function isIpv6Host(host) {
+  return net.isIP(unbracketedHost(host)) === 6;
+}
+
+function loopbackBindHost(host) {
+  return isIpv6Host(host) ? "::1" : "127.0.0.1";
+}
+
+function remoteBindHost(host, remoteAccess) {
+  if (isIpv6Host(host) || remoteAccess.accepted_hosts.some((value) => isIpv6Host(value))) {
+    return "::";
+  }
+  const normalized = unbracketedHost(host);
+  return !isLoopbackHost(normalized) && normalized !== "0.0.0.0" ? normalized : "0.0.0.0";
 }
 
 function hash(value) {
@@ -933,7 +954,7 @@ export async function choosePort(config, identity, stateDir, { portFree = portIs
   throw new PluginError(`no free bridge port is available in ${config.port_range[0]}-${config.port_range[1]}`);
 }
 
-function selectedEnvironment(env, target, serviceId, root, nodePath) {
+function selectedEnvironment(env, target, serviceId, root, nodePath, supervisor) {
   const result = {
     HERDR_SOCKET_PATH: target.socket_path,
     HERDR_WORLD_SETUP: "never",
@@ -949,6 +970,12 @@ function selectedEnvironment(env, target, serviceId, root, nodePath) {
   }
   result.HERDR_WORLD_CONTROLLER = path.join(root, "scripts", "herdr-world-plugin.mjs");
   result.HERDR_WORLD_NODE_PATH = nodePath;
+  result.HERDR_WORLD_CONTROLLER_MODE = supervisor.kind;
+  if (supervisor.kind === "systemd-user") {
+    result.HERDR_WORLD_SYSTEMD_RUN = resolveExecutable("systemd-run", { env });
+  } else if (supervisor.kind === "launchd") {
+    result.HERDR_WORLD_LAUNCHCTL = supervisor.command;
+  }
   return result;
 }
 
@@ -990,6 +1017,18 @@ function pathForSupervisor(stateDir, record, suffix) {
     return path.join(stateDir, "supervisors", record.service_name);
   }
   return path.join(stateDir, "supervisors", `${hash(record.target_identity).slice(0, 32)}.${suffix}`);
+}
+
+function fallbackLeasePath(stateDir, identity) {
+  return path.join(stateDir, "supervisors", `${hash(identity).slice(0, 32)}.fallback-lease`);
+}
+
+function writeFallbackLease(stateDir, record) {
+  atomicWrite(fallbackLeasePath(stateDir, record.target_identity), `${JSON.stringify(record, null, 2)}\n`);
+}
+
+function removeFallbackLease(stateDir, identity) {
+  rmSync(fallbackLeasePath(stateDir, identity), { force: true });
 }
 
 function systemdEscape(value) {
@@ -1139,11 +1178,12 @@ function unrecordedService(identity, supervisor) {
   return {
     target_identity: identity,
     supervisor: supervisor.kind,
+    controller_mode: supervisor.kind,
     service_name: serviceName(identity, supervisor.kind),
   };
 }
 
-async function recoverUnrecordedService(identity, stateDir, supervisor) {
+async function recoverUnrecordedService(identity, stateDir, supervisor, platform = process.platform) {
   if (supervisor.kind === "launchd") {
     const record = unrecordedService(identity, supervisor);
     if (!launchdServicePresent(record, supervisor.command)) return false;
@@ -1197,6 +1237,31 @@ async function recoverUnrecordedService(identity, stateDir, supervisor) {
     return true;
   }
 
+  if (supervisor.kind === "fallback") {
+    const leasePath = fallbackLeasePath(stateDir, identity);
+    const record = readRecord(leasePath);
+    if (!record) return false;
+    if (
+      record.target_identity !== identity ||
+      record.supervisor !== "fallback" ||
+      record.service_name !== serviceName(identity, "fallback")
+    ) {
+      throw new PluginError("fallback service ownership is stale; refusing to signal an unrelated process");
+    }
+    const state = supervisorStatus(record, supervisor, platform);
+    if (!state.active) {
+      removeFallbackLease(stateDir, identity);
+      return false;
+    }
+    if (!state.owned) {
+      throw new PluginError("fallback service ownership is stale; refusing to signal an unrelated process");
+    }
+    stopProcessGroup(record.pid);
+    await waitForStopped(record, supervisor, platform);
+    removeFallbackLease(stateDir, identity);
+    return true;
+  }
+
   return false;
 }
 
@@ -1238,7 +1303,10 @@ function createRecord({ identity, target, config, payload, node, port, superviso
     root: path.resolve(root),
     updated_at: new Date().toISOString(),
   };
-  return { record, environment: selectedEnvironment(env, target, record.service_name, root, node.path) };
+  return {
+    record,
+    environment: selectedEnvironment(env, target, record.service_name, root, node.path, supervisor),
+  };
 }
 
 function spawnFallback(record, environment, stateDir) {
@@ -1252,6 +1320,12 @@ function spawnFallback(record, environment, stateDir) {
       stdio: ["ignore", fd, fd],
     });
     if (!Number.isInteger(child.pid)) throw new PluginError("fallback supervisor did not return a process id");
+    try {
+      writeFallbackLease(stateDir, { ...record, pid: child.pid });
+    } catch (error) {
+      try { process.kill(-child.pid, "SIGTERM"); } catch {}
+      throw error;
+    }
     child.unref();
     return child.pid;
   } finally {
@@ -1452,6 +1526,9 @@ async function stopRecord(record, env, platform = process.platform) {
     await unloadLaunchd(record, supervisor.command);
   }
   if (record.supervisor !== "launchd") await waitForStopped(record, supervisor, platform);
+  if (record.supervisor === "fallback" && env.HERDR_PLUGIN_STATE_DIR) {
+    removeFallbackLease(env.HERDR_PLUGIN_STATE_DIR, record.target_identity);
+  }
   if (record.supervisor === "systemd-user") {
     try {
       runChecked(supervisor.command, ["--user", "disable", record.service_name]);
@@ -1469,6 +1546,7 @@ function recordCompatible(record, manifestVersion, payload, config, target, node
     record.payload_root === payload.packageRoot &&
     record.node_path === node.path &&
     record.host === config.host &&
+    record.controller_mode === record.supervisor &&
     record.socket_path === target.socket_path &&
     record.session_name === target.session_name &&
     (config.port_was_explicit !== true || record.port === config.port) &&
@@ -1532,7 +1610,12 @@ async function startPrepared(plan, { lockHeld = false } = {}) {
       if (ownership.state.active) await stopRecord(previous, env, platform);
       removeRecord(recordPath);
     }
-    const recovered = await recoverUnrecordedService(context.target.identity, context.stateDir, supervisor);
+    const recovered = await recoverUnrecordedService(
+      context.target.identity,
+      context.stateDir,
+      supervisor,
+      platform,
+    );
     if (recovered) {
       console.log("Recovered an unrecorded Herdr World service; applying the current configuration.");
     }
@@ -1620,7 +1703,12 @@ async function stopAction({ root = ROOT, env = process.env, platform = process.p
   const record = readRecord(recordPath);
   if (!record) {
     const supervisor = selectSupervisor(platform, env);
-    const recovered = await recoverUnrecordedService(context.target.identity, context.stateDir, supervisor);
+    const recovered = await recoverUnrecordedService(
+      context.target.identity,
+      context.stateDir,
+      supervisor,
+      platform,
+    );
     if (recovered) {
       console.log(`Stopped the unrecorded Herdr World service for ${displayTarget(context.target)}.`);
       return null;
@@ -1845,6 +1933,10 @@ export async function applyRemoteAccessAction({
   arch = process.arch,
   glibcVersion,
 } = {}) {
+  const handoffGraceMs = Number(env.HERDR_WORLD_APPLY_GRACE_MS ?? 0);
+  if (Number.isFinite(handoffGraceMs) && handoffGraceMs > 0) {
+    await new Promise((resolve) => setTimeout(resolve, Math.min(handoffGraceMs, 1000)));
+  }
   const context = runtimeContext(env);
   const configPath = path.join(context.configDir, CONFIG_FILE);
   const previousText = existsSync(configPath) ? readFileSync(configPath, "utf8") : null;
@@ -1859,6 +1951,20 @@ export async function applyRemoteAccessAction({
     if (record) {
       const ownership = assertRecordOwnership(record, env, platform);
       previousActive = ownership.state.active;
+    } else {
+      const supervisor = selectSupervisor(platform, env);
+      previousActive = await recoverUnrecordedService(
+        context.target.identity,
+        context.stateDir,
+        supervisor,
+        platform,
+      );
+      if (supervisor.kind === "fallback" && !previousActive) {
+        const reason = "fallback bridge service ownership could not be verified because its runtime record is missing; run the plugin stop and start actions before applying settings";
+        writeApplyStatus(context.stateDir, "failed", reason, false);
+        rmSync(draftPath, { force: true });
+        throw new PluginError(reason);
+      }
     }
     writeApplyStatus(context.stateDir, "applying", "settings saved; reconciling the managed bridge", null);
     try {

--- a/scripts/herdr-world-plugin.mjs
+++ b/scripts/herdr-world-plugin.mjs
@@ -48,6 +48,9 @@ const RUNTIME_TIMEOUT_MS = 5_000;
 const START_TIMEOUT_MS = 15_000;
 const STOP_TIMEOUT_MS = 5_000;
 const LOCK_TIMEOUT_MS = 10_000;
+const APPLY_STATUS_FILE = "remote-access-apply.json";
+const MAX_REMOTE_ACCESS_ITEMS = 32;
+const MAX_REMOTE_ACCESS_VALUE_BYTES = 512;
 
 export class PluginError extends Error {
   constructor(message, options = {}) {
@@ -325,13 +328,27 @@ const DEFAULT_CONFIG = {
   allowed_origins: [],
   allowed_connect_origins: [],
   bridge_label: null,
+  remote_access: {
+    enabled: false,
+    accepted_hosts: [],
+    allowed_page_origins: [],
+    allowed_bridge_origins: [],
+    password_hash: null,
+  },
 };
 
 function validHost(value) {
   if (typeof value !== "string" || value.length === 0 || value.length > 253 || /[\s\0\r\n]/.test(value)) return false;
-  if (net.isIP(value)) return true;
-  return !value.includes("/") && !value.includes("\\") &&
-    /^(?=.{1,253}$)(?:[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?)(?:\.(?:[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?))*$/.test(value);
+  const host = unbracketedHost(value);
+  if (value.trim().startsWith("[") && (net.isIP(host) !== 6 || !value.trim().endsWith("]"))) return false;
+  if (net.isIP(host)) return true;
+  return !host.includes("/") && !host.includes("\\") &&
+    /^(?=.{1,253}$)(?:[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?)(?:\.(?:[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?))*$/.test(host);
+}
+
+function unbracketedHost(value) {
+  const trimmed = value.trim();
+  return trimmed.startsWith("[") && trimmed.endsWith("]") ? trimmed.slice(1, -1) : trimmed;
 }
 
 function validSession(value) {
@@ -351,6 +368,15 @@ function validOrigin(value) {
   }
 }
 
+function validPasswordHash(value) {
+  return value === null || (
+    typeof value === "string" &&
+    value.length <= MAX_REMOTE_ACCESS_VALUE_BYTES &&
+    value.startsWith("$argon2") &&
+    !/[\0\r\n]/.test(value)
+  );
+}
+
 function validStringArray(value, validator, label) {
   if (!Array.isArray(value) || value.length > 32 || value.some((item) => !validator(item))) {
     throw new PluginError(`${label} must be an array of valid values`);
@@ -358,11 +384,60 @@ function validStringArray(value, validator, label) {
   return [...new Set(value)];
 }
 
+export function normalizeRemoteAccess(input) {
+  const hasHighLevel = isObject(input.remote_access);
+  const source = hasHighLevel
+    ? input.remote_access
+    : {
+        enabled: !isLoopbackHost(input.host ?? DEFAULT_CONFIG.host),
+        accepted_hosts: input.allowed_hosts ?? [],
+        allowed_page_origins: input.allowed_origins ?? [],
+        allowed_bridge_origins: input.allowed_connect_origins ?? [],
+        password_hash: null,
+      };
+  if (typeof source.enabled !== "boolean") throw new PluginError("remote_access.enabled must be boolean");
+  const accepted_hosts = validStringArray(source.accepted_hosts, validHost, "remote_access.accepted_hosts")
+    .map(unbracketedHost);
+  const allowed_page_origins = validStringArray(source.allowed_page_origins, validOrigin, "remote_access.allowed_page_origins (legacy allowed_origins)");
+  const allowed_bridge_origins = validStringArray(source.allowed_bridge_origins, validOrigin, "remote_access.allowed_bridge_origins");
+  if (!validPasswordHash(source.password_hash ?? null)) throw new PluginError("remote_access.password_hash must be null or a bounded Argon2 hash");
+  if (source.enabled && (accepted_hosts.length === 0 || allowed_page_origins.length === 0)) {
+    throw new PluginError("enabled remote access requires accepted_hosts and allowed_page_origins; legacy allowed_hosts and allowed_origins must not be empty");
+  }
+  return {
+    enabled: source.enabled,
+    accepted_hosts,
+    allowed_page_origins,
+    allowed_bridge_origins,
+    password_hash: source.password_hash ?? null,
+  };
+}
+
+export function configWithRemoteAccess(config, remoteAccess) {
+  const remote_access = normalizeRemoteAccess({ remote_access: remoteAccess });
+  return validateConfig({
+    ...config,
+    remote_access,
+    host: remote_access.enabled ? "0.0.0.0" : "127.0.0.1",
+    allowed_hosts: remote_access.accepted_hosts,
+    allowed_origins: remote_access.allowed_page_origins,
+    allowed_connect_origins: remote_access.allowed_bridge_origins,
+  });
+}
+
 export function validateConfig(input) {
   if (!isObject(input)) throw new PluginError("plugin config must be a JSON object");
   const config = { ...DEFAULT_CONFIG, ...input };
-  config.port_was_explicit = input.port_was_explicit === true;
   if (!validHost(config.host)) throw new PluginError("config host must be a non-empty hostname or IP literal");
+  const remote_access = normalizeRemoteAccess(input);
+  config.remote_access = remote_access;
+  config.host = isObject(input.remote_access)
+    ? (remote_access.enabled ? "0.0.0.0" : "127.0.0.1")
+    : config.host;
+  config.allowed_hosts = remote_access.accepted_hosts;
+  config.allowed_origins = remote_access.allowed_page_origins;
+  config.allowed_connect_origins = remote_access.allowed_bridge_origins;
+  config.port_was_explicit = input.port_was_explicit === true;
   if (!Number.isInteger(config.port) || config.port < 1 || config.port > 65535) {
     throw new PluginError("config port must be an integer between 1 and 65535");
   }
@@ -386,9 +461,6 @@ export function validateConfig(input) {
   if (config.bridge_label !== null && (typeof config.bridge_label !== "string" || config.bridge_label.length === 0 || config.bridge_label.length > 80 || /[\0\r\n]/.test(config.bridge_label))) {
     throw new PluginError("config bridge_label must be 1-80 characters without control characters");
   }
-  config.allowed_hosts = validStringArray(config.allowed_hosts, validHost, "config allowed_hosts");
-  config.allowed_origins = validStringArray(config.allowed_origins, validOrigin, "config allowed_origins");
-  config.allowed_connect_origins = validStringArray(config.allowed_connect_origins, validOrigin, "config allowed_connect_origins");
   if (!isLoopbackHost(config.host) && (config.allowed_hosts.length === 0 || config.allowed_origins.length === 0)) {
     throw new PluginError("non-loopback binding requires explicit allowed_hosts and allowed_origins configuration");
   }
@@ -408,7 +480,9 @@ export function loadConfig(configDir) {
 }
 
 function isLoopbackHost(host) {
-  return host === "localhost" || host === "127.0.0.1" || host === "::1";
+  if (host === "localhost") return true;
+  const version = net.isIP(host);
+  return version === 4 ? host.split(".")[0] === "127" : version === 6 && host === "::1";
 }
 
 function hash(value) {
@@ -599,9 +673,9 @@ export function buildPayload({ root = ROOT, env = process.env, nodePath, npmPath
   }
 }
 
-function runtimeContext(env) {
+function runtimeContext(env, configOverride) {
   const directories = ensureRuntimeDirectories(env);
-  const config = loadConfig(directories.configDir);
+  const config = configOverride ?? loadConfig(directories.configDir);
   const target = resolveTargetIdentity(config, env);
   return { ...directories, config, target };
 }
@@ -699,10 +773,11 @@ function safeCapability(capabilities, expectedVersion) {
   return null;
 }
 
-export async function probeCapabilities(url, { timeoutMs = 750, fetchImpl = globalThis.fetch } = {}) {
+export async function probeCapabilities(url, { timeoutMs = 750, fetchImpl = globalThis.fetch, headers } = {}) {
   try {
     const response = await fetchImpl(`${url}/api/capabilities`, {
       signal: AbortSignal.timeout(timeoutMs),
+      ...(headers ? { headers } : {}),
     });
     if (!response.ok) {
       await response.body?.cancel?.();
@@ -720,11 +795,21 @@ export async function probeCapabilities(url, { timeoutMs = 750, fetchImpl = glob
   }
 }
 
+function probeHeaders(record) {
+  if (typeof record?.host !== "string" || !Number.isInteger(record.port)) return undefined;
+  const args = Array.isArray(record?.bridge_args) ? record.bridge_args : [];
+  const hostIndex = args.indexOf("--allow-host");
+  const acceptedHost = hostIndex >= 0 ? args[hostIndex + 1] : null;
+  const host = acceptedHost || probeHost(record.host);
+  const displayHost = net.isIP(host) === 6 ? `[${host}]` : host;
+  return { host: `${displayHost}:${record.port}` };
+}
+
 export async function waitForReadiness(url, expected, { timeoutMs = START_TIMEOUT_MS, fetchImpl } = {}) {
   const deadline = Date.now() + timeoutMs;
   let lastError = "no response";
   while (Date.now() < deadline) {
-    const result = await probeCapabilities(url, { fetchImpl });
+    const result = await probeCapabilities(url, { fetchImpl, headers: probeHeaders(expected) });
     if (result.ok) {
       const compatibility = safeCapability(result.capabilities, expected.package_version);
       if (!compatibility) return result.capabilities;
@@ -848,16 +933,22 @@ export async function choosePort(config, identity, stateDir, { portFree = portIs
   throw new PluginError(`no free bridge port is available in ${config.port_range[0]}-${config.port_range[1]}`);
 }
 
-function selectedEnvironment(env, target, serviceId) {
+function selectedEnvironment(env, target, serviceId, root, nodePath) {
   const result = {
     HERDR_SOCKET_PATH: target.socket_path,
     HERDR_WORLD_SETUP: "never",
     HERDR_WORLD_PLUGIN_SERVICE_ID: serviceId,
     PATH: env.PATH || "/usr/local/bin:/usr/bin:/bin",
   };
-  for (const name of ["HOME", "XDG_CONFIG_HOME", "XDG_DATA_HOME", "XDG_STATE_HOME", "HERDR_CONFIG_PATH", "TMPDIR", "LANG", "LC_ALL"]) {
+  for (const name of [
+    "HOME", "XDG_CONFIG_HOME", "XDG_DATA_HOME", "XDG_STATE_HOME", "HERDR_CONFIG_PATH", "TMPDIR",
+    "LANG", "LC_ALL", "HERDR_PLUGIN_CONFIG_DIR", "HERDR_PLUGIN_STATE_DIR", "HERDR_BIN_PATH",
+    "HERDR_WORLD_LAUNCHCTL", "HERDR_WORLD_SYSTEMCTL",
+  ]) {
     if (env[name]) result[name] = env[name];
   }
+  result.HERDR_WORLD_CONTROLLER = path.join(root, "scripts", "herdr-world-plugin.mjs");
+  result.HERDR_WORLD_NODE_PATH = nodePath;
   return result;
 }
 
@@ -869,6 +960,7 @@ function bridgeArguments(config, target, port) {
   for (const host of config.allowed_hosts) args.push("--allow-host", host);
   for (const origin of config.allowed_origins) args.push("--allow-origin", origin);
   for (const origin of config.allowed_connect_origins) args.push("--allow-connect-origin", origin);
+  if (config.remote_access.password_hash) args.push("--password-hash", config.remote_access.password_hash);
   if (config.bridge_label) args.push("--bridge-label", config.bridge_label);
   return args;
 }
@@ -888,6 +980,7 @@ function configSignature(config) {
     allowed_hosts: config.allowed_hosts,
     allowed_origins: config.allowed_origins,
     allowed_connect_origins: config.allowed_connect_origins,
+    password_hash: config.remote_access.password_hash,
     bridge_label: config.bridge_label,
   }));
 }
@@ -1145,7 +1238,7 @@ function createRecord({ identity, target, config, payload, node, port, superviso
     root: path.resolve(root),
     updated_at: new Date().toISOString(),
   };
-  return { record, environment: selectedEnvironment(env, target, record.service_name) };
+  return { record, environment: selectedEnvironment(env, target, record.service_name, root, node.path) };
 }
 
 function spawnFallback(record, environment, stateDir) {
@@ -1385,7 +1478,7 @@ function recordCompatible(record, manifestVersion, payload, config, target, node
 
 async function currentRecordReadiness(record) {
   if (!record?.url) return { ready: false, error: "service record has no URL" };
-  const result = await probeCapabilities(probeUrl(record.host, record.port));
+  const result = await probeCapabilities(probeUrl(record.host, record.port), { headers: probeHeaders(record) });
   if (!result.ok) return { ready: false, error: result.error };
   const error = safeCapability(result.capabilities, record.package_version);
   return error ? { ready: false, error } : { ready: true, capabilities: result.capabilities };
@@ -1410,11 +1503,11 @@ function printService(record, capabilities, prefix = "Herdr World") {
   console.log(`  access: ${displayPosture(record.host)}`);
 }
 
-function prepareStart({ root = ROOT, env = process.env, platform = process.platform, arch = process.arch, glibcVersion } = {}) {
+function prepareStart({ root = ROOT, env = process.env, platform = process.platform, arch = process.arch, glibcVersion, configOverride } = {}) {
   const manifestVersion = readManifestVersion(root);
   const targetPlatform = selectTarget({ platform, arch, glibcVersion });
   const node = checkNode(resolveNode({ env }));
-  const context = runtimeContext(env);
+  const context = runtimeContext(env, configOverride);
   const targetStatus = resolveHerdrTarget(context.config, env);
   const target = { ...context.target, socket_path: targetStatus.socket_path };
   const payload = requirePayload(root, manifestVersion, targetPlatform.target);
@@ -1700,8 +1793,113 @@ async function doctorAction({ root = ROOT, env = process.env, platform = process
   return checks;
 }
 
+function applyStatusPath(stateDir) {
+  return path.join(stateDir, APPLY_STATUS_FILE);
+}
+
+function writeApplyStatus(stateDir, state, reason = null, restored = null) {
+  const boundedReason = typeof reason === "string" && reason.trim()
+    ? reason
+      .replace(/[\r\n]+/g, " ")
+      .replace(/(^|[\s("'=])((?:\/|[A-Za-z]:[\\/])[^\s,;)]+)/g, "$1[path]")
+      .trim()
+      .slice(0, 240)
+    : null;
+  atomicWrite(applyStatusPath(stateDir), `${JSON.stringify({
+    state,
+    reason: boundedReason,
+    restored,
+    updated_at: new Date().toISOString(),
+  }, null, 2)}\n`);
+}
+
+function restoreConfig(configPath, previousText) {
+  if (previousText === null) {
+    rmSync(configPath, { force: true });
+  } else {
+    atomicWrite(configPath, previousText);
+  }
+}
+
+function readRemoteAccessRequest(draftPath) {
+  if (typeof draftPath !== "string" || !path.isAbsolute(draftPath)) {
+    throw new PluginError("remote access draft path must be absolute");
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(readFileSync(draftPath, "utf8"));
+  } catch (error) {
+    throw new PluginError(`could not read remote access draft: ${error.message}`);
+  }
+  if (!isObject(parsed) || !isObject(parsed.remote_access)) {
+    throw new PluginError("remote access draft is invalid");
+  }
+  return normalizeRemoteAccess(parsed);
+}
+
+export async function applyRemoteAccessAction({
+  draftPath,
+  root = ROOT,
+  env = process.env,
+  platform = process.platform,
+  arch = process.arch,
+  glibcVersion,
+} = {}) {
+  const context = runtimeContext(env);
+  const configPath = path.join(context.configDir, CONFIG_FILE);
+  const previousText = existsSync(configPath) ? readFileSync(configPath, "utf8") : null;
+  const previousConfig = context.config;
+  const remoteAccess = readRemoteAccessRequest(draftPath);
+  const nextConfig = configWithRemoteAccess(previousConfig, remoteAccess);
+  const recordPath = targetRecordPath(context.stateDir, context.target.identity);
+
+  const execute = async () => {
+    const record = readRecord(recordPath);
+    let previousActive = false;
+    if (record) {
+      const ownership = assertRecordOwnership(record, env, platform);
+      previousActive = ownership.state.active;
+    }
+    writeApplyStatus(context.stateDir, "applying", "settings saved; reconciling the managed bridge", null);
+    try {
+      atomicWrite(configPath, `${JSON.stringify(nextConfig, null, 2)}\n`);
+      if (previousActive) {
+        const plan = prepareStart({ root, env, platform, arch, glibcVersion, configOverride: nextConfig });
+        await startPrepared(plan, { lockHeld: true });
+        writeApplyStatus(context.stateDir, "ready", "bridge ready after applying settings", false);
+      } else {
+        writeApplyStatus(context.stateDir, "ready", "settings saved; the managed bridge was not running", false);
+      }
+      return nextConfig;
+    } catch (error) {
+      let restored = false;
+      try {
+        restoreConfig(configPath, previousText);
+        if (previousActive) {
+          const plan = prepareStart({ root, env, platform, arch, glibcVersion, configOverride: previousConfig });
+          await startPrepared(plan, { lockHeld: true });
+        }
+        restored = true;
+      } catch (restoreError) {
+        writeApplyStatus(
+          context.stateDir,
+          "failed",
+          `settings apply failed and recovery could not be verified: ${restoreError.message}`,
+          false,
+        );
+        throw error;
+      }
+      writeApplyStatus(context.stateDir, "failed", error instanceof Error ? error.message : String(error), restored);
+      throw error;
+    } finally {
+      rmSync(draftPath, { force: true });
+    }
+  };
+  return withTargetLock(context.stateDir, context.target.identity, execute);
+}
+
 export async function runAction(action, options = {}) {
-  if (![...ACTIONS, STARTUP_COMMAND].includes(action)) throw new PluginError(`unknown action ${action}; expected ${[...ACTIONS, STARTUP_COMMAND].join(" | ")}`);
+  if (![...ACTIONS, STARTUP_COMMAND, "apply"].includes(action)) throw new PluginError(`unknown action ${action}; expected ${[...ACTIONS, STARTUP_COMMAND].join(" | ")}`);
   if (action === "build") return buildPayload(options);
   if (action === "start") return startAction(options);
   if (action === STARTUP_COMMAND) return startupAction(options);
@@ -1709,16 +1907,17 @@ export async function runAction(action, options = {}) {
   if (action === "restart") return restartAction(options);
   if (action === "status") return statusAction(options);
   if (action === "open") return openAction(options);
+  if (action === "apply") return applyRemoteAccessAction(options);
   return doctorAction(options);
 }
 
 if (process.argv[1] && path.resolve(process.argv[1]) === path.resolve(fileURLToPath(import.meta.url))) {
   const [action, ...extra] = process.argv.slice(2);
-  if (!action || extra.length > 0 || ![...ACTIONS, STARTUP_COMMAND].includes(action)) {
+  if (!action || (![...ACTIONS, STARTUP_COMMAND].includes(action) && action !== "apply") || (action !== "apply" && extra.length > 0) || (action === "apply" && extra.length !== 1)) {
     console.error(`Usage: herdr-world-plugin.sh ${[...ACTIONS, STARTUP_COMMAND].join(" | ")}`);
     process.exit(2);
   }
-  runAction(action).catch((error) => {
+  runAction(action, action === "apply" ? { draftPath: extra[0] } : {}).catch((error) => {
     console.error(`Herdr World plugin ${action} failed: ${error.message}`);
     process.exitCode = 1;
   });

--- a/scripts/herdr-world-plugin.mjs
+++ b/scripts/herdr-world-plugin.mjs
@@ -970,7 +970,8 @@ function selectedEnvironment(env, target, serviceId, root, nodePath, supervisor)
   };
   for (const name of [
     "HOME", "XDG_CONFIG_HOME", "XDG_DATA_HOME", "XDG_STATE_HOME", "HERDR_CONFIG_PATH", "TMPDIR",
-    "LANG", "LC_ALL", "HERDR_PLUGIN_CONFIG_DIR", "HERDR_PLUGIN_STATE_DIR", "HERDR_BIN_PATH",
+    "LANG", "LC_ALL", "HOSTNAME", "HERDR_PLUGIN_CONFIG_DIR", "HERDR_PLUGIN_STATE_DIR",
+    "HERDR_BIN_PATH",
     "HERDR_WORLD_LAUNCHCTL", "HERDR_WORLD_SYSTEMCTL",
   ]) {
     if (env[name]) result[name] = env[name];

--- a/scripts/herdr-world-plugin.mjs
+++ b/scripts/herdr-world-plugin.mjs
@@ -499,8 +499,15 @@ function loopbackBindHost(host) {
 }
 
 function remoteBindHost(host, remoteAccess) {
-  if (isIpv6Host(host) || remoteAccess.accepted_hosts.some((value) => isIpv6Host(value))) {
+  const acceptedIpv6 = remoteAccess.accepted_hosts.some((value) => isIpv6Host(value));
+  if (isIpv6Host(host)) {
     return "::";
+  }
+  if (acceptedIpv6) {
+    // The bridge binds the opposite family as a second listener when this
+    // wildcard is paired with IPv6 accepted hosts. This keeps an existing
+    // IPv4 page reachable while the remote profile gains IPv6 support.
+    return "0.0.0.0";
   }
   const normalized = unbracketedHost(host);
   return !isLoopbackHost(normalized) && normalized !== "0.0.0.0" ? normalized : "0.0.0.0";
@@ -1293,6 +1300,7 @@ function createRecord({ identity, target, config, payload, node, port, superviso
     payload_entrypoint: payload.entrypoint,
     node_path: node.path,
     supervisor: supervisor.kind,
+    controller_mode: supervisor.kind,
     service_name: serviceName(identity, supervisor.kind),
     pid: 0,
     application_version: payload.packageJson.version,
@@ -1934,40 +1942,48 @@ export async function applyRemoteAccessAction({
   glibcVersion,
 } = {}) {
   const handoffGraceMs = Number(env.HERDR_WORLD_APPLY_GRACE_MS ?? 0);
-  if (Number.isFinite(handoffGraceMs) && handoffGraceMs > 0) {
-    await new Promise((resolve) => setTimeout(resolve, Math.min(handoffGraceMs, 1000)));
-  }
-  const context = runtimeContext(env);
-  const configPath = path.join(context.configDir, CONFIG_FILE);
-  const previousText = existsSync(configPath) ? readFileSync(configPath, "utf8") : null;
-  const previousConfig = context.config;
-  const remoteAccess = readRemoteAccessRequest(draftPath);
-  const nextConfig = configWithRemoteAccess(previousConfig, remoteAccess);
-  const recordPath = targetRecordPath(context.stateDir, context.target.identity);
+  const lockContext = runtimeContext(env);
 
   const execute = async () => {
-    const record = readRecord(recordPath);
+    let context;
+    let configPath;
+    let previousText = null;
+    let previousConfig;
     let previousActive = false;
-    if (record) {
-      const ownership = assertRecordOwnership(record, env, platform);
-      previousActive = ownership.state.active;
-    } else {
-      const supervisor = selectSupervisor(platform, env);
-      previousActive = await recoverUnrecordedService(
-        context.target.identity,
-        context.stateDir,
-        supervisor,
-        platform,
-      );
-      if (supervisor.kind === "fallback" && !previousActive) {
-        const reason = "fallback bridge service ownership could not be verified because its runtime record is missing; run the plugin stop and start actions before applying settings";
-        writeApplyStatus(context.stateDir, "failed", reason, false);
-        rmSync(draftPath, { force: true });
-        throw new PluginError(reason);
-      }
-    }
-    writeApplyStatus(context.stateDir, "applying", "settings saved; reconciling the managed bridge", null);
+    let baselineCaptured = false;
+
+    writeApplyStatus(lockContext.stateDir, "applying", "settings saved; reconciling the managed bridge", null);
     try {
+      if (Number.isFinite(handoffGraceMs) && handoffGraceMs > 0) {
+        await new Promise((resolve) => setTimeout(resolve, Math.min(handoffGraceMs, 1000)));
+      }
+      context = runtimeContext(env);
+      if (context.target.identity !== lockContext.target.identity) {
+        throw new PluginError("selected Herdr target changed while remote access settings were waiting to apply");
+      }
+      configPath = path.join(context.configDir, CONFIG_FILE);
+      previousText = existsSync(configPath) ? readFileSync(configPath, "utf8") : null;
+      previousConfig = context.config;
+      baselineCaptured = true;
+      const remoteAccess = readRemoteAccessRequest(draftPath);
+      const nextConfig = configWithRemoteAccess(previousConfig, remoteAccess);
+      const recordPath = targetRecordPath(context.stateDir, context.target.identity);
+      const record = readRecord(recordPath);
+      if (record) {
+        const ownership = assertRecordOwnership(record, env, platform);
+        previousActive = ownership.state.active;
+      } else {
+        const supervisor = selectSupervisor(platform, env);
+        previousActive = await recoverUnrecordedService(
+          context.target.identity,
+          context.stateDir,
+          supervisor,
+          platform,
+        );
+        if (supervisor.kind === "fallback" && !previousActive) {
+          throw new PluginError("fallback bridge service ownership could not be verified because its runtime record is missing; run the plugin stop and start actions before applying settings");
+        }
+      }
       atomicWrite(configPath, `${JSON.stringify(nextConfig, null, 2)}\n`);
       if (previousActive) {
         const plan = prepareStart({ root, env, platform, arch, glibcVersion, configOverride: nextConfig });
@@ -1979,29 +1995,31 @@ export async function applyRemoteAccessAction({
       return nextConfig;
     } catch (error) {
       let restored = false;
-      try {
-        restoreConfig(configPath, previousText);
-        if (previousActive) {
-          const plan = prepareStart({ root, env, platform, arch, glibcVersion, configOverride: previousConfig });
-          await startPrepared(plan, { lockHeld: true });
+      if (baselineCaptured) {
+        try {
+          restoreConfig(configPath, previousText);
+          if (previousActive) {
+            const plan = prepareStart({ root, env, platform, arch, glibcVersion, configOverride: previousConfig });
+            await startPrepared(plan, { lockHeld: true });
+          }
+          restored = true;
+        } catch (restoreError) {
+          writeApplyStatus(
+            lockContext.stateDir,
+            "failed",
+            `settings apply failed and recovery could not be verified: ${restoreError.message}`,
+            false,
+          );
+          throw error;
         }
-        restored = true;
-      } catch (restoreError) {
-        writeApplyStatus(
-          context.stateDir,
-          "failed",
-          `settings apply failed and recovery could not be verified: ${restoreError.message}`,
-          false,
-        );
-        throw error;
       }
-      writeApplyStatus(context.stateDir, "failed", error instanceof Error ? error.message : String(error), restored);
+      writeApplyStatus(lockContext.stateDir, "failed", error instanceof Error ? error.message : String(error), restored);
       throw error;
     } finally {
       rmSync(draftPath, { force: true });
     }
   };
-  return withTargetLock(context.stateDir, context.target.identity, execute);
+  return withTargetLock(lockContext.stateDir, lockContext.target.identity, execute);
 }
 
 export async function runAction(action, options = {}) {

--- a/scripts/herdr-world-plugin.mjs
+++ b/scripts/herdr-world-plugin.mjs
@@ -1215,10 +1215,47 @@ function unrecordedService(identity, supervisor) {
   };
 }
 
-async function recoverUnrecordedService(identity, stateDir, supervisor, platform = process.platform) {
+function validServicePort(value) {
+  const port = Number(value);
+  return Number.isInteger(port) && port >= 1 && port <= 65535 ? port : null;
+}
+
+function portFromBridgeArguments(args) {
+  if (!Array.isArray(args)) return null;
+  const ports = [];
+  for (let index = 0; index < args.length; index += 1) {
+    if (args[index] === "--port") ports.push(validServicePort(args[index + 1]));
+  }
+  return ports.length === 1 ? ports[0] : null;
+}
+
+function portFromSupervisorDefinition(definition, kind) {
+  const pattern = kind === "launchd"
+    ? /<string>--port<\/string>\s*<string>(\d+)<\/string>/g
+    : /"--port"\s+"(\d+)"/g;
+  const ports = [...definition.matchAll(pattern)].map((match) => validServicePort(match[1]));
+  return ports.length === 1 ? ports[0] : null;
+}
+
+function requireRecoveredPort(port, serviceName, required) {
+  if (required && port === null) {
+    throw new PluginError(
+      `could not establish the active port for unrecorded service ${serviceName}; refusing to stop it during settings apply`,
+    );
+  }
+  return port;
+}
+
+async function recoverUnrecordedService(
+  identity,
+  stateDir,
+  supervisor,
+  platform = process.platform,
+  { requirePort = false } = {},
+) {
   if (supervisor.kind === "launchd") {
     const record = unrecordedService(identity, supervisor);
-    if (!launchdServicePresent(record, supervisor.command)) return false;
+    if (!launchdServicePresent(record, supervisor.command)) return null;
 
     const expectedPath = pathForSupervisor(stateDir, record, "plist");
     const actualPath = launchdServicePath(record, supervisor.command);
@@ -1227,8 +1264,15 @@ async function recoverUnrecordedService(identity, stateDir, supervisor, platform
         `launchd service ${record.service_name} is already loaded from an unexpected definition; refusing to stop an unrelated service`,
       );
     }
+    let definition = "";
+    try { definition = readFileSync(expectedPath, "utf8"); } catch {}
+    const port = requireRecoveredPort(
+      portFromSupervisorDefinition(definition, supervisor.kind),
+      record.service_name,
+      requirePort,
+    );
     await unloadLaunchd(record, supervisor.command);
-    return true;
+    return { port };
   }
 
   if (supervisor.kind === "systemd-user") {
@@ -1241,7 +1285,7 @@ async function recoverUnrecordedService(identity, stateDir, supervisor, platform
     if (result.error) {
       throw new PluginError(`systemctl --user show ${record.service_name} failed: ${result.error.message}`);
     }
-    if (result.status !== 0 || String(result.stdout ?? "").trim() !== "loaded") return false;
+    if (result.status !== 0 || String(result.stdout ?? "").trim() !== "loaded") return null;
 
     const fragment = commandResult(
       supervisor.command,
@@ -1260,19 +1304,26 @@ async function recoverUnrecordedService(identity, stateDir, supervisor, platform
         `systemd service ${record.service_name} is already loaded from an unexpected definition; refusing to stop an unrelated service`,
       );
     }
+    let definition = "";
+    try { definition = readFileSync(expectedPath, "utf8"); } catch {}
+    const port = requireRecoveredPort(
+      portFromSupervisorDefinition(definition, supervisor.kind),
+      record.service_name,
+      requirePort,
+    );
     runChecked(supervisor.command, ["--user", "stop", record.service_name]);
     try {
       runChecked(supervisor.command, ["--user", "disable", record.service_name]);
     } catch {
       // A stopped unit may already be disabled by the user supervisor.
     }
-    return true;
+    return { port };
   }
 
   if (supervisor.kind === "fallback") {
     const leasePath = fallbackLeasePath(stateDir, identity);
     const record = readRecord(leasePath);
-    if (!record) return false;
+    if (!record) return null;
     if (
       record.target_identity !== identity ||
       record.supervisor !== "fallback" ||
@@ -1283,18 +1334,24 @@ async function recoverUnrecordedService(identity, stateDir, supervisor, platform
     const state = supervisorStatus(record, supervisor, platform);
     if (!state.active) {
       removeFallbackLease(stateDir, identity);
-      return false;
+      return null;
     }
     if (!state.owned) {
       throw new PluginError("fallback service ownership is stale; refusing to signal an unrelated process");
     }
+    const argumentPort = portFromBridgeArguments(record.bridge_args);
+    const port = requireRecoveredPort(
+      validServicePort(record.port) === argumentPort ? argumentPort : null,
+      record.service_name,
+      requirePort,
+    );
     stopProcessGroup(record.pid);
     await waitForStopped(record, supervisor, platform);
     removeFallbackLease(stateDir, identity);
-    return true;
+    return { port };
   }
 
-  return false;
+  return null;
 }
 
 export function selectSupervisor(platform, env) {
@@ -2017,12 +2074,15 @@ export async function applyRemoteAccessAction({
         previousPort = previousActive ? record.port : null;
       } else {
         const supervisor = selectSupervisor(platform, env);
-        previousActive = await recoverUnrecordedService(
+        const recovered = await recoverUnrecordedService(
           context.target.identity,
           context.stateDir,
           supervisor,
           platform,
+          { requirePort: true },
         );
+        previousActive = Boolean(recovered);
+        previousPort = recovered?.port ?? null;
         if (supervisor.kind === "fallback" && !previousActive) {
           throw new PluginError("fallback bridge service ownership could not be verified because its runtime record is missing; run the plugin stop and start actions before applying settings");
         }

--- a/scripts/herdr-world-plugin.mjs
+++ b/scripts/herdr-world-plugin.mjs
@@ -948,12 +948,26 @@ function recordActivePort(records, identity, port) {
   return records.some(({ record }) => record.target_identity !== identity && record.port === port);
 }
 
-export async function choosePort(config, identity, stateDir, { portFree = portIsFree } = {}) {
+export async function choosePort(
+  config,
+  identity,
+  stateDir,
+  { portFree = portIsFree, preservePort = null } = {},
+) {
   const records = listRecords(stateDir);
   const requested = config.port;
   const explicit = config.port_was_explicit === true;
   const namedTarget = config.session_name !== null || config.socket_path !== null;
   const hasDifferentTarget = records.some(({ record }) => record.target_identity !== identity);
+  if (preservePort !== null) {
+    if (!Number.isInteger(preservePort) || preservePort < 1 || preservePort > 65535) {
+      throw new PluginError("running bridge record has an invalid port");
+    }
+    if (recordActivePort(records, identity, preservePort) || !(await portFree(config.host, preservePort))) {
+      throw new PluginError(`running bridge port ${preservePort} is no longer available; retry after resolving the port conflict`);
+    }
+    return preservePort;
+  }
   if (explicit) {
     if (recordActivePort(records, identity, requested) || !(await portFree(config.host, requested))) {
       throw new PluginError(`configured bridge port ${requested} is already in use; choose another port`);
@@ -1612,7 +1626,7 @@ function prepareStart({ root = ROOT, env = process.env, platform = process.platf
   return { root, env, platform, context, manifestVersion, targetPlatform, node, target, payload, supervisor };
 }
 
-async function startPrepared(plan, { lockHeld = false } = {}) {
+async function startPrepared(plan, { lockHeld = false, preservePort = null } = {}) {
   const { root, env, platform, context, manifestVersion, node, target, payload, supervisor } = plan;
   const start = async () => {
     const recordPath = targetRecordPath(context.stateDir, context.target.identity);
@@ -1638,7 +1652,9 @@ async function startPrepared(plan, { lockHeld = false } = {}) {
     if (recovered) {
       console.log("Recovered an unrecorded Herdr World service; applying the current configuration.");
     }
-    const port = await choosePort(context.config, context.target.identity, context.stateDir);
+    const port = await choosePort(context.config, context.target.identity, context.stateDir, {
+      preservePort,
+    });
     const { record, environment } = createRecord({
       identity: context.target.identity,
       target,
@@ -1973,6 +1989,7 @@ export async function applyRemoteAccessAction({
     let previousText = null;
     let previousConfig;
     let previousActive = false;
+    let previousPort = null;
     let baselineCaptured = false;
 
     writeApplyStatus(lockContext.stateDir, applyId, "applying", "settings saved; reconciling the managed bridge", null);
@@ -1997,6 +2014,7 @@ export async function applyRemoteAccessAction({
       if (record) {
         const ownership = assertRecordOwnership(record, env, platform);
         previousActive = ownership.state.active;
+        previousPort = previousActive ? record.port : null;
       } else {
         const supervisor = selectSupervisor(platform, env);
         previousActive = await recoverUnrecordedService(
@@ -2012,7 +2030,7 @@ export async function applyRemoteAccessAction({
       atomicWrite(configPath, `${JSON.stringify(persistedConfig(nextConfig), null, 2)}\n`);
       if (previousActive) {
         const plan = prepareStart({ root, env, platform, arch, glibcVersion, configOverride: nextConfig });
-        await startPrepared(plan, { lockHeld: true });
+        await startPrepared(plan, { lockHeld: true, preservePort: previousPort });
         writeApplyStatus(context.stateDir, applyId, "ready", "bridge ready after applying settings", false);
       } else {
         writeApplyStatus(context.stateDir, applyId, "ready", "settings saved; the managed bridge was not running", false);
@@ -2025,7 +2043,7 @@ export async function applyRemoteAccessAction({
           restoreConfig(configPath, previousText);
           if (previousActive) {
             const plan = prepareStart({ root, env, platform, arch, glibcVersion, configOverride: previousConfig });
-            await startPrepared(plan, { lockHeld: true });
+            await startPrepared(plan, { lockHeld: true, preservePort: previousPort });
           }
           restored = true;
         } catch (restoreError) {

--- a/scripts/herdr-world-plugin.test.mjs
+++ b/scripts/herdr-world-plugin.test.mjs
@@ -18,6 +18,7 @@ import {
   choosePort,
   compareVersions,
   applyRemoteAccessAction,
+  configWithRemoteAccess,
   minimumVersionSatisfied,
   nodeMatchesRecord,
   npmInstallArgs,
@@ -262,6 +263,30 @@ test("legacy host policies migrate without losing directional IPv6 bridge permis
     password_hash: null,
   });
   assert.deepEqual(normalizeRemoteAccess(config), config.remote_access);
+});
+
+test("remote access preserves the configured IPv6 bind family", () => {
+  const config = validateConfig({
+    host: "::",
+    allowed_hosts: ["2001:db8::20"],
+    allowed_origins: ["https://[2001:db8::20]:8787"],
+  });
+  assert.equal(config.host, "::");
+
+  const enabled = configWithRemoteAccess(config, {
+    enabled: true,
+    accepted_hosts: ["2001:db8::20"],
+    allowed_page_origins: ["https://[2001:db8::20]:8787"],
+    allowed_bridge_origins: [],
+  });
+  assert.equal(enabled.host, "::");
+  assert.equal(net.isIP(enabled.host), 6);
+
+  const disabled = configWithRemoteAccess(enabled, {
+    ...enabled.remote_access,
+    enabled: false,
+  });
+  assert.equal(disabled.host, "::1");
 });
 
 test("npm installation is exact, private, script-free, and registry-pinned", () => {
@@ -623,6 +648,8 @@ test("remote access apply waits for readiness and restores the prior service on 
   const draftPath = path.join(fixture.stateDir, "remote-access-request.json");
   try {
     await runAction("start", options);
+    const identity = resolveTargetIdentity(validateConfig({}), fixture.env);
+    rmSync(targetRecordPath(fixture.stateDir, identity.identity), { force: true });
     writeFileSync(draftPath, JSON.stringify({
       remote_access: {
         enabled: true,
@@ -637,6 +664,7 @@ test("remote access apply waits for readiness and restores the prior service on 
     assert.deepEqual(appliedConfig.allowed_hosts, ["bridge.example.test"]);
     assert.equal(JSON.parse(readFileSync(statusPath, "utf8")).state, "ready");
     assert.equal(fsExists(fixture.statePath), true);
+    assert.ok(readFileSync(fixture.logPath, "utf8").includes('"bootout"'));
 
     const previousText = readFileSync(configPath, "utf8");
     writeFileSync(draftPath, JSON.stringify({
@@ -657,6 +685,44 @@ test("remote access apply waits for readiness and restores the prior service on 
     assert.equal(applyStatus.state, "failed");
     assert.equal(applyStatus.restored, true);
     assert.equal(fsExists(fixture.statePath), true);
+  } finally {
+    try { await runAction("stop", options); } catch {}
+    await new Promise((resolve) => fixture.socketServer.close(resolve));
+    rmSync(fixture.socketPath, { force: true });
+    rmSync(fixture.root, { recursive: true, force: true });
+  }
+});
+
+test("fallback remote access apply recovers an owned service when its runtime record is missing", async () => {
+  const fixture = await launchdFixture();
+  const unavailableLaunchctl = path.join(fixture.root, "bin", "unavailable-launchctl");
+  executableScript(unavailableLaunchctl, "#!/bin/sh\nexit 1\n");
+  mkdirSync(path.join(fixture.root, "scripts"), { recursive: true });
+  writeFileSync(
+    path.join(fixture.root, "scripts", "herdr-world-plugin.mjs"),
+    readFileSync(path.join(ROOT, "scripts", "herdr-world-plugin.mjs")),
+  );
+  fixture.env.HERDR_WORLD_LAUNCHCTL = unavailableLaunchctl;
+  const options = { root: fixture.root, env: fixture.env, platform: "darwin", arch: "arm64" };
+  const configPath = path.join(fixture.env.HERDR_PLUGIN_CONFIG_DIR, "config.json");
+  const statusPath = path.join(fixture.stateDir, "remote-access-apply.json");
+  const draftPath = path.join(fixture.stateDir, "remote-access-request.json");
+  try {
+    await runAction("start", options);
+    const identity = resolveTargetIdentity(validateConfig({}), fixture.env);
+    rmSync(targetRecordPath(fixture.stateDir, identity.identity), { force: true });
+    writeFileSync(draftPath, JSON.stringify({
+      remote_access: {
+        enabled: true,
+        accepted_hosts: ["bridge.example.test"],
+        allowed_page_origins: ["http://world.example.test"],
+        allowed_bridge_origins: [],
+      },
+    }));
+    await applyRemoteAccessAction({ draftPath, ...options });
+    assert.equal(JSON.parse(readFileSync(configPath, "utf8")).remote_access.enabled, true);
+    assert.equal(JSON.parse(readFileSync(statusPath, "utf8")).state, "ready");
+    assert.equal(fsExists(fixture.statePath), false);
   } finally {
     try { await runAction("stop", options); } catch {}
     await new Promise((resolve) => fixture.socketServer.close(resolve));

--- a/scripts/herdr-world-plugin.test.mjs
+++ b/scripts/herdr-world-plugin.test.mjs
@@ -756,6 +756,82 @@ test("remote access apply waits for readiness and restores the prior service on 
   }
 });
 
+test("consecutive remote access applies preserve an automatically allocated target port", async () => {
+  const fixture = await launchdFixture();
+  mkdirSync(path.join(fixture.root, "scripts"), { recursive: true });
+  writeFileSync(
+    path.join(fixture.root, "scripts", "herdr-world-plugin.mjs"),
+    readFileSync(path.join(ROOT, "scripts", "herdr-world-plugin.mjs")),
+  );
+  const options = { root: fixture.root, env: fixture.env, platform: "darwin", arch: "arm64" };
+  const configPath = path.join(fixture.env.HERDR_PLUGIN_CONFIG_DIR, "config.json");
+  const allocatedPort = fixture.port === 8787 ? await freePort() : fixture.port;
+  const selectedIdentity = resolveTargetIdentity(validateConfig({}), fixture.env).identity;
+  const otherRecordPath = targetRecordPath(fixture.stateDir, "other-target");
+  writeFileSync(configPath, JSON.stringify({ port_range: [allocatedPort, allocatedPort] }));
+  mkdirSync(path.dirname(otherRecordPath), { recursive: true });
+  writeFileSync(otherRecordPath, JSON.stringify({ target_identity: "other-target", port: 8787 }));
+
+  try {
+    const started = await runAction("start", options);
+    assert.equal(started.port, allocatedPort);
+    assert.notEqual(started.port, 8787);
+
+    for (const [index, enabled] of [true, false].entries()) {
+      const draftPath = path.join(fixture.stateDir, `remote-access-${index}.json`);
+      writeFileSync(draftPath, JSON.stringify({
+        apply_id: `apply-${index}`,
+        remote_access: {
+          enabled,
+          accepted_hosts: enabled ? ["bridge.example.test"] : [],
+          allowed_page_origins: enabled ? ["http://world.example.test"] : [],
+          allowed_bridge_origins: [],
+        },
+      }));
+      await applyRemoteAccessAction({ draftPath, ...options });
+
+      const record = JSON.parse(readFileSync(
+        targetRecordPath(fixture.stateDir, selectedIdentity),
+        "utf8",
+      ));
+      assert.equal(record.port, allocatedPort);
+      const persisted = JSON.parse(readFileSync(configPath, "utf8"));
+      assert.equal(Object.hasOwn(persisted, "port"), false);
+      assert.equal(Object.hasOwn(persisted, "port_was_explicit"), false);
+      assert.equal(JSON.parse(
+        readFileSync(path.join(fixture.stateDir, "remote-access-apply.json"), "utf8"),
+      ).id, `apply-${index}`);
+    }
+
+    const previousText = readFileSync(configPath, "utf8");
+    const failingDraft = path.join(fixture.stateDir, "remote-access-failing.json");
+    writeFileSync(failingDraft, JSON.stringify({
+      apply_id: "apply-failing",
+      remote_access: {
+        enabled: true,
+        accepted_hosts: ["bridge.example.test"],
+        allowed_page_origins: ["http://world.example.test"],
+        allowed_bridge_origins: [],
+      },
+    }));
+    writeFileSync(fixture.failPath, "fail once\n");
+    await assert.rejects(
+      applyRemoteAccessAction({ draftPath: failingDraft, ...options }),
+      /fixture bootstrap failed/,
+    );
+    assert.equal(readFileSync(configPath, "utf8"), previousText);
+    assert.equal(JSON.parse(readFileSync(
+      targetRecordPath(fixture.stateDir, selectedIdentity),
+      "utf8",
+    )).port, allocatedPort);
+  } finally {
+    try { await runAction("stop", options); } catch {}
+    await new Promise((resolve) => fixture.socketServer.close(resolve));
+    rmSync(fixture.socketPath, { force: true });
+    rmSync(fixture.root, { recursive: true, force: true });
+  }
+});
+
 test("fallback remote access apply recovers an owned service when its runtime record is missing", async () => {
   const fixture = await launchdFixture();
   const unavailableLaunchctl = path.join(fixture.root, "bin", "unavailable-launchctl");

--- a/scripts/herdr-world-plugin.test.mjs
+++ b/scripts/herdr-world-plugin.test.mjs
@@ -558,12 +558,21 @@ test("supervisor definitions contain the absolute Node command and safe environm
 
 test("launchd bootstraps RunAtLoad services once and unloads partial startup", async () => {
   const fixture = await launchdFixture();
+  fixture.env.HOSTNAME = "workstation.local";
   const options = { root: fixture.root, env: fixture.env, platform: "darwin", arch: "arm64" };
   try {
     const record = await runAction("start", options);
     assert.equal(record.supervisor, "launchd");
     assert.equal(record.controller_mode, "launchd");
     assert.equal(record.port, fixture.port);
+    const plistName = readdirSync(path.join(fixture.stateDir, "supervisors"))
+      .find((name) => name.endsWith(".plist"));
+    assert.ok(plistName);
+    const serviceDefinition = readFileSync(
+      path.join(fixture.stateDir, "supervisors", plistName),
+      "utf8",
+    );
+    assert.match(serviceDefinition, /<key>HOSTNAME<\/key><string>workstation\.local<\/string>/);
     const commands = readFileSync(fixture.logPath, "utf8")
       .trim()
       .split("\n")

--- a/scripts/herdr-world-plugin.test.mjs
+++ b/scripts/herdr-world-plugin.test.mjs
@@ -289,6 +289,21 @@ test("remote access preserves the configured IPv6 bind family", () => {
   assert.equal(disabled.host, "::1");
 });
 
+test("remote access keeps an IPv4 page reachable when accepted hosts include IPv6", () => {
+  const config = validateConfig({
+    host: "127.0.0.1",
+    allowed_hosts: [],
+    allowed_origins: [],
+  });
+  const enabled = configWithRemoteAccess(config, {
+    enabled: true,
+    accepted_hosts: ["192.0.2.20", "2001:db8::20"],
+    allowed_page_origins: ["http://192.0.2.20:8787"],
+    allowed_bridge_origins: [],
+  });
+  assert.equal(enabled.host, "0.0.0.0");
+});
+
 test("npm installation is exact, private, script-free, and registry-pinned", () => {
   assert.deepEqual(npmInstallArgs("0.1.0-rc.5", ".herdr-world-plugin"), [
     "install",
@@ -547,6 +562,7 @@ test("launchd bootstraps RunAtLoad services once and unloads partial startup", a
   try {
     const record = await runAction("start", options);
     assert.equal(record.supervisor, "launchd");
+    assert.equal(record.controller_mode, "launchd");
     assert.equal(record.port, fixture.port);
     const commands = readFileSync(fixture.logPath, "utf8")
       .trim()
@@ -556,6 +572,17 @@ test("launchd bootstraps RunAtLoad services once and unloads partial startup", a
     assert.ok(commands.some((args) => args[0] === "bootstrap"));
     assert.equal(commands.some((args) => args[0] === "kickstart"), false);
     assert.ok(commands.some((args) => args[0] === "print" && args[1].split("/").length === 3));
+
+    const bootstrapCount = () => readFileSync(fixture.logPath, "utf8")
+      .trim()
+      .split("\n")
+      .filter(Boolean)
+      .map((line) => JSON.parse(line))
+      .filter((args) => args[0] === "bootstrap").length;
+    const beforeIdempotentStart = bootstrapCount();
+    const sameRecord = await runAction("start", options);
+    assert.equal(sameRecord.service_name, record.service_name);
+    assert.equal(bootstrapCount(), beforeIdempotentStart);
 
     await runAction("stop", options);
     assert.equal(fsExists(fixture.statePath), false);
@@ -658,7 +685,13 @@ test("remote access apply waits for readiness and restores the prior service on 
         allowed_bridge_origins: [],
       },
     }));
-    await applyRemoteAccessAction({ draftPath, ...options });
+    fixture.env.HERDR_WORLD_APPLY_GRACE_MS = "100";
+    const applying = applyRemoteAccessAction({ draftPath, ...options });
+    for (let attempt = 0; attempt < 20 && !fsExists(statusPath); attempt += 1) {
+      await new Promise((resolve) => setTimeout(resolve, 5));
+    }
+    assert.equal(JSON.parse(readFileSync(statusPath, "utf8")).state, "applying");
+    await applying;
     const appliedConfig = JSON.parse(readFileSync(configPath, "utf8"));
     assert.equal(appliedConfig.remote_access.enabled, true);
     assert.deepEqual(appliedConfig.allowed_hosts, ["bridge.example.test"]);
@@ -723,6 +756,54 @@ test("fallback remote access apply recovers an owned service when its runtime re
     assert.equal(JSON.parse(readFileSync(configPath, "utf8")).remote_access.enabled, true);
     assert.equal(JSON.parse(readFileSync(statusPath, "utf8")).state, "ready");
     assert.equal(fsExists(fixture.statePath), false);
+  } finally {
+    try { await runAction("stop", options); } catch {}
+    await new Promise((resolve) => fixture.socketServer.close(resolve));
+    rmSync(fixture.socketPath, { force: true });
+    rmSync(fixture.root, { recursive: true, force: true });
+  }
+});
+
+test("concurrent remote access applies roll back to the locked successful baseline", async () => {
+  const fixture = await launchdFixture();
+  mkdirSync(path.join(fixture.root, "scripts"), { recursive: true });
+  writeFileSync(
+    path.join(fixture.root, "scripts", "herdr-world-plugin.mjs"),
+    readFileSync(path.join(ROOT, "scripts", "herdr-world-plugin.mjs")),
+  );
+  const options = { root: fixture.root, env: fixture.env, platform: "darwin", arch: "arm64" };
+  const configPath = path.join(fixture.env.HERDR_PLUGIN_CONFIG_DIR, "config.json");
+  const firstDraft = path.join(fixture.stateDir, "remote-access-first.json");
+  const secondDraft = path.join(fixture.stateDir, "remote-access-second.json");
+  try {
+    await runAction("start", options);
+    fixture.env.HERDR_WORLD_APPLY_GRACE_MS = "200";
+    writeFileSync(firstDraft, JSON.stringify({
+      remote_access: {
+        enabled: true,
+        accepted_hosts: ["first.example.test"],
+        allowed_page_origins: ["http://world.example.test"],
+        allowed_bridge_origins: [],
+      },
+    }));
+    writeFileSync(secondDraft, JSON.stringify({
+      remote_access: {
+        enabled: true,
+        accepted_hosts: ["second.example.test"],
+        allowed_page_origins: ["http://world.example.test"],
+        allowed_bridge_origins: [],
+      },
+    }));
+
+    const firstApply = applyRemoteAccessAction({ draftPath: firstDraft, ...options });
+    const secondApply = applyRemoteAccessAction({ draftPath: secondDraft, ...options });
+    await firstApply;
+    writeFileSync(fixture.failPath, "fail after first apply\n");
+    await assert.rejects(secondApply, /fixture bootstrap failed/);
+
+    const restored = JSON.parse(readFileSync(configPath, "utf8"));
+    assert.deepEqual(restored.allowed_hosts, ["first.example.test"]);
+    assert.equal(fsExists(fixture.statePath), true);
   } finally {
     try { await runAction("stop", options); } catch {}
     await new Promise((resolve) => fixture.socketServer.close(resolve));

--- a/scripts/herdr-world-plugin.test.mjs
+++ b/scripts/herdr-world-plugin.test.mjs
@@ -237,7 +237,11 @@ test("target selection enforces the published platform and libc matrix", () => {
 
 test("configuration validates safe remote access and mutually exclusive targets", () => {
   assert.deepEqual(validateConfig({}).port_range, DEFAULT_PORT_RANGE);
-  assert.throws(() => validateConfig({ host: "0.0.0.0" }), /allowed_hosts and allowed_origins/);
+  assert.throws(() => validateConfig({ host: "0.0.0.0" }), /allowed_hosts/);
+  assert.doesNotThrow(() => validateConfig({
+    host: "0.0.0.0",
+    allowed_hosts: ["world.example"],
+  }));
   assert.doesNotThrow(() => validateConfig({
     host: "0.0.0.0",
     allowed_hosts: ["world.example"],
@@ -246,6 +250,23 @@ test("configuration validates safe remote access and mutually exclusive targets"
   assert.throws(() => validateConfig({ session_name: "a", socket_path: "/tmp/herdr.sock" }), /mutually exclusive/);
   assert.throws(() => validateConfig({ allowed_origins: ["https://world.example/path"] }), /allowed_origins/);
   assert.throws(() => validateConfig({ host: "https://world.example" }), /hostname or IP/);
+});
+
+test("remote access needs a served address but additional page origins are optional", () => {
+  assert.deepEqual(normalizeRemoteAccess({
+    remote_access: {
+      enabled: true,
+      accepted_hosts: ["world.example"],
+      allowed_page_origins: [],
+      allowed_bridge_origins: [],
+    },
+  }), {
+    enabled: true,
+    accepted_hosts: ["world.example"],
+    allowed_page_origins: [],
+    allowed_bridge_origins: [],
+    password_hash: null,
+  });
 });
 
 test("legacy host policies migrate without losing directional IPv6 bridge permissions", () => {

--- a/scripts/herdr-world-plugin.test.mjs
+++ b/scripts/herdr-world-plugin.test.mjs
@@ -17,6 +17,7 @@ import {
   checkNode,
   choosePort,
   compareVersions,
+  applyRemoteAccessAction,
   minimumVersionSatisfied,
   nodeMatchesRecord,
   npmInstallArgs,
@@ -32,6 +33,7 @@ import {
   serviceName,
   STARTUP_COMMAND,
   targetRecordPath,
+  normalizeRemoteAccess,
   validateConfig,
   validatePluginManifest,
   waitForReadiness,
@@ -140,6 +142,7 @@ if (args[0] === "bootstrap") {
   writeFileSync(statePath, String(child.pid));
   writeFileSync(servicePath, args[2]);
   if (existsSync(failPath)) {
+    rmSync(failPath, { force: true });
     process.stderr.write("fixture bootstrap failed\\n");
     process.exit(7);
   }
@@ -242,6 +245,23 @@ test("configuration validates safe remote access and mutually exclusive targets"
   assert.throws(() => validateConfig({ session_name: "a", socket_path: "/tmp/herdr.sock" }), /mutually exclusive/);
   assert.throws(() => validateConfig({ allowed_origins: ["https://world.example/path"] }), /allowed_origins/);
   assert.throws(() => validateConfig({ host: "https://world.example" }), /hostname or IP/);
+});
+
+test("legacy host policies migrate without losing directional IPv6 bridge permissions", () => {
+  const config = validateConfig({
+    host: "0.0.0.0",
+    allowed_hosts: ["[2001:db8::20]"],
+    allowed_origins: ["https://world.example.test"],
+    allowed_connect_origins: ["http://bridge.example.test:4000"],
+  });
+  assert.deepEqual(config.remote_access, {
+    enabled: true,
+    accepted_hosts: ["2001:db8::20"],
+    allowed_page_origins: ["https://world.example.test"],
+    allowed_bridge_origins: ["http://bridge.example.test:4000"],
+    password_hash: null,
+  });
+  assert.deepEqual(normalizeRemoteAccess(config), config.remote_access);
 });
 
 test("npm installation is exact, private, script-free, and registry-pinned", () => {
@@ -427,6 +447,24 @@ test("readiness requires bridge, Herdr, protocol, and web compatibility", async 
   assert.equal(capabilities.terminal_protocol, 20);
 });
 
+test("LAN readiness probes use an accepted Host while connecting through loopback", async () => {
+  const response = (body) => ({ ok: true, status: 200, json: async () => body, body: { cancel: async () => {} } });
+  const expected = {
+    package_version: "0.1.0-rc.5",
+    host: "0.0.0.0",
+    port: 8787,
+    bridge_args: ["--host", "0.0.0.0", "--allow-host", "bridge.example.test"],
+  };
+  let requestOptions;
+  await waitForReadiness("http://127.0.0.1:8787", expected, {
+    fetchImpl: async (_url, options) => {
+      requestOptions = options;
+      return response({ bridge_api_version: 1, herdr_version: "0.8.2", terminal_protocol: 20, web_compat: 1 });
+    },
+  });
+  assert.equal(requestOptions.headers.host, "bridge.example.test:8787");
+});
+
 test("service ownership rejects command or signature drift", () => {
   const record = {
     node_path: "/usr/bin/node",
@@ -564,6 +602,61 @@ test("start recovers an owned launchd service when its runtime record is missing
     assert.ok(plistName);
     const serviceDefinition = readFileSync(path.join(fixture.stateDir, "supervisors", plistName), "utf8");
     assert.match(serviceDefinition, /<string>0\.0\.0\.0<\/string>/);
+  } finally {
+    try { await runAction("stop", options); } catch {}
+    await new Promise((resolve) => fixture.socketServer.close(resolve));
+    rmSync(fixture.socketPath, { force: true });
+    rmSync(fixture.root, { recursive: true, force: true });
+  }
+});
+
+test("remote access apply waits for readiness and restores the prior service on failure", async () => {
+  const fixture = await launchdFixture();
+  mkdirSync(path.join(fixture.root, "scripts"), { recursive: true });
+  writeFileSync(
+    path.join(fixture.root, "scripts", "herdr-world-plugin.mjs"),
+    readFileSync(path.join(ROOT, "scripts", "herdr-world-plugin.mjs")),
+  );
+  const options = { root: fixture.root, env: fixture.env, platform: "darwin", arch: "arm64" };
+  const configPath = path.join(fixture.env.HERDR_PLUGIN_CONFIG_DIR, "config.json");
+  const statusPath = path.join(fixture.stateDir, "remote-access-apply.json");
+  const draftPath = path.join(fixture.stateDir, "remote-access-request.json");
+  try {
+    await runAction("start", options);
+    writeFileSync(draftPath, JSON.stringify({
+      remote_access: {
+        enabled: true,
+        accepted_hosts: ["bridge.example.test"],
+        allowed_page_origins: ["http://world.example.test"],
+        allowed_bridge_origins: [],
+      },
+    }));
+    await applyRemoteAccessAction({ draftPath, ...options });
+    const appliedConfig = JSON.parse(readFileSync(configPath, "utf8"));
+    assert.equal(appliedConfig.remote_access.enabled, true);
+    assert.deepEqual(appliedConfig.allowed_hosts, ["bridge.example.test"]);
+    assert.equal(JSON.parse(readFileSync(statusPath, "utf8")).state, "ready");
+    assert.equal(fsExists(fixture.statePath), true);
+
+    const previousText = readFileSync(configPath, "utf8");
+    writeFileSync(draftPath, JSON.stringify({
+      remote_access: {
+        enabled: false,
+        accepted_hosts: ["bridge.example.test"],
+        allowed_page_origins: ["http://world.example.test"],
+        allowed_bridge_origins: [],
+      },
+    }));
+    writeFileSync(fixture.failPath, "fail once\n");
+    await assert.rejects(
+      applyRemoteAccessAction({ draftPath, ...options }),
+      /fixture bootstrap failed/,
+    );
+    assert.equal(readFileSync(configPath, "utf8"), previousText);
+    const applyStatus = JSON.parse(readFileSync(statusPath, "utf8"));
+    assert.equal(applyStatus.state, "failed");
+    assert.equal(applyStatus.restored, true);
+    assert.equal(fsExists(fixture.statePath), true);
   } finally {
     try { await runAction("stop", options); } catch {}
     await new Promise((resolve) => fixture.socketServer.close(resolve));

--- a/scripts/herdr-world-plugin.test.mjs
+++ b/scripts/herdr-world-plugin.test.mjs
@@ -756,7 +756,7 @@ test("remote access apply waits for readiness and restores the prior service on 
   }
 });
 
-test("consecutive remote access applies preserve an automatically allocated target port", async () => {
+test("remote access apply and rollback preserve an automatic port after an earlier port is released", async () => {
   const fixture = await launchdFixture();
   mkdirSync(path.join(fixture.root, "scripts"), { recursive: true });
   writeFileSync(
@@ -765,17 +765,23 @@ test("consecutive remote access applies preserve an automatically allocated targ
   );
   const options = { root: fixture.root, env: fixture.env, platform: "darwin", arch: "arm64" };
   const configPath = path.join(fixture.env.HERDR_PLUGIN_CONFIG_DIR, "config.json");
-  const allocatedPort = fixture.port === 8787 ? await freePort() : fixture.port;
+  const allocatedPort = fixture.port;
+  const earlierPort = allocatedPort - 1;
   const selectedIdentity = resolveTargetIdentity(validateConfig({}), fixture.env).identity;
-  const otherRecordPath = targetRecordPath(fixture.stateDir, "other-target");
-  writeFileSync(configPath, JSON.stringify({ port_range: [allocatedPort, allocatedPort] }));
-  mkdirSync(path.dirname(otherRecordPath), { recursive: true });
-  writeFileSync(otherRecordPath, JSON.stringify({ target_identity: "other-target", port: 8787 }));
+  const defaultRecordPath = targetRecordPath(fixture.stateDir, "other-default-target");
+  const earlierRecordPath = targetRecordPath(fixture.stateDir, "other-earlier-target");
+  writeFileSync(configPath, JSON.stringify({ port_range: [earlierPort, allocatedPort] }));
+  mkdirSync(path.dirname(defaultRecordPath), { recursive: true });
+  writeFileSync(defaultRecordPath, JSON.stringify({ target_identity: "other-default-target", port: 8787 }));
+  writeFileSync(earlierRecordPath, JSON.stringify({ target_identity: "other-earlier-target", port: earlierPort }));
 
   try {
     const started = await runAction("start", options);
     assert.equal(started.port, allocatedPort);
     assert.notEqual(started.port, 8787);
+
+    // Simulate the earlier target stopping and releasing its lower automatic port.
+    rmSync(earlierRecordPath, { force: true });
 
     for (const [index, enabled] of [true, false].entries()) {
       const draftPath = path.join(fixture.stateDir, `remote-access-${index}.json`);

--- a/scripts/herdr-world-plugin.test.mjs
+++ b/scripts/herdr-world-plugin.test.mjs
@@ -838,7 +838,7 @@ test("remote access apply and rollback preserve an automatic port after an earli
   }
 });
 
-test("fallback remote access apply recovers an owned service when its runtime record is missing", async () => {
+test("fallback remote access apply preserves an automatic port when its runtime record is missing", async () => {
   const fixture = await launchdFixture();
   const unavailableLaunchctl = path.join(fixture.root, "bin", "unavailable-launchctl");
   executableScript(unavailableLaunchctl, "#!/bin/sh\nexit 1\n");
@@ -852,10 +852,20 @@ test("fallback remote access apply recovers an owned service when its runtime re
   const configPath = path.join(fixture.env.HERDR_PLUGIN_CONFIG_DIR, "config.json");
   const statusPath = path.join(fixture.stateDir, "remote-access-apply.json");
   const draftPath = path.join(fixture.stateDir, "remote-access-request.json");
+  const allocatedPort = fixture.port;
+  const earlierPort = allocatedPort - 1;
+  const identity = resolveTargetIdentity(validateConfig({}), fixture.env);
+  const defaultRecordPath = targetRecordPath(fixture.stateDir, "other-default-target");
+  const earlierRecordPath = targetRecordPath(fixture.stateDir, "other-earlier-target");
+  writeFileSync(configPath, JSON.stringify({ port_range: [earlierPort, allocatedPort] }));
+  mkdirSync(path.dirname(defaultRecordPath), { recursive: true });
+  writeFileSync(defaultRecordPath, JSON.stringify({ target_identity: "other-default-target", port: 8787 }));
+  writeFileSync(earlierRecordPath, JSON.stringify({ target_identity: "other-earlier-target", port: earlierPort }));
   try {
-    await runAction("start", options);
-    const identity = resolveTargetIdentity(validateConfig({}), fixture.env);
+    const started = await runAction("start", options);
+    assert.equal(started.port, allocatedPort);
     rmSync(targetRecordPath(fixture.stateDir, identity.identity), { force: true });
+    rmSync(earlierRecordPath, { force: true });
     writeFileSync(draftPath, JSON.stringify({
       remote_access: {
         enabled: true,
@@ -867,9 +877,70 @@ test("fallback remote access apply recovers an owned service when its runtime re
     await applyRemoteAccessAction({ draftPath, ...options });
     assert.equal(JSON.parse(readFileSync(configPath, "utf8")).remote_access.enabled, true);
     assert.equal(JSON.parse(readFileSync(statusPath, "utf8")).state, "ready");
+    const record = JSON.parse(readFileSync(
+      targetRecordPath(fixture.stateDir, identity.identity),
+      "utf8",
+    ));
+    assert.equal(record.port, allocatedPort);
+    assert.equal(JSON.parse(readFileSync(configPath, "utf8")).port, undefined);
     assert.equal(fsExists(fixture.statePath), false);
   } finally {
     try { await runAction("stop", options); } catch {}
+    await new Promise((resolve) => fixture.socketServer.close(resolve));
+    rmSync(fixture.socketPath, { force: true });
+    rmSync(fixture.root, { recursive: true, force: true });
+  }
+});
+
+test("fallback remote access apply leaves an unrecorded service running when its port cannot be verified", async () => {
+  const fixture = await launchdFixture();
+  const unavailableLaunchctl = path.join(fixture.root, "bin", "unavailable-launchctl");
+  executableScript(unavailableLaunchctl, "#!/bin/sh\nexit 1\n");
+  mkdirSync(path.join(fixture.root, "scripts"), { recursive: true });
+  writeFileSync(
+    path.join(fixture.root, "scripts", "herdr-world-plugin.mjs"),
+    readFileSync(path.join(ROOT, "scripts", "herdr-world-plugin.mjs")),
+  );
+  fixture.env.HERDR_WORLD_LAUNCHCTL = unavailableLaunchctl;
+  const options = { root: fixture.root, env: fixture.env, platform: "darwin", arch: "arm64" };
+  const statusPath = path.join(fixture.stateDir, "remote-access-apply.json");
+  const draftPath = path.join(fixture.stateDir, "remote-access-request.json");
+  let started;
+  try {
+    started = await runAction("start", options);
+    const identity = resolveTargetIdentity(validateConfig({}), fixture.env);
+    rmSync(targetRecordPath(fixture.stateDir, identity.identity), { force: true });
+    const supervisorDirectory = path.join(fixture.stateDir, "supervisors");
+    const leasePath = path.join(
+      supervisorDirectory,
+      readdirSync(supervisorDirectory).find((name) => name.endsWith(".fallback-lease")),
+    );
+    const lease = JSON.parse(readFileSync(leasePath, "utf8"));
+    lease.port = null;
+    writeFileSync(leasePath, JSON.stringify(lease));
+    writeFileSync(draftPath, JSON.stringify({
+      remote_access: {
+        enabled: true,
+        accepted_hosts: ["bridge.example.test"],
+        allowed_page_origins: [],
+        allowed_bridge_origins: [],
+      },
+    }));
+
+    await assert.rejects(
+      applyRemoteAccessAction({ draftPath, ...options }),
+      /could not establish the active port.*refusing to stop it during settings apply/,
+    );
+    assert.doesNotThrow(() => process.kill(started.pid, 0));
+    assert.equal(fsExists(leasePath), true);
+    const applyStatus = JSON.parse(readFileSync(statusPath, "utf8"));
+    assert.equal(applyStatus.state, "failed");
+    assert.equal(applyStatus.restored, true);
+  } finally {
+    try { await runAction("stop", options); } catch {}
+    if (started?.pid) {
+      try { process.kill(-started.pid, "SIGTERM"); } catch {}
+    }
     await new Promise((resolve) => fixture.socketServer.close(resolve));
     rmSync(fixture.socketPath, { force: true });
     rmSync(fixture.root, { recursive: true, force: true });

--- a/tests/e2e/federation.spec.ts
+++ b/tests/e2e/federation.spec.ts
@@ -83,7 +83,7 @@ test("offline, incompatible, and malformed profiles stay isolated", async ({
   await expect(page.getByRole("button", { name: "New tab" })).toHaveCount(0);
   await expect(page.locator(".xterm-helper-textarea")).toHaveCount(0);
   await expect(
-    page.getByText("Bridge disconnected", { exact: true }),
+    page.getByText("Connection disconnected", { exact: true }),
   ).toBeVisible();
 
   await page.getByRole("button", { name: "localhost, compatible" }).click();

--- a/tests/e2e/remote-access.spec.ts
+++ b/tests/e2e/remote-access.spec.ts
@@ -26,3 +26,23 @@ test("manages direct network access as a draft with separate browser permissions
   await expect(page.getByText("Protected", { exact: true })).toBeVisible();
   await expect(page.getByRole("status")).toContainText(/Bridge ready|Settings saved/iu);
 });
+
+test("authenticates a cross-origin bridge and diagnoses HTTP, WebSocket, and terminal paths", async ({ page, request }) => {
+  await request.post("http://127.0.0.1:4173/__fixture/state", {
+    data: { hostId: "host-b", passwordConfigured: true },
+  });
+  await page.goto("/spaces");
+
+  const prompt = page.getByRole("dialog", { name: "Bridge password" });
+  await expect(prompt).toBeVisible();
+  await prompt.getByLabel("Password").fill("fixture-only-password");
+  await prompt.getByRole("button", { name: "Connect" }).click();
+  await expect(prompt).toBeHidden();
+
+  await page.getByRole("button", { name: "Settings" }).press("Enter");
+  await page.getByRole("tab", { name: "Bridge" }).click();
+  await page.locator(".backend-row-main").filter({ hasText: "Remote B" }).click();
+  await page.getByRole("button", { name: "Test", exact: true }).click();
+
+  await expect(page.getByText("Backend reachable.", { exact: true })).toBeVisible();
+});

--- a/tests/e2e/remote-access.spec.ts
+++ b/tests/e2e/remote-access.spec.ts
@@ -47,6 +47,14 @@ test("authenticates a cross-origin bridge and diagnoses HTTP, WebSocket, and ter
   await prompt.getByLabel("Password").fill("fixture-only-password");
   await prompt.getByRole("button", { name: "Connect" }).click();
   await expect(prompt).toBeHidden();
+  await expect.poll(() => page.evaluate(() => (
+    sessionStorage.getItem(
+      `herdrWeb.bridgeSession.v1:${encodeURIComponent("http://127.0.0.1:4174")}`,
+    )
+  ))).not.toBeNull();
+
+  await page.reload();
+  await expect(prompt).toBeHidden();
 
   await page.getByRole("button", { name: "Settings" }).press("Enter");
   await page.getByRole("tab", { name: "Bridges" }).click();
@@ -55,9 +63,6 @@ test("authenticates a cross-origin bridge and diagnoses HTTP, WebSocket, and ter
     page.getByRole("button", { name: "Allow saved bridges & reload" }).click(),
   ]);
 
-  await expect(prompt).toBeVisible();
-  await prompt.getByLabel("Password").fill("fixture-only-password");
-  await prompt.getByRole("button", { name: "Connect" }).click();
   await expect(prompt).toBeHidden();
   await page.getByRole("button", { name: "Settings" }).press("Enter");
   await page.getByRole("tab", { name: "Bridges" }).click();

--- a/tests/e2e/remote-access.spec.ts
+++ b/tests/e2e/remote-access.spec.ts
@@ -8,24 +8,32 @@ test.beforeEach(async ({ page, request }) => {
   }, hostStore());
 });
 
-test("manages direct network access as a draft with separate browser permissions", async ({ page }) => {
+test("shares this machine with host settings separate from bridge destinations", async ({ page }) => {
   await page.goto("/spaces");
   await expect(page.getByRole("button", { name: "localhost, compatible" })).toBeVisible();
   await page.getByRole("button", { name: "Settings" }).press("Enter");
   await expect(page.getByRole("dialog", { name: "Settings" })).toBeVisible();
-  await page.getByRole("tab", { name: "Remote access" }).click();
+  await page.getByRole("tab", { name: "Share this machine" }).click();
 
-  await expect(page.getByText("Direct network access", { exact: true })).toBeVisible();
-  const switchButton = page.getByRole("switch", { name: "Allow direct network connections" });
+  await expect(page.getByText("Share this bridge", { exact: true })).toBeVisible();
+  const switchButton = page.getByRole("switch", { name: "Allow other devices to connect" });
   await expect(switchButton).toHaveAttribute("aria-checked", "false");
-  await page.getByText("bridge.example.test", { exact: true }).click();
   await switchButton.click();
-  await page.getByLabel("Set bridge password").fill("synthetic-password");
+  await expect(page.getByText("http://bridge.example.test:4173", { exact: true })).toBeVisible();
+  await page.getByLabel("Set this bridge password").fill("fixture-only-password");
   await expect(page.getByText(/unencrypted HTTP and WebSocket connections/iu)).toBeVisible();
-  await page.getByRole("button", { name: "Apply", exact: true }).click();
+  await page.getByText("Advanced browser permissions", { exact: true }).click();
+  await expect(page.getByText("Client web app origins", { exact: true })).toBeVisible();
+  await expect(page.getByText("Bridge destinations for this page", { exact: true })).toHaveCount(0);
+  await Promise.all([
+    page.waitForEvent("load"),
+    page.getByRole("button", { name: "Apply", exact: true }).click(),
+  ]);
 
+  await page.getByRole("button", { name: "Settings" }).press("Enter");
+  await page.getByRole("tab", { name: "Share this machine" }).click();
   await expect(page.getByText("Protected", { exact: true })).toBeVisible();
-  await expect(page.getByRole("status")).toContainText(/Bridge ready|Settings saved/iu);
+  await expect(page.getByRole("status")).toContainText(/Bridge ready/iu);
 });
 
 test("authenticates a cross-origin bridge and diagnoses HTTP, WebSocket, and terminal paths", async ({ page, request }) => {
@@ -41,7 +49,18 @@ test("authenticates a cross-origin bridge and diagnoses HTTP, WebSocket, and ter
   await expect(prompt).toBeHidden();
 
   await page.getByRole("button", { name: "Settings" }).press("Enter");
-  await page.getByRole("tab", { name: "Bridge" }).click();
+  await page.getByRole("tab", { name: "Bridges" }).click();
+  await Promise.all([
+    page.waitForEvent("load"),
+    page.getByRole("button", { name: "Allow saved bridges & reload" }).click(),
+  ]);
+
+  await expect(prompt).toBeVisible();
+  await prompt.getByLabel("Password").fill("fixture-only-password");
+  await prompt.getByRole("button", { name: "Connect" }).click();
+  await expect(prompt).toBeHidden();
+  await page.getByRole("button", { name: "Settings" }).press("Enter");
+  await page.getByRole("tab", { name: "Bridges" }).click();
   await page.locator(".backend-row-main").filter({ hasText: "Remote B" }).click();
   await page.getByRole("button", { name: "Test", exact: true }).click();
 

--- a/tests/e2e/remote-access.spec.ts
+++ b/tests/e2e/remote-access.spec.ts
@@ -8,40 +8,64 @@ test.beforeEach(async ({ page, request }) => {
   }, hostStore());
 });
 
-test("shares this machine with host settings separate from bridge destinations", async ({ page }) => {
+test("allows connections with advanced inbound permissions separate from destinations", async ({ page }) => {
   await page.goto("/spaces");
   await expect(page.getByRole("button", { name: "localhost, compatible" })).toBeVisible();
   await openSettings(page);
-  await page.getByRole("tab", { name: "Share this machine" }).click();
+  await page.getByRole("tab", { name: "Allow connections" }).click();
 
-  await expect(page.getByText("Share this bridge", { exact: true })).toBeVisible();
-  const switchButton = page.getByRole("switch", { name: "Allow other devices to connect" });
+  await expect(page.getByText("Allow connections", { exact: true }).last()).toBeVisible();
+  const switchButton = page.getByRole("switch", { name: "Allow connections to this Herdr" });
   await expect(switchButton).toHaveAttribute("aria-checked", "false");
   await switchButton.click();
   await expect(page.getByText("http://bridge.example.test:4173", { exact: true })).toBeVisible();
-  await page.getByLabel("Set this bridge password").fill("fixture-only-password");
-  await expect(page.getByText(/unencrypted HTTP and WebSocket connections/iu)).toBeVisible();
-  await page.getByText("Advanced browser permissions", { exact: true }).click();
-  await expect(page.getByText("Additional client page origins", { exact: true })).toBeVisible();
-  await expect(page.getByText("Bridge destinations for this page", { exact: true })).toHaveCount(0);
+  await page.getByLabel("Set connection password").fill("fixture-only-password");
+  await expect(page.getByText(/Direct connections are not encrypted/iu)).toBeVisible();
+  await page.getByText("Advanced network permissions", { exact: true }).click();
+  await expect(page.getByText("Web pages allowed to connect", { exact: true })).toBeVisible();
+  await expect(page.getByText("Herdrs this page may connect to", { exact: true })).toHaveCount(0);
   await Promise.all([
     page.waitForEvent("load"),
-    page.getByRole("button", { name: "Apply", exact: true }).click(),
+    page.getByRole("button", { name: "Apply changes", exact: true }).click(),
   ]);
 
   await openSettings(page);
-  await page.getByRole("tab", { name: "Share this machine" }).click();
-  await expect(page.getByText("Protected", { exact: true })).toBeVisible();
-  await expect(page.getByRole("status")).toContainText(/Bridge ready/iu);
+  await page.getByRole("tab", { name: "Allow connections" }).click();
+  await expect(page.getByText("Password protected", { exact: true })).toBeVisible();
+  await expect(page.getByRole("status")).toContainText(/Network ready/iu);
 });
 
-test("authenticates a cross-origin bridge and diagnoses HTTP, WebSocket, and terminal paths", async ({ page, request }) => {
+test("adds and enables a connection from its address", async ({ page }) => {
+  await page.goto("/spaces");
+  await openSettings(page);
+  await page.locator(".backend-row-main").filter({ hasText: "Remote B" }).click();
+  await page.getByRole("button", { name: "Delete connection" }).click();
+  await page.getByRole("button", { name: /Add connection/ }).click();
+  await page.getByLabel("Herdr address").fill("http://127.0.0.1:4174");
+  await Promise.all([
+    page.waitForEvent("load"),
+    page.getByRole("button", { name: "Connect", exact: true }).click(),
+  ]);
+
+  await openSettings(page);
+  const connection = page.locator(".backend-row-main").filter({ hasText: "127.0.0.1:4174" });
+  await expect(connection).toContainText("Connected");
+  await expect.poll(() => page.evaluate(() => {
+    const raw = localStorage.getItem("herdrWeb.bridgeBackends.v2");
+    if (!raw) return false;
+    const store = JSON.parse(raw) as { backends: { id: string; baseUrl: string }[]; enabledBridgeIds: string[] };
+    const saved = store.backends.find((backend) => backend.baseUrl === "http://127.0.0.1:4174");
+    return Boolean(saved && store.enabledBridgeIds.includes(saved.id));
+  })).toBe(true);
+});
+
+test("authenticates a cross-origin Herdr and diagnoses HTTP, WebSocket, and terminal paths", async ({ page, request }) => {
   await request.post("http://127.0.0.1:4173/__fixture/state", {
     data: { hostId: "host-b", passwordConfigured: true },
   });
   await page.goto("/spaces");
 
-  const prompt = page.getByRole("dialog", { name: "Bridge password" });
+  const prompt = page.getByRole("dialog", { name: "Connect to Herdr" });
   await expect(prompt).toBeVisible();
   await prompt.getByLabel("Password").fill("fixture-only-password");
   await prompt.getByRole("button", { name: "Connect" }).click();
@@ -56,25 +80,23 @@ test("authenticates a cross-origin bridge and diagnoses HTTP, WebSocket, and ter
   await expect(prompt).toBeHidden();
 
   await openSettings(page);
-  await page.getByRole("tab", { name: "Bridges" }).click();
   await Promise.all([
     page.waitForEvent("load"),
-    page.getByRole("button", { name: "Allow saved bridges & reload" }).click(),
+    page.getByRole("button", { name: "Allow saved connections & reload" }).click(),
   ]);
 
   await expect(prompt).toBeHidden();
   await openSettings(page);
-  await page.getByRole("tab", { name: "Bridges" }).click();
   await page.locator(".backend-row-main").filter({ hasText: "Remote B" }).click();
-  await page.getByRole("button", { name: "Test", exact: true }).click();
+  await page.getByRole("button", { name: "Test connection", exact: true }).click();
 
-  await expect(page.getByText("Backend reachable.", { exact: true })).toBeVisible();
+  await expect(page.getByText("Connection successful.", { exact: true })).toBeVisible();
 });
 
 function switcherSettings(page: Page) {
   return page
     .getByRole("complementary", { name: "Switcher" })
-    .locator('button[title^="Settings; bridge:"]');
+    .locator('button[title^="Settings; Herdr:"]');
 }
 
 async function openSettings(page: Page) {

--- a/tests/e2e/remote-access.spec.ts
+++ b/tests/e2e/remote-access.spec.ts
@@ -67,6 +67,8 @@ test("authenticates a cross-origin Herdr and diagnoses HTTP, WebSocket, and term
 
   const prompt = page.getByRole("dialog", { name: "Connect to Herdr" });
   await expect(prompt).toBeVisible();
+  await expect(prompt.getByText("Remote B", { exact: true })).toBeVisible();
+  await expect(prompt.getByText("127.0.0.1:4174", { exact: true })).toBeVisible();
   await prompt.getByLabel("Password").fill("fixture-only-password");
   await prompt.getByRole("button", { name: "Connect" }).click();
   await expect(prompt).toBeHidden();

--- a/tests/e2e/remote-access.spec.ts
+++ b/tests/e2e/remote-access.spec.ts
@@ -11,8 +11,7 @@ test.beforeEach(async ({ page, request }) => {
 test("shares this machine with host settings separate from bridge destinations", async ({ page }) => {
   await page.goto("/spaces");
   await expect(page.getByRole("button", { name: "localhost, compatible" })).toBeVisible();
-  await switcherSettings(page).press("Enter");
-  await expect(page.getByRole("dialog", { name: "Settings" })).toBeVisible();
+  await openSettings(page);
   await page.getByRole("tab", { name: "Share this machine" }).click();
 
   await expect(page.getByText("Share this bridge", { exact: true })).toBeVisible();
@@ -23,14 +22,14 @@ test("shares this machine with host settings separate from bridge destinations",
   await page.getByLabel("Set this bridge password").fill("fixture-only-password");
   await expect(page.getByText(/unencrypted HTTP and WebSocket connections/iu)).toBeVisible();
   await page.getByText("Advanced browser permissions", { exact: true }).click();
-  await expect(page.getByText("Client web app origins", { exact: true })).toBeVisible();
+  await expect(page.getByText("Additional client page origins", { exact: true })).toBeVisible();
   await expect(page.getByText("Bridge destinations for this page", { exact: true })).toHaveCount(0);
   await Promise.all([
     page.waitForEvent("load"),
     page.getByRole("button", { name: "Apply", exact: true }).click(),
   ]);
 
-  await switcherSettings(page).press("Enter");
+  await openSettings(page);
   await page.getByRole("tab", { name: "Share this machine" }).click();
   await expect(page.getByText("Protected", { exact: true })).toBeVisible();
   await expect(page.getByRole("status")).toContainText(/Bridge ready/iu);
@@ -56,7 +55,7 @@ test("authenticates a cross-origin bridge and diagnoses HTTP, WebSocket, and ter
   await page.reload();
   await expect(prompt).toBeHidden();
 
-  await switcherSettings(page).press("Enter");
+  await openSettings(page);
   await page.getByRole("tab", { name: "Bridges" }).click();
   await Promise.all([
     page.waitForEvent("load"),
@@ -64,7 +63,7 @@ test("authenticates a cross-origin bridge and diagnoses HTTP, WebSocket, and ter
   ]);
 
   await expect(prompt).toBeHidden();
-  await switcherSettings(page).press("Enter");
+  await openSettings(page);
   await page.getByRole("tab", { name: "Bridges" }).click();
   await page.locator(".backend-row-main").filter({ hasText: "Remote B" }).click();
   await page.getByRole("button", { name: "Test", exact: true }).click();
@@ -76,4 +75,9 @@ function switcherSettings(page: Page) {
   return page
     .getByRole("complementary", { name: "Switcher" })
     .getByRole("button", { name: "Settings" });
+}
+
+async function openSettings(page: Page) {
+  await switcherSettings(page).click();
+  await expect(page.getByRole("dialog", { name: "Settings" })).toBeVisible();
 }

--- a/tests/e2e/remote-access.spec.ts
+++ b/tests/e2e/remote-access.spec.ts
@@ -21,6 +21,7 @@ test("manages direct network access as a draft with separate browser permissions
   await page.getByText("bridge.example.test", { exact: true }).click();
   await switchButton.click();
   await page.getByLabel("Set bridge password").fill("synthetic-password");
+  await expect(page.getByText(/unencrypted HTTP and WebSocket connections/iu)).toBeVisible();
   await page.getByRole("button", { name: "Apply", exact: true }).click();
 
   await expect(page.getByText("Protected", { exact: true })).toBeVisible();

--- a/tests/e2e/remote-access.spec.ts
+++ b/tests/e2e/remote-access.spec.ts
@@ -74,7 +74,7 @@ test("authenticates a cross-origin bridge and diagnoses HTTP, WebSocket, and ter
 function switcherSettings(page: Page) {
   return page
     .getByRole("complementary", { name: "Switcher" })
-    .getByRole("button", { name: "Settings" });
+    .locator('button[title^="Settings; bridge:"]');
 }
 
 async function openSettings(page: Page) {

--- a/tests/e2e/remote-access.spec.ts
+++ b/tests/e2e/remote-access.spec.ts
@@ -1,0 +1,28 @@
+import { expect, test } from "@playwright/test";
+import { hostStore } from "./hostStore";
+
+test.beforeEach(async ({ page, request }) => {
+  await request.post("http://127.0.0.1:4173/__fixture/reset");
+  await page.addInitScript((store) => {
+    localStorage.setItem("herdrWeb.bridgeBackends.v2", JSON.stringify(store));
+  }, hostStore());
+});
+
+test("manages direct network access as a draft with separate browser permissions", async ({ page }) => {
+  await page.goto("/spaces");
+  await expect(page.getByRole("button", { name: "localhost, compatible" })).toBeVisible();
+  await page.getByRole("button", { name: "Settings" }).press("Enter");
+  await expect(page.getByRole("dialog", { name: "Settings" })).toBeVisible();
+  await page.getByRole("tab", { name: "Remote access" }).click();
+
+  await expect(page.getByText("Direct network access", { exact: true })).toBeVisible();
+  const switchButton = page.getByRole("switch", { name: "Allow direct network connections" });
+  await expect(switchButton).toHaveAttribute("aria-checked", "false");
+  await page.getByText("bridge.example.test", { exact: true }).click();
+  await switchButton.click();
+  await page.getByLabel("Set bridge password").fill("synthetic-password");
+  await page.getByRole("button", { name: "Apply", exact: true }).click();
+
+  await expect(page.getByText("Protected", { exact: true })).toBeVisible();
+  await expect(page.getByRole("status")).toContainText(/Bridge ready|Settings saved/iu);
+});

--- a/tests/e2e/remote-access.spec.ts
+++ b/tests/e2e/remote-access.spec.ts
@@ -93,6 +93,32 @@ test("authenticates a cross-origin Herdr and diagnoses HTTP, WebSocket, and term
   await expect(page.getByText("Connection successful.", { exact: true })).toBeVisible();
 });
 
+test("clears a password before showing the next queued connection prompt", async ({ page, request }) => {
+  for (const hostId of ["host-b", "host-c"]) {
+    await request.post("http://127.0.0.1:4173/__fixture/state", {
+      data: {
+        hostId,
+        passwordConfigured: true,
+        ...(hostId === "host-c" ? { terminalProtocol: 20 } : {}),
+      },
+    });
+  }
+  await page.goto("/spaces");
+
+  const prompt = page.getByRole("dialog", { name: "Connect to Herdr" });
+  await expect(prompt).toBeVisible();
+  const firstOrigin = await prompt.textContent();
+  await prompt.getByLabel("Password").fill("fixture-only-password");
+  await prompt.getByRole("button", { name: "Connect" }).click();
+
+  await expect(prompt).toBeVisible();
+  await expect.poll(async () => prompt.textContent()).not.toBe(firstOrigin);
+  await expect(prompt.getByLabel("Password")).toHaveValue("");
+  await expect(prompt.getByRole("button", { name: "Connect" })).toBeDisabled();
+  await expect(prompt.getByLabel("Password")).toBeFocused();
+  await prompt.getByRole("button", { name: "Cancel" }).click();
+});
+
 function switcherSettings(page: Page) {
   return page
     .getByRole("complementary", { name: "Switcher" })

--- a/tests/e2e/remote-access.spec.ts
+++ b/tests/e2e/remote-access.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test";
+import { expect, test, type Page } from "@playwright/test";
 import { hostStore } from "./hostStore";
 
 test.beforeEach(async ({ page, request }) => {
@@ -11,7 +11,7 @@ test.beforeEach(async ({ page, request }) => {
 test("shares this machine with host settings separate from bridge destinations", async ({ page }) => {
   await page.goto("/spaces");
   await expect(page.getByRole("button", { name: "localhost, compatible" })).toBeVisible();
-  await page.getByRole("button", { name: "Settings" }).press("Enter");
+  await switcherSettings(page).press("Enter");
   await expect(page.getByRole("dialog", { name: "Settings" })).toBeVisible();
   await page.getByRole("tab", { name: "Share this machine" }).click();
 
@@ -30,7 +30,7 @@ test("shares this machine with host settings separate from bridge destinations",
     page.getByRole("button", { name: "Apply", exact: true }).click(),
   ]);
 
-  await page.getByRole("button", { name: "Settings" }).press("Enter");
+  await switcherSettings(page).press("Enter");
   await page.getByRole("tab", { name: "Share this machine" }).click();
   await expect(page.getByText("Protected", { exact: true })).toBeVisible();
   await expect(page.getByRole("status")).toContainText(/Bridge ready/iu);
@@ -56,7 +56,7 @@ test("authenticates a cross-origin bridge and diagnoses HTTP, WebSocket, and ter
   await page.reload();
   await expect(prompt).toBeHidden();
 
-  await page.getByRole("button", { name: "Settings" }).press("Enter");
+  await switcherSettings(page).press("Enter");
   await page.getByRole("tab", { name: "Bridges" }).click();
   await Promise.all([
     page.waitForEvent("load"),
@@ -64,10 +64,16 @@ test("authenticates a cross-origin bridge and diagnoses HTTP, WebSocket, and ter
   ]);
 
   await expect(prompt).toBeHidden();
-  await page.getByRole("button", { name: "Settings" }).press("Enter");
+  await switcherSettings(page).press("Enter");
   await page.getByRole("tab", { name: "Bridges" }).click();
   await page.locator(".backend-row-main").filter({ hasText: "Remote B" }).click();
   await page.getByRole("button", { name: "Test", exact: true }).click();
 
   await expect(page.getByText("Backend reachable.", { exact: true })).toBeVisible();
 });
+
+function switcherSettings(page: Page) {
+  return page
+    .getByRole("complementary", { name: "Switcher" })
+    .getByRole("button", { name: "Settings" });
+}

--- a/tests/e2e/remote-access.spec.ts
+++ b/tests/e2e/remote-access.spec.ts
@@ -26,13 +26,26 @@ test("allows connections with advanced inbound permissions separate from destina
   await expect(page.getByText("Herdrs this page may connect to", { exact: true })).toHaveCount(0);
   await Promise.all([
     page.waitForEvent("load"),
-    page.getByRole("button", { name: "Apply changes", exact: true }).click(),
+    page.getByRole("button", { name: "Set password & apply", exact: true }).click(),
   ]);
 
   await openSettings(page);
   await page.getByRole("tab", { name: "Allow connections" }).click();
-  await expect(page.getByText("Password protected", { exact: true })).toBeVisible();
+  const authentication = page.locator(".remote-access-authentication");
+  await expect(authentication.getByText("On", { exact: true })).toBeVisible();
   await expect(page.getByRole("status")).toContainText(/Network ready/iu);
+
+  await authentication.getByRole("button", { name: "Remove password", exact: true }).click();
+  await expect(authentication.getByText("Password will be removed", { exact: true })).toBeVisible();
+  await expect(authentication.getByRole("button", { name: "Remove password", exact: true })).toHaveCount(0);
+  await Promise.all([
+    page.waitForEvent("load"),
+    page.getByRole("button", { name: "Remove password & apply", exact: true }).click(),
+  ]);
+
+  await openSettings(page);
+  await page.getByRole("tab", { name: "Allow connections" }).click();
+  await expect(page.locator(".remote-access-authentication").getByText("Off", { exact: true })).toBeVisible();
 });
 
 test("adds and enables a connection from its address", async ({ page }) => {
@@ -42,6 +55,7 @@ test("adds and enables a connection from its address", async ({ page }) => {
   await page.getByRole("button", { name: "Delete connection" }).click();
   await page.getByRole("button", { name: /Add connection/ }).click();
   await page.getByLabel("Herdr address").fill("http://127.0.0.1:4174");
+  await expect(page.getByLabel("Connection name")).toHaveValue("127.0.0.1");
   await Promise.all([
     page.waitForEvent("load"),
     page.getByRole("button", { name: "Connect", exact: true }).click(),

--- a/third_party/dependencies/cargo-licenses.html
+++ b/third_party/dependencies/cargo-licenses.html
@@ -44,7 +44,7 @@
 
         <h2>Overview of licenses:</h2>
         <ul class="licenses-overview">
-            <li><a href="#Apache-2.0">Apache License 2.0</a> (132)</li>
+            <li><a href="#Apache-2.0">Apache License 2.0</a> (139)</li>
             <li><a href="#MIT">MIT License</a> (64)</li>
             <li><a href="#Unicode-3.0">Unicode License v3</a> (19)</li>
             <li><a href="#ISC">ISC License</a> (18)</li>
@@ -4465,10 +4465,14 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
+                    <li><a href=" https://github.com/RustCrypto/password-hashes/tree/master/argon2 ">argon2 0.5.3</a></li>
+                    <li><a href=" https://github.com/RustCrypto/formats ">base64ct 1.8.3</a></li>
+                    <li><a href=" https://github.com/RustCrypto/hashes ">blake2 0.10.6</a></li>
                     <li><a href=" https://github.com/RustCrypto/utils ">block-buffer 0.10.4</a></li>
                     <li><a href=" https://github.com/RustCrypto/utils ">cpufeatures 0.2.17</a></li>
                     <li><a href=" https://github.com/RustCrypto/traits ">crypto-common 0.1.7</a></li>
                     <li><a href=" https://github.com/RustCrypto/traits ">digest 0.10.7</a></li>
+                    <li><a href=" https://github.com/RustCrypto/traits/tree/master/password-hash ">password-hash 0.5.0</a></li>
                     <li><a href=" https://github.com/RustCrypto/hashes ">sha1 0.10.6</a></li>
                     <li><a href=" https://github.com/RustCrypto/hashes ">sha2 0.10.9</a></li>
                 </ul>
@@ -4679,6 +4683,7 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
+                    <li><a href=" https://github.com/rust-random/rand ">rand_core 0.6.4</a></li>
                     <li><a href=" https://github.com/rust-random/rand ">rand_core 0.9.5</a></li>
                 </ul>
                 <pre class="license-text">                              Apache License
@@ -4876,6 +4881,7 @@ APPENDIX: How to apply the Apache License to your work.
                 <ul class="license-used-by">
                     <li><a href=" https://github.com/rust-random/getrandom ">getrandom 0.2.17</a></li>
                     <li><a href=" https://github.com/rust-random/getrandom ">getrandom 0.3.4</a></li>
+                    <li><a href=" https://github.com/rust-random/rand ">rand_chacha 0.3.1</a></li>
                 </ul>
                 <pre class="license-text">                              Apache License
                         Version 2.0, January 2004
@@ -5308,6 +5314,7 @@ limitations under the License.
                     <li><a href=" https://github.com/taiki-e/pin-project-lite ">pin-project-lite 0.2.17</a></li>
                     <li><a href=" https://github.com/dtolnay/proc-macro2 ">proc-macro2 1.0.106</a></li>
                     <li><a href=" https://github.com/dtolnay/quote ">quote 1.0.45</a></li>
+                    <li><a href=" https://github.com/rust-random/rand ">rand 0.8.6</a></li>
                     <li><a href=" https://github.com/rust-random/rand ">rand 0.9.4</a></li>
                     <li><a href=" https://github.com/rust-random/rand ">rand_chacha 0.9.0</a></li>
                     <li><a href=" https://github.com/dtolnay/ref-cast ">ref-cast-impl 1.0.25</a></li>

--- a/web/src/AccessOriginList.tsx
+++ b/web/src/AccessOriginList.tsx
@@ -1,0 +1,90 @@
+import { Plus, Trash2 } from "lucide-react";
+import { useState } from "react";
+
+type Props = {
+  label: string;
+  values: string[];
+  suggestions?: readonly string[];
+  onChange: (values: string[]) => void;
+};
+
+export function AccessOriginList({ label, values, suggestions = [], onChange }: Props) {
+  const [input, setInput] = useState("");
+
+  return (
+    <div className="remote-access-permission-list">
+      <span>{label}</span>
+      {values.map((value) => (
+        <div className="remote-access-chip" key={value}>
+          <span>{value}</span>
+          <button
+            type="button"
+            aria-label={`Remove ${value}`}
+            onClick={() => onChange(values.filter((item) => item !== value))}
+          >
+            <Trash2 size={13} />
+          </button>
+        </div>
+      ))}
+      {suggestions.filter((item) => !values.includes(item)).map((suggestion) => (
+        <label className="remote-access-suggestion" key={suggestion}>
+          <input
+            type="checkbox"
+            checked={false}
+            onChange={(event) => {
+              if (event.target.checked) onChange([...values, suggestion]);
+            }}
+          />
+          <span>{suggestion}</span>
+          <small>Suggested</small>
+        </label>
+      ))}
+      <div className="remote-access-add-row">
+        <input
+          className="field"
+          aria-label={`Add ${label.toLowerCase()}`}
+          placeholder="http(s)://host:port"
+          value={input}
+          onChange={(event) => setInput(event.target.value)}
+        />
+        <button
+          type="button"
+          className="btn"
+          onClick={() => {
+            const value = input.trim();
+            if (value && !values.includes(value)) {
+              onChange([...values, value]);
+              setInput("");
+            }
+          }}
+        >
+          <Plus size={13} /> Add
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export function uniqueHttpOrigins(values: readonly (string | undefined)[]) {
+  const origins: string[] = [];
+  for (const value of values) {
+    if (!value) continue;
+    try {
+      const parsed = new URL(value);
+      if (
+        (parsed.protocol === "http:" || parsed.protocol === "https:") &&
+        parsed.pathname === "/" &&
+        !parsed.username &&
+        !parsed.password &&
+        !parsed.search &&
+        !parsed.hash &&
+        !origins.includes(parsed.origin)
+      ) {
+        origins.push(parsed.origin);
+      }
+    } catch {
+      // Suggestions are optional and untrusted profile values are ignored.
+    }
+  }
+  return origins.slice(0, 32);
+}

--- a/web/src/App.test.ts
+++ b/web/src/App.test.ts
@@ -155,10 +155,10 @@ describe("App connection guards", () => {
 describe("App multi-bridge helpers", () => {
   it("reports actionable launcher unavailability and load errors", () => {
     expect(launcherEmptyMessage(false, false, null)).toBe(
-      "Bridge is not ready. Close this dialog and reconnect.",
+      "Connection is not ready. Close this dialog and reconnect.",
     );
     expect(launcherEmptyMessage(true, false, null)).toBe(
-      "Launching is unavailable on this bridge. Update the bridge and reconnect.",
+      "Launching is unavailable on this Herdr. Update it and reconnect.",
     );
     expect(
       launcherEmptyMessage(true, true, {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -362,10 +362,10 @@ export function launcherEmptyMessage(
   state: BridgeLauncherPresetsState | null,
 ) {
   if (!bridgeReady) {
-    return "Bridge is not ready. Close this dialog and reconnect.";
+    return "Connection is not ready. Close this dialog and reconnect.";
   }
   if (!launcherSupported) {
-    return "Launching is unavailable on this bridge. Update the bridge and reconnect.";
+    return "Launching is unavailable on this Herdr. Update it and reconnect.";
   }
   if (state?.loadState === "error") {
     return `Could not load launcher presets: ${state.error ?? "unknown error"}. Close and reopen this dialog to retry.`;
@@ -3401,7 +3401,7 @@ export function App() {
       !runtimeIsAdmitted(selectedRuntime.id) ||
       !supportsNotes(selectedRuntime.capabilities)
     ) {
-      setError("Notes are not available for this bridge");
+      setError("Notes are not available for this Herdr");
       return;
     }
     try {
@@ -3429,7 +3429,7 @@ export function App() {
     }
     const runtime = bridgeId ? bridge.getRuntime(bridgeId) : null;
     if (!runtime || !runtimeIsAdmitted(runtime.id) || !supportsNotes(runtime.capabilities)) {
-      setError("Notes are not available for this bridge");
+      setError("Notes are not available for this Herdr");
       return;
     }
     try {
@@ -3515,7 +3515,7 @@ export function App() {
       !runtimeIsAdmitted(runtime.id) ||
       !supportsNotes(runtime.capabilities)
     ) {
-      setError("Notes are not available for this bridge");
+      setError("Notes are not available for this Herdr");
       return;
     }
     const bridgeSnapshot = snapshotForBridge(bridgeId);
@@ -3547,7 +3547,7 @@ export function App() {
       !runtimeIsAdmitted(runtime.id) ||
       !supportsNotes(runtime.capabilities)
     ) {
-      setError("Notes are not available for this bridge");
+      setError("Notes are not available for this Herdr");
       return;
     }
     const bridgeSnapshot = snapshotForBridge(target.bridgeId);
@@ -3645,8 +3645,8 @@ export function App() {
   ) => {
     const runtime = bridge.getRuntime(entry.bridgeId);
     if (!runtime || !runtimeIsAdmitted(runtime.id) || !supportsNotes(runtime.capabilities)) {
-      setError("Bridge is not ready");
-      throw new Error("Bridge is not ready");
+      setError("Connection is not ready");
+      throw new Error("Connection is not ready");
     }
     try {
       const savedNote = await updateNote(runtime.httpUrl, entry.note.note_id, {
@@ -3677,7 +3677,7 @@ export function App() {
       !runtimeIsAdmitted(selectedRuntime.id) ||
       !supportsNotes(selectedRuntime.capabilities)
     ) {
-      setError("Select a pane on the same bridge first");
+      setError("Select a pane on the same Herdr first");
       return;
     }
     try {
@@ -3694,7 +3694,7 @@ export function App() {
   const detachScopedNote = async (entry: ScopedNoteEntry) => {
     const runtime = bridge.getRuntime(entry.bridgeId);
     if (!runtime || !runtimeIsAdmitted(runtime.id) || !supportsNotes(runtime.capabilities)) {
-      setError("Bridge is not ready");
+      setError("Connection is not ready");
       return;
     }
     try {
@@ -3710,7 +3710,7 @@ export function App() {
   const archiveScopedNote = async (entry: ScopedNoteEntry) => {
     const runtime = bridge.getRuntime(entry.bridgeId);
     if (!runtime || !runtimeIsAdmitted(runtime.id) || !supportsNotes(runtime.capabilities)) {
-      setError("Bridge is not ready");
+      setError("Connection is not ready");
       return;
     }
     try {
@@ -3726,7 +3726,7 @@ export function App() {
   const restoreScopedNote = async (entry: ScopedNoteEntry) => {
     const runtime = bridge.getRuntime(entry.bridgeId);
     if (!runtime || !runtimeIsAdmitted(runtime.id) || !supportsNotes(runtime.capabilities)) {
-      setError("Bridge is not ready");
+      setError("Connection is not ready");
       return;
     }
     try {
@@ -3742,7 +3742,7 @@ export function App() {
   const deleteScopedNote = async (entry: ScopedNoteEntry) => {
     const runtime = bridge.getRuntime(entry.bridgeId);
     if (!runtime || !runtimeIsAdmitted(runtime.id) || !supportsNotes(runtime.capabilities)) {
-      setError("Bridge is not ready");
+      setError("Connection is not ready");
       return false;
     }
     try {
@@ -4335,7 +4335,7 @@ export function App() {
         runtime.generationKey,
       )
     ) {
-      setError("Bridge is not ready");
+      setError("Connection is not ready");
       return false;
     }
     let routed;
@@ -4346,7 +4346,7 @@ export function App() {
       return false;
     }
     if (routed.generationKey !== runtime.generationKey) {
-      setError("Bridge is not ready");
+      setError("Connection is not ready");
       return false;
     }
     const requestConnectionKey = runtime.generationKey;
@@ -4512,7 +4512,7 @@ export function App() {
       );
     } else if (key === "move_new_space" && kind === "pane") {
       if (!commands) {
-        setError("Bridge is not ready");
+        setError("Connection is not ready");
         return;
       }
       void exec(
@@ -4532,7 +4532,7 @@ export function App() {
     const runtime = bridge.getRuntime(bridgeId);
     const commands = runtime ? createCommands(runtime.httpUrl) : null;
     if (!commands) {
-      setError("Bridge is not ready");
+      setError("Connection is not ready");
       return;
     }
     const command =
@@ -4556,7 +4556,7 @@ export function App() {
     }
     const runtime = bridge.getRuntime(dialog.bridgeId);
     if (!runtime) {
-      setError("Bridge is not ready");
+      setError("Connection is not ready");
       return;
     }
     void exec(
@@ -4589,7 +4589,7 @@ export function App() {
     const runtime = bridge.getRuntime(bridgeId);
     const commands = runtime ? createCommands(runtime.httpUrl) : null;
     if (!commands) {
-      setError("Bridge is not ready");
+      setError("Connection is not ready");
       return;
     }
     const command = kind === "space" ? "workspace.rename" : "tab.rename";
@@ -4612,7 +4612,7 @@ export function App() {
     const runtime = bridge.getRuntime(bridgeId);
     const commands = runtime ? createCommands(runtime.httpUrl) : null;
     if (!commands) {
-      setError("Bridge is not ready");
+      setError("Connection is not ready");
       return;
     }
     const command =
@@ -4636,11 +4636,11 @@ export function App() {
     const runtime = bridge.getRuntime(launchTarget.bridgeId);
     const commands = runtime ? createCommands(runtime.httpUrl) : null;
     if (!runtime || !commands) {
-      setError("Bridge is not ready");
+      setError("Connection is not ready");
       return;
     }
     if (!supportsLauncherPresets(runtime.capabilities)) {
-      setError("Launching is unavailable on this bridge. Update the bridge and reconnect.");
+      setError("Launching is unavailable on this Herdr. Update it and reconnect.");
       return;
     }
     if (!launchPresetState?.response) {
@@ -4905,7 +4905,7 @@ export function App() {
             Boolean(selectedRuntime?.canConnect) && !selectedBridgeView?.surfaceError
           }
           bridgeError={selectedBridgeView?.surfaceError ?? selectedRuntime?.capabilityError ?? null}
-          bridgeLabel={selectedRuntime?.label ?? "No bridge"}
+          bridgeLabel={selectedRuntime?.label ?? "No connection"}
           bridgeMode={selectedRuntime?.mode ?? "configured"}
           capabilityState={
             selectedBridgeView?.surfaceError
@@ -4976,7 +4976,7 @@ export function App() {
                   (commands) => commands.createWorkspace(),
                   true,
                 )
-              : setError("Bridge is not ready")
+              : setError("Connection is not ready")
           }
           onCreateTab={(bridgeId, workspaceId) =>
             setLaunchTarget({ mode: "tab", workspaceId, bridgeId })
@@ -7772,7 +7772,7 @@ function Switcher({
         label={view.runtime.label}
         message={
           view.runtime.capabilityError ||
-          (view.loadState === "error" ? "Could not reach bridge" : "Bridge disconnected")
+          (view.loadState === "error" ? "Could not reach Herdr" : "Connection disconnected")
         }
         onSelect={() => {
           onSelectBridge(view.runtime.id);
@@ -7884,7 +7884,7 @@ function Switcher({
       return (
         <div className="empty">
           <strong>Notes unavailable</strong>
-          <span>Update the selected bridge to use pane notes.</span>
+          <span>Update the selected Herdr to use pane notes.</span>
         </div>
       );
     }
@@ -8014,7 +8014,7 @@ function Switcher({
           className="icon-btn"
           type="button"
           aria-label="Settings"
-          title={`Settings; bridge: ${bridgeLabel}`}
+          title={`Settings; Herdr: ${bridgeLabel}`}
           data-spin={capabilityState === "probing" ? "" : undefined}
           onClick={onBackendSettings}
         >
@@ -8138,20 +8138,20 @@ function Switcher({
           <div className="empty">
             <strong>
               {bridgeViews.length === 0
-                ? "No bridges enabled"
+                ? "No connections enabled"
                 : bridgeBlocked
-                ? "Bridge disconnected"
+                ? "Connection disconnected"
                 : loadState === "error"
-                  ? "Bridge unavailable"
+                  ? "Connection unavailable"
                   : "Connecting…"}
             </strong>
             <span>
               {bridgeViews.length === 0
-                ? "Enable one or more bridges in settings."
+                ? "Enable one or more connections in Network settings."
                 : bridgeBlocked
-                ? bridgeError || "Choose a usable bridge backend."
+                ? bridgeError || "Choose a usable connection."
                 : loadState === "error"
-                  ? "Could not reach the herdr bridge."
+                  ? "Could not reach this Herdr."
                   : ""}
             </span>
             {bridgeBlocked ? (
@@ -10444,10 +10444,10 @@ function stageBreadcrumb(
 ) {
   if (!pane) {
     if (!bridgeCanConnect) {
-      return "bridge disconnected";
+      return "connection disconnected";
     }
     if (loadState === "error") {
-      return "bridge unavailable";
+      return "connection unavailable";
     }
     return snapshot ? "no pane selected" : "connecting…";
   }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -64,6 +64,7 @@ import {
 } from "./agentPins";
 import type { AgentPinsListResponse } from "./agentPins";
 import { BackendSettingsDialog } from "./BackendSettingsDialog";
+import { authenticatedFetch } from "./bridgeApi";
 import type { BridgeId, BridgeRuntime, CapabilityState } from "./bridge";
 import { createCommands, createdPaneId, createdWorkspaceId } from "./commands";
 import type { LaunchSpec, PaneFocusDirection, SplitDirection } from "./commands";
@@ -5460,6 +5461,7 @@ export function App() {
       {backendSettingsOpen ? (
         <BackendSettingsDialog
           showMobileTerminalSettings={isTouchInput}
+          showRemoteAccess={!isNativeAndroid()}
           onOpenWorldSettings={worldSettingsController.open}
           notesEnabled={notesEnabled}
           onNotesEnabled={setNotesEnabled}
@@ -10467,7 +10469,7 @@ async function syncSelectedPane(
   httpUrl: (path: string, query?: URLSearchParams) => string,
   paneId: string,
 ) {
-  const response = await fetch(httpUrl("/api/selection"), {
+  const response = await authenticatedFetch(httpUrl("/api/selection"), {
     method: "POST",
     headers: { "content-type": "application/json" },
     body: JSON.stringify({ pane_id: paneId }),

--- a/web/src/BackendSettingsDialog.test.ts
+++ b/web/src/BackendSettingsDialog.test.ts
@@ -3,7 +3,7 @@ import { suggestedConnectionName } from "./BackendSettingsDialog";
 
 describe("connection name suggestions", () => {
   it("uses the hostname or IP without copying protocol and port", () => {
-    expect(suggestedConnectionName("http://192.168.1.145:8787")).toBe("192.168.1.145");
+    expect(suggestedConnectionName("http://192.0.2.145:8787")).toBe("192.0.2.145");
     expect(suggestedConnectionName("herdr.example:8791")).toBe("herdr.example");
     expect(suggestedConnectionName("http://[2001:db8::20]:8787")).toBe("2001:db8::20");
     expect(suggestedConnectionName("not a valid address")).toBe("");

--- a/web/src/BackendSettingsDialog.test.ts
+++ b/web/src/BackendSettingsDialog.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from "vitest";
+import { suggestedConnectionName } from "./BackendSettingsDialog";
+
+describe("connection name suggestions", () => {
+  it("uses the hostname or IP without copying protocol and port", () => {
+    expect(suggestedConnectionName("http://192.168.1.145:8787")).toBe("192.168.1.145");
+    expect(suggestedConnectionName("herdr.example:8791")).toBe("herdr.example");
+    expect(suggestedConnectionName("http://[2001:db8::20]:8787")).toBe("2001:db8::20");
+    expect(suggestedConnectionName("not a valid address")).toBe("");
+  });
+});

--- a/web/src/BackendSettingsDialog.tsx
+++ b/web/src/BackendSettingsDialog.tsx
@@ -3,21 +3,19 @@ import type { HsvaColor } from "@uiw/color-convert";
 import Wheel from "@uiw/react-color-wheel";
 import {
   Building2,
+  Network,
   Plus,
   RotateCcw,
-  Server,
   SlidersHorizontal,
   Smartphone,
   SquareTerminal,
   StickyNote,
-  Wifi,
   X,
 } from "lucide-react";
 import { useEffect, useId, useMemo, useRef, useState } from "react";
 import type { CSSProperties, KeyboardEvent } from "react";
 import {
   duplicateBackend,
-  allAvailableBridgeIds,
   fallbackBackendColor,
   normalizeBridgeBaseUrl,
   normalizeBackendColor,
@@ -121,7 +119,8 @@ type FormState = {
 };
 
 type SelectionMode = "same-origin" | "new" | "backend";
-type SettingsArea = "bridge" | "remote" | "features" | "display" | "terminal" | "mobile";
+type SettingsArea = "network" | "features" | "display" | "terminal" | "mobile";
+type NetworkArea = "connections" | "allow";
 const relativeHttpUrl = (path: string) => path;
 
 export function BackendSettingsDialog({
@@ -180,7 +179,8 @@ export function BackendSettingsDialog({
   const [busy, setBusy] = useState(false);
   const [message, setMessage] = useState<string | null>(null);
   const [duplicate, setDuplicate] = useState<BridgeBackendProfile | null>(null);
-  const [activeArea, setActiveArea] = useState<SettingsArea>("bridge");
+  const [activeArea, setActiveArea] = useState<SettingsArea>("network");
+  const [networkArea, setNetworkArea] = useState<NetworkArea>("connections");
   useFocusReturn();
 
   const selectedBackend = useMemo(
@@ -254,7 +254,7 @@ export function BackendSettingsDialog({
         try {
           const access = await fetchRemoteAccess(localHttpUrl);
           if (!access.remote_access.allowed_bridge_origins.includes(new URL(baseUrl).origin)) {
-            setMessage("Save this bridge first. Herdr World will allow its URL and reload before connecting.");
+            setMessage("Connect first. Herdr World needs to allow this address and reload the page.");
             return;
           }
         } catch {
@@ -262,9 +262,9 @@ export function BackendSettingsDialog({
         }
       }
       await bridge.probeBackend(baseUrl);
-      setMessage(found ? `Reachable; same URL as ${found.name}.` : "Backend reachable.");
+      setMessage(found ? `Reachable; already saved as ${found.name}.` : "Connection successful.");
     } catch (error) {
-      setMessage(error instanceof Error ? error.message : "Backend test failed");
+      setMessage(error instanceof Error ? error.message : "Connection test failed");
     } finally {
       setBusy(false);
     }
@@ -283,7 +283,7 @@ export function BackendSettingsDialog({
       }
       const profile = form.id
         ? await bridge.updateBackend(form.id, { name: form.name, baseUrl, color: form.color })
-        : await bridge.addBackend({ name: form.name, baseUrl, color: form.color }, false);
+        : await bridge.addBackend({ name: form.name, baseUrl, color: form.color }, true);
       setSelectionMode("backend");
       setForm(backendFormFromProfile(profile));
       let permissionChanged = false;
@@ -299,7 +299,7 @@ export function BackendSettingsDialog({
         }
       }
       if (permissionChanged) {
-        setMessage("Bridge saved and allowed. Reloading Herdr World to activate browser access…");
+        setMessage("Connection saved. Reloading Herdr World to connect…");
         window.setTimeout(() => window.location.reload(), 0);
         return;
       }
@@ -307,17 +307,17 @@ export function BackendSettingsDialog({
       try {
         await bridge.probeBackend(baseUrl);
       } catch (error) {
-        probeWarning = error instanceof Error ? error.message : "Backend could not be reached.";
+        probeWarning = error instanceof Error ? error.message : "The Herdr address could not be reached.";
       }
       setMessage(
         permissionWarning
-          ? `Bridge saved. ${permissionWarning}`
+          ? `Connection saved. ${permissionWarning}`
           : probeWarning
-            ? `Bridge saved. ${probeWarning}`
-            : "Bridge saved.",
+            ? `Connection saved. ${probeWarning}`
+            : "Connection saved.",
       );
     } catch (error) {
-      setMessage(error instanceof Error ? error.message : "Could not save backend");
+      setMessage(error instanceof Error ? error.message : "Could not save connection");
     } finally {
       setBusy(false);
     }
@@ -336,14 +336,18 @@ export function BackendSettingsDialog({
   const sameOriginUrl = sameOriginDisplayUrl();
   const sameOriginLabel = sameOriginHostLabel();
   const showSameOrigin = bridge.sameOriginAvailable;
-  const availableBridgeIds = allAvailableBridgeIds(bridge.store.backends, showSameOrigin);
-  const enabledBridgeCount = availableBridgeIds.filter((id) =>
-    bridge.store.enabledBridgeIds.includes(id),
-  ).length;
-  const allBridgesEnabled = availableBridgeIds.length > 0 && enabledBridgeCount === availableBridgeIds.length;
-  const areas: { id: SettingsArea; label: string; icon: typeof Server }[] = [
-    { id: "bridge", label: "Bridges", icon: Server },
-    ...(showRemoteAccess ? [{ id: "remote" as const, label: "Share this machine", icon: Wifi }] : []),
+  const sameOriginStatus = connectionStatus(
+    sameOriginEnabled,
+    bridge.getRuntime(SAME_ORIGIN_BRIDGE_ID)?.capabilityState,
+  );
+  const selectedConnectionStatus = selectedBackend
+    ? connectionStatus(
+        bridge.store.enabledBridgeIds.includes(selectedBackend.id),
+        bridge.getRuntime(selectedBackend.id)?.capabilityState,
+      )
+    : null;
+  const areas: { id: SettingsArea; label: string; icon: typeof Network }[] = [
+    { id: "network", label: "Network", icon: Network },
     { id: "features", label: "Features", icon: StickyNote },
     { id: "display", label: "Display", icon: SlidersHorizontal },
     { id: "terminal", label: "Terminal", icon: SquareTerminal },
@@ -371,7 +375,7 @@ export function BackendSettingsDialog({
         }}
         onSubmit={(event) => {
           event.preventDefault();
-          if (activeArea !== "bridge" || !editingBackend) {
+          if (activeArea !== "network" || networkArea !== "connections" || !editingBackend) {
             return;
           }
           void saveBackend();
@@ -418,187 +422,207 @@ export function BackendSettingsDialog({
           </div>
 
           <div className="settings-panel" role="tabpanel">
-            {activeArea === "bridge" ? (
+            {activeArea === "network" ? (
               <>
-                <div className="settings-label">Connect to bridges</div>
+                <div className="settings-label">Network</div>
                 <p className="settings-help">
-                  Add machines this browser should connect to. This list is stored separately for
-                  each Herdr World page URL, so a list saved on port 8787 is not copied to port 8791.
+                  Connect this Herdr World to other Herdr instances, or allow connections to this
+                  one.
                 </p>
-                <div className="bridge-settings-grid">
-                  <div className="backend-list" role="list" aria-label="Saved bridges">
-                    <div className="backend-fleet-summary">
-                      <div>
-                        <strong>Bridge fleet</strong>
-                        <small>{enabledBridgeCount}/{availableBridgeIds.length} included in Office</small>
-                      </div>
-                      <div className="backend-fleet-actions">
-                        <button
-                          className="settings-inline-action"
-                          type="button"
-                          disabled={allBridgesEnabled}
-                          onClick={() => bridge.setAllBridgesEnabled(true)}
-                        >
-                          Enable all
-                        </button>
-                        <button
-                          className="settings-inline-action"
-                          type="button"
-                          disabled={enabledBridgeCount === 0}
-                          onClick={() => bridge.setAllBridgesEnabled(false)}
-                        >
-                          Disable all
-                        </button>
-                      </div>
-                    </div>
-                    {showSameOrigin ? (
-                      <BackendToggleRow
-                        active={selectionMode === "same-origin"}
-                        color={SAME_ORIGIN_BRIDGE_COLOR}
-                        enabled={sameOriginEnabled}
-                        title={sameOriginLabel}
-                        subtitle={sameOriginUrl}
-                        toggleLabel={`${sameOriginEnabled ? "Disable" : "Enable"} ${sameOriginLabel} bridge`}
-                        onSelect={selectSameOrigin}
-                        onToggle={() => bridge.setBridgeEnabled(SAME_ORIGIN_BRIDGE_ID, !sameOriginEnabled)}
-                      />
-                    ) : null}
-                    {bridge.store.backends.map((backend) => {
-                      const enabled = bridge.store.enabledBridgeIds.includes(backend.id);
-                      return (
-                        <BackendToggleRow
-                          key={backend.id}
-                          active={backend.id === form.id}
-                          color={backend.color ?? fallbackBackendColor(backend.id)}
-                          enabled={enabled}
-                          title={backend.name}
-                          subtitle={backend.baseUrl}
-                          toggleLabel={`${enabled ? "Disable" : "Enable"} ${backend.name}`}
-                          onSelect={() => editBackend(backend)}
-                          onToggle={() => bridge.setBridgeEnabled(backend.id, !enabled)}
-                        />
-                      );
-                    })}
+                {showRemoteAccess ? (
+                  <div
+                    className="segmented-control network-area-tabs"
+                    role="tablist"
+                    aria-label="Network settings"
+                  >
                     <button
-                      className="backend-row-action"
                       type="button"
-                      data-active={selectionMode === "new" ? "true" : undefined}
-                      onClick={startNew}
+                      role="tab"
+                      aria-selected={networkArea === "connections"}
+                      data-on={networkArea === "connections" ? "true" : undefined}
+                      onClick={() => setNetworkArea("connections")}
                     >
-                      <Plus size={14} />
-                      <span>
-                        <strong>Add bridge</strong>
-                        <small>Save another bridge URL</small>
-                      </span>
+                      Connections
+                    </button>
+                    <button
+                      type="button"
+                      role="tab"
+                      aria-selected={networkArea === "allow"}
+                      data-on={networkArea === "allow" ? "true" : undefined}
+                      onClick={() => setNetworkArea("allow")}
+                    >
+                      Allow connections
                     </button>
                   </div>
-                  <div className="backend-form">
-                    {selectionMode === "same-origin" ? (
-                      <div className="backend-static">
-                        <strong>{sameOriginLabel}</strong>
-                        <span>
-                          {sameOriginEnabled ? "Enabled" : "Disabled"}; uses the server that
-                          delivered this web app.
-                        </span>
+                ) : null}
+
+                {networkArea === "connections" ? (
+                  <>
+                    <div className="settings-label">Connections</div>
+                    <p className="settings-help">
+                      Connect this Herdr World to another Herdr. Connections are saved in this browser.
+                    </p>
+                    <div className="bridge-settings-grid">
+                      <div className="backend-list" role="list" aria-label="Connections">
+                        {showSameOrigin ? (
+                          <BackendToggleRow
+                            active={selectionMode === "same-origin"}
+                            color={SAME_ORIGIN_BRIDGE_COLOR}
+                            enabled={sameOriginEnabled}
+                            title={sameOriginLabel}
+                            subtitle={sameOriginUrl}
+                            status={sameOriginStatus}
+                            toggleLabel={`${sameOriginEnabled ? "Disconnect from" : "Connect to"} ${sameOriginLabel}`}
+                            onSelect={selectSameOrigin}
+                            onToggle={() => bridge.setBridgeEnabled(SAME_ORIGIN_BRIDGE_ID, !sameOriginEnabled)}
+                          />
+                        ) : null}
+                        {bridge.store.backends.map((backend) => {
+                          const enabled = bridge.store.enabledBridgeIds.includes(backend.id);
+                          const status = connectionStatus(
+                            enabled,
+                            bridge.getRuntime(backend.id)?.capabilityState,
+                          );
+                          return (
+                            <BackendToggleRow
+                              key={backend.id}
+                              active={backend.id === form.id}
+                              color={backend.color ?? fallbackBackendColor(backend.id)}
+                              enabled={enabled}
+                              title={backend.name}
+                              subtitle={backend.baseUrl}
+                              status={status}
+                              toggleLabel={`${enabled ? "Disconnect from" : "Connect to"} ${backend.name}`}
+                              onSelect={() => editBackend(backend)}
+                              onToggle={() => bridge.setBridgeEnabled(backend.id, !enabled)}
+                            />
+                          );
+                        })}
+                        <button
+                          className="backend-row-action"
+                          type="button"
+                          data-active={selectionMode === "new" ? "true" : undefined}
+                          onClick={startNew}
+                        >
+                          <Plus size={14} />
+                          <span>
+                            <strong>Add connection</strong>
+                            <small>Connect to another Herdr</small>
+                          </span>
+                        </button>
                       </div>
-                    ) : (
-                      <>
-                        <label className="field-label">
-                          <span>Display name</span>
-                          <input
-                            className="field"
-                            value={form.name}
-                            placeholder="Home workstation"
-                            autoComplete="off"
-                            onChange={(event) =>
-                              setForm((current) => ({ ...current, name: event.target.value }))
-                            }
-                          />
-                        </label>
-                        <label className="field-label">
-                          <span>Bridge URL</span>
-                          <input
-                            className="field"
-                            value={form.baseUrl}
-                            placeholder="http://bridge-a.example.test:4000"
-                            autoComplete="off"
-                            spellCheck={false}
-                            onBlur={validateDuplicate}
-                            onChange={(event) =>
-                              setForm((current) => ({ ...current, baseUrl: event.target.value }))
-                            }
-                          />
-                        </label>
-                        <label className="field-label">
-                          <span>Bridge color</span>
-                          <BackendColorControl
-                            value={form.color}
-                            defaultValue={
-                              form.id
-                                ? fallbackBackendColor(form.id)
-                                : suggestBackendColor(bridge.store.backends)
-                            }
-                            onChange={(color) => setForm((current) => ({ ...current, color }))}
-                          />
-                        </label>
-                        {selectedBackend?.lastConnectedAt ? (
-                          <div className="backend-note">
-                            Last used {formatDate(selectedBackend.lastConnectedAt)}
+                      <div className="backend-form">
+                        {selectionMode === "same-origin" ? (
+                          <div className="backend-static">
+                            <strong>{sameOriginLabel}</strong>
+                            <span>{sameOriginStatus}. This Herdr served the page you are using.</span>
+                          </div>
+                        ) : (
+                          <>
+                            <label className="field-label">
+                              <span>Herdr address</span>
+                              <input
+                                className="field"
+                                value={form.baseUrl}
+                                placeholder="http://herdr.example:8787"
+                                autoComplete="off"
+                                spellCheck={false}
+                                onBlur={validateDuplicate}
+                                onChange={(event) =>
+                                  setForm((current) => ({ ...current, baseUrl: event.target.value }))
+                                }
+                              />
+                            </label>
+                            <details className="remote-access-advanced connection-customize">
+                              <summary>Customize connection</summary>
+                              <div className="remote-access-advanced-content connection-customize-content">
+                                <label className="field-label">
+                                  <span>Name</span>
+                                  <input
+                                    className="field"
+                                    value={form.name}
+                                    placeholder="Ubuntu VM"
+                                    autoComplete="off"
+                                    onChange={(event) =>
+                                      setForm((current) => ({ ...current, name: event.target.value }))
+                                    }
+                                  />
+                                </label>
+                                <label className="field-label">
+                                  <span>Color</span>
+                                  <BackendColorControl
+                                    value={form.color}
+                                    defaultValue={
+                                      form.id
+                                        ? fallbackBackendColor(form.id)
+                                        : suggestBackendColor(bridge.store.backends)
+                                    }
+                                    onChange={(color) => setForm((current) => ({ ...current, color }))}
+                                  />
+                                </label>
+                                {selectedBackend?.lastConnectedAt ? (
+                                  <div className="backend-note">
+                                    Last connected {formatDate(selectedBackend.lastConnectedAt)}
+                                  </div>
+                                ) : null}
+                              </div>
+                            </details>
+                          </>
+                        )}
+                        {selectedConnectionStatus ? (
+                          <div
+                            className="connection-state"
+                            data-state={selectedConnectionStatus.toLowerCase()}
+                          >
+                            {selectedConnectionStatus}
                           </div>
                         ) : null}
-                      </>
-                    )}
-                    {selectedBackend ? (
-                      <div className="backend-note">
-                        {bridge.store.enabledBridgeIds.includes(selectedBackend.id)
-                          ? "Enabled"
-                          : "Disabled"}
+                        {duplicate ? (
+                          <div className="backend-warning">
+                            This address is already saved as {duplicate.name}.
+                          </div>
+                        ) : null}
+                        {message ? <div className="modal-message">{message}</div> : null}
+                      </div>
+                    </div>
+                    {editingBackend ? (
+                      <div className="modal-actions">
+                        {canDelete ? (
+                          <button type="button" className="btn btn-danger" disabled={busy} onClick={deleteBackend}>
+                            Delete connection
+                          </button>
+                        ) : null}
+                        <button
+                          type="button"
+                          className="btn"
+                          disabled={busy || !form.baseUrl.trim()}
+                          onClick={testBackend}
+                        >
+                          Test connection
+                        </button>
+                        <button
+                          type="button"
+                          className="btn btn-primary"
+                          disabled={busy || !form.baseUrl.trim()}
+                          onClick={() => void saveBackend()}
+                        >
+                          {form.id ? "Save changes" : "Connect"}
+                        </button>
                       </div>
                     ) : null}
-                    {duplicate ? (
-                      <div className="backend-warning">
-                        This URL is already saved as {duplicate.name}.
-                      </div>
+                    {showRemoteAccess ? (
+                      <BridgeDestinationSettings
+                        httpUrl={localHttpUrl}
+                        backends={bridge.store.backends}
+                      />
                     ) : null}
-                    {message ? <div className="modal-message">{message}</div> : null}
-                  </div>
-                </div>
-                {editingBackend ? (
-                  <div className="modal-actions">
-                    {canDelete ? (
-                      <button type="button" className="btn btn-danger" disabled={busy} onClick={deleteBackend}>
-                        Delete
-                      </button>
-                    ) : null}
-                    <button
-                      type="button"
-                      className="btn"
-                      disabled={busy || !form.baseUrl.trim()}
-                      onClick={testBackend}
-                    >
-                      Test
-                    </button>
-                    <button
-                      type="button"
-                      className="btn btn-primary"
-                      disabled={busy || !form.baseUrl.trim()}
-                      onClick={() => void saveBackend()}
-                    >
-                      Save
-                    </button>
-                  </div>
+                  </>
                 ) : null}
-                {showRemoteAccess ? (
-                  <BridgeDestinationSettings
-                    httpUrl={localHttpUrl}
-                    backends={bridge.store.backends}
-                  />
+
+                {networkArea === "allow" && showRemoteAccess ? (
+                  <RemoteAccessSettings httpUrl={localHttpUrl} />
                 ) : null}
               </>
-            ) : null}
-
-            {activeArea === "remote" && showRemoteAccess ? (
-              <RemoteAccessSettings httpUrl={localHttpUrl} />
             ) : null}
 
             {activeArea === "features" ? (
@@ -1152,7 +1176,7 @@ function BackendColorControl({
         className="backend-color-swatch"
         ref={buttonRef}
         type="button"
-        aria-label="Bridge color"
+        aria-label="Connection color"
         aria-expanded={open}
         aria-controls={open ? popoverId : undefined}
         aria-haspopup="true"
@@ -1162,7 +1186,7 @@ function BackendColorControl({
       <input
         className="backend-color-value mono"
         value={draft}
-        aria-label="Bridge color hex value"
+        aria-label="Connection color hex value"
         spellCheck={false}
         autoCapitalize="none"
         onFocus={(event) => event.currentTarget.select()}
@@ -1195,10 +1219,10 @@ function BackendColorControl({
           className="backend-color-popover"
           id={popoverId}
           role="group"
-          aria-label="Bridge color picker"
+          aria-label="Connection color picker"
         >
           <Wheel
-            aria-label="Bridge color hue and saturation"
+            aria-label="Connection color hue and saturation"
             color={hsva}
             width={176}
             height={176}
@@ -1212,7 +1236,7 @@ function BackendColorControl({
             max={100}
             step={1}
             value={Math.round(hsva.v)}
-            aria-label="Bridge color brightness"
+            aria-label="Connection color brightness"
             style={{ "--shade-color": shadeColor } as CSSProperties}
             onChange={(event) => setHsvaColor({ ...hsva, v: event.currentTarget.valueAsNumber })}
           />
@@ -1221,7 +1245,7 @@ function BackendColorControl({
             <button
               className="settings-reset icon-btn"
               type="button"
-              aria-label="Reset bridge color"
+              aria-label="Reset connection color"
               title="Reset"
               disabled={color === fallbackColor}
               onClick={() => setColor(fallbackColor)}
@@ -1418,6 +1442,7 @@ function BackendToggleRow({
   active,
   color,
   enabled,
+  status,
   title,
   subtitle,
   toggleLabel,
@@ -1427,6 +1452,7 @@ function BackendToggleRow({
   active: boolean;
   color: string;
   enabled: boolean;
+  status: string;
   title: string;
   subtitle: string;
   toggleLabel: string;
@@ -1443,7 +1469,11 @@ function BackendToggleRow({
         />
         <span className="backend-row-text">
           <strong>{title}</strong>
-          <small>{subtitle}</small>
+          <small>
+            <span className="connection-status" data-state={status.toLowerCase()}>{status}</span>
+            <span aria-hidden="true"> · </span>
+            {subtitle}
+          </small>
         </span>
       </button>
       <button
@@ -1460,6 +1490,18 @@ function BackendToggleRow({
       </button>
     </div>
   );
+}
+
+function connectionStatus(
+  enabled: boolean,
+  capabilityState: "idle" | "probing" | "ready" | "error" | "offline" | "incompatible" | undefined,
+) {
+  if (!enabled) return "Off";
+  if (capabilityState === "ready") return "Connected";
+  if (!capabilityState || capabilityState === "idle" || capabilityState === "probing") {
+    return "Connecting";
+  }
+  return "Offline";
 }
 
 function newBackendForm(backends: readonly BridgeBackendProfile[]): FormState {

--- a/web/src/BackendSettingsDialog.tsx
+++ b/web/src/BackendSettingsDialog.tsx
@@ -28,7 +28,9 @@ import {
   useBridge,
 } from "./bridge";
 import type { BridgeBackendProfile } from "./bridge";
+import { BridgeDestinationSettings } from "./BridgeDestinationSettings";
 import { RemoteAccessSettings } from "./RemoteAccessSettings";
+import { allowBridgeDestinations, fetchRemoteAccess } from "./remoteAccess";
 import {
   DEFAULT_CONTENT_INSET_BOTTOM_PX,
   DEFAULT_CONTENT_INSET_TOP_PX,
@@ -120,6 +122,7 @@ type FormState = {
 
 type SelectionMode = "same-origin" | "new" | "backend";
 type SettingsArea = "bridge" | "remote" | "features" | "display" | "terminal" | "mobile";
+const relativeHttpUrl = (path: string) => path;
 
 export function BackendSettingsDialog({
   showMobileTerminalSettings,
@@ -167,6 +170,7 @@ export function BackendSettingsDialog({
   onClose,
 }: Props) {
   const bridge = useBridge();
+  const localHttpUrl = bridge.getRuntime(SAME_ORIGIN_BRIDGE_ID)?.httpUrl ?? relativeHttpUrl;
   const titleId = useId();
   const closeButtonRef = useRef<HTMLButtonElement | null>(null);
   const [form, setForm] = useState<FormState>(() => newBackendForm(bridge.store.backends));
@@ -246,6 +250,17 @@ export function BackendSettingsDialog({
       const baseUrl = normalizeBridgeBaseUrl(form.baseUrl);
       const found = duplicateBackend(bridge.store.backends, baseUrl, form.id ?? undefined);
       setDuplicate(found);
+      if (showRemoteAccess) {
+        try {
+          const access = await fetchRemoteAccess(localHttpUrl);
+          if (!access.remote_access.allowed_bridge_origins.includes(new URL(baseUrl).origin)) {
+            setMessage("Save this bridge first. Herdr World will allow its URL and reload before connecting.");
+            return;
+          }
+        } catch {
+          // Standalone and development launches may not expose writable local management.
+        }
+      }
       await bridge.probeBackend(baseUrl);
       setMessage(found ? `Reachable; same URL as ${found.name}.` : "Backend reachable.");
     } catch (error) {
@@ -266,18 +281,41 @@ export function BackendSettingsDialog({
         setMessage(`This URL is already saved as ${found.name}.`);
         return;
       }
+      const profile = form.id
+        ? await bridge.updateBackend(form.id, { name: form.name, baseUrl, color: form.color })
+        : await bridge.addBackend({ name: form.name, baseUrl, color: form.color }, false);
+      setSelectionMode("backend");
+      setForm(backendFormFromProfile(profile));
+      let permissionChanged = false;
+      let permissionWarning: string | null = null;
+      if (showRemoteAccess) {
+        try {
+          const result = await allowBridgeDestinations(localHttpUrl, [new URL(baseUrl).origin]);
+          permissionChanged = result.changed;
+        } catch (error) {
+          permissionWarning = error instanceof Error
+            ? error.message
+            : "Browser connection permission could not be applied.";
+        }
+      }
+      if (permissionChanged) {
+        setMessage("Bridge saved and allowed. Reloading Herdr World to activate browser access…");
+        window.setTimeout(() => window.location.reload(), 0);
+        return;
+      }
       let probeWarning: string | null = null;
       try {
         await bridge.probeBackend(baseUrl);
       } catch (error) {
         probeWarning = error instanceof Error ? error.message : "Backend could not be reached.";
       }
-      const profile = form.id
-        ? await bridge.updateBackend(form.id, { name: form.name, baseUrl, color: form.color })
-        : await bridge.addBackend({ name: form.name, baseUrl, color: form.color }, false);
-      setSelectionMode("backend");
-      setForm(backendFormFromProfile(profile));
-      setMessage(probeWarning ? `Backend saved. ${probeWarning}` : "Backend saved.");
+      setMessage(
+        permissionWarning
+          ? `Bridge saved. ${permissionWarning}`
+          : probeWarning
+            ? `Bridge saved. ${probeWarning}`
+            : "Bridge saved.",
+      );
     } catch (error) {
       setMessage(error instanceof Error ? error.message : "Could not save backend");
     } finally {
@@ -304,8 +342,8 @@ export function BackendSettingsDialog({
   ).length;
   const allBridgesEnabled = availableBridgeIds.length > 0 && enabledBridgeCount === availableBridgeIds.length;
   const areas: { id: SettingsArea; label: string; icon: typeof Server }[] = [
-    { id: "bridge", label: "Bridge", icon: Server },
-    ...(showRemoteAccess ? [{ id: "remote" as const, label: "Remote access", icon: Wifi }] : []),
+    { id: "bridge", label: "Bridges", icon: Server },
+    ...(showRemoteAccess ? [{ id: "remote" as const, label: "Share this machine", icon: Wifi }] : []),
     { id: "features", label: "Features", icon: StickyNote },
     { id: "display", label: "Display", icon: SlidersHorizontal },
     { id: "terminal", label: "Terminal", icon: SquareTerminal },
@@ -382,6 +420,11 @@ export function BackendSettingsDialog({
           <div className="settings-panel" role="tabpanel">
             {activeArea === "bridge" ? (
               <>
+                <div className="settings-label">Connect to bridges</div>
+                <p className="settings-help">
+                  Add machines this browser should connect to. This list is stored separately for
+                  each Herdr World page URL, so a list saved on port 8787 is not copied to port 8791.
+                </p>
                 <div className="bridge-settings-grid">
                   <div className="backend-list" role="list" aria-label="Saved bridges">
                     <div className="backend-fleet-summary">
@@ -545,14 +588,17 @@ export function BackendSettingsDialog({
                     </button>
                   </div>
                 ) : null}
+                {showRemoteAccess ? (
+                  <BridgeDestinationSettings
+                    httpUrl={localHttpUrl}
+                    backends={bridge.store.backends}
+                  />
+                ) : null}
               </>
             ) : null}
 
             {activeArea === "remote" && showRemoteAccess ? (
-              <RemoteAccessSettings
-                httpUrl={bridge.getRuntime(SAME_ORIGIN_BRIDGE_ID)?.httpUrl ?? ((path) => path)}
-                backends={bridge.store.backends}
-              />
+              <RemoteAccessSettings httpUrl={localHttpUrl} />
             ) : null}
 
             {activeArea === "features" ? (

--- a/web/src/BackendSettingsDialog.tsx
+++ b/web/src/BackendSettingsDialog.tsx
@@ -10,6 +10,7 @@ import {
   Smartphone,
   SquareTerminal,
   StickyNote,
+  Wifi,
   X,
 } from "lucide-react";
 import { useEffect, useId, useMemo, useRef, useState } from "react";
@@ -27,6 +28,7 @@ import {
   useBridge,
 } from "./bridge";
 import type { BridgeBackendProfile } from "./bridge";
+import { RemoteAccessSettings } from "./RemoteAccessSettings";
 import {
   DEFAULT_CONTENT_INSET_BOTTOM_PX,
   DEFAULT_CONTENT_INSET_TOP_PX,
@@ -63,6 +65,7 @@ import { trapFocusWithin, useFocusReturn } from "./overlayFocus";
 
 type Props = {
   showMobileTerminalSettings: boolean;
+  showRemoteAccess: boolean;
   onOpenWorldSettings: () => void;
   notesEnabled: boolean;
   onNotesEnabled: (enabled: boolean) => void;
@@ -116,10 +119,11 @@ type FormState = {
 };
 
 type SelectionMode = "same-origin" | "new" | "backend";
-type SettingsArea = "bridge" | "features" | "display" | "terminal" | "mobile";
+type SettingsArea = "bridge" | "remote" | "features" | "display" | "terminal" | "mobile";
 
 export function BackendSettingsDialog({
   showMobileTerminalSettings,
+  showRemoteAccess,
   onOpenWorldSettings,
   notesEnabled,
   onNotesEnabled,
@@ -301,6 +305,7 @@ export function BackendSettingsDialog({
   const allBridgesEnabled = availableBridgeIds.length > 0 && enabledBridgeCount === availableBridgeIds.length;
   const areas: { id: SettingsArea; label: string; icon: typeof Server }[] = [
     { id: "bridge", label: "Bridge", icon: Server },
+    ...(showRemoteAccess ? [{ id: "remote" as const, label: "Remote access", icon: Wifi }] : []),
     { id: "features", label: "Features", icon: StickyNote },
     { id: "display", label: "Display", icon: SlidersHorizontal },
     { id: "terminal", label: "Terminal", icon: SquareTerminal },
@@ -541,6 +546,13 @@ export function BackendSettingsDialog({
                   </div>
                 ) : null}
               </>
+            ) : null}
+
+            {activeArea === "remote" && showRemoteAccess ? (
+              <RemoteAccessSettings
+                httpUrl={bridge.getRuntime(SAME_ORIGIN_BRIDGE_ID)?.httpUrl ?? ((path) => path)}
+                backends={bridge.store.backends}
+              />
             ) : null}
 
             {activeArea === "features" ? (

--- a/web/src/BackendSettingsDialog.tsx
+++ b/web/src/BackendSettingsDialog.tsx
@@ -528,26 +528,42 @@ export function BackendSettingsDialog({
                                 autoComplete="off"
                                 spellCheck={false}
                                 onBlur={validateDuplicate}
+                                onChange={(event) => {
+                                  const baseUrl = event.target.value;
+                                  setForm((current) => {
+                                    const previousSuggestion = suggestedConnectionName(current.baseUrl);
+                                    const nameIsAutomatic = !current.name || current.name === previousSuggestion;
+                                    return {
+                                      ...current,
+                                      baseUrl,
+                                      name: nameIsAutomatic
+                                        ? suggestedConnectionName(baseUrl)
+                                        : current.name,
+                                    };
+                                  });
+                                }}
+                              />
+                            </label>
+                            <label className="field-label">
+                              <span>Connection name</span>
+                              <input
+                                className="field"
+                                value={form.name}
+                                placeholder="Ubuntu VM"
+                                autoComplete="off"
                                 onChange={(event) =>
-                                  setForm((current) => ({ ...current, baseUrl: event.target.value }))
+                                  setForm((current) => ({ ...current, name: event.target.value }))
                                 }
                               />
                             </label>
+                            {selectionMode === "new" ? (
+                              <span className="backend-note">
+                                Suggested from the address; change it to any name you recognize.
+                              </span>
+                            ) : null}
                             <details className="remote-access-advanced connection-customize">
-                              <summary>Customize connection</summary>
+                              <summary>Appearance</summary>
                               <div className="remote-access-advanced-content connection-customize-content">
-                                <label className="field-label">
-                                  <span>Name</span>
-                                  <input
-                                    className="field"
-                                    value={form.name}
-                                    placeholder="Ubuntu VM"
-                                    autoComplete="off"
-                                    onChange={(event) =>
-                                      setForm((current) => ({ ...current, name: event.target.value }))
-                                    }
-                                  />
-                                </label>
                                 <label className="field-label">
                                   <span>Color</span>
                                   <BackendColorControl
@@ -1511,6 +1527,19 @@ function newBackendForm(backends: readonly BridgeBackendProfile[]): FormState {
     baseUrl: "",
     color: suggestBackendColor(backends),
   };
+}
+
+export function suggestedConnectionName(input: string) {
+  const trimmed = input.trim();
+  if (!trimmed) return "";
+  try {
+    const url = new URL(/^[a-z][a-z0-9+.-]*:\/\//iu.test(trimmed)
+      ? trimmed
+      : `http://${trimmed}`);
+    return url.hostname.replace(/^\[|\]$/g, "");
+  } catch {
+    return "";
+  }
 }
 
 function backendFormFromProfile(backend: BridgeBackendProfile): FormState {

--- a/web/src/BridgeDestinationSettings.test.tsx
+++ b/web/src/BridgeDestinationSettings.test.tsx
@@ -21,16 +21,18 @@ describe("BridgeDestinationSettings", () => {
     const requests: RequestInit[] = [];
     const reloadPage = vi.fn();
     let allowedBridgeOrigins: string[] = [];
+    let applyId: string | null = null;
     vi.spyOn(globalThis, "fetch").mockImplementation(async (_input, init) => {
       if (init?.method === "POST") {
         requests.push(init);
         const body = JSON.parse(String(init.body));
         allowedBridgeOrigins = body.remote_access.allowed_bridge_origins;
-        return new Response(JSON.stringify({ state: "applying", reason: "restarting" }), {
+        applyId = "apply-destinations";
+        return new Response(JSON.stringify({ id: applyId, state: "applying", reason: "restarting" }), {
           status: 202,
         });
       }
-      return new Response(JSON.stringify(remoteAccessStatus(allowedBridgeOrigins)), { status: 200 });
+      return new Response(JSON.stringify(remoteAccessStatus(allowedBridgeOrigins, applyId)), { status: 200 });
     });
 
     const { container } = await render(
@@ -67,7 +69,7 @@ describe("BridgeDestinationSettings", () => {
   });
 });
 
-function remoteAccessStatus(allowedBridgeOrigins: string[]) {
+function remoteAccessStatus(allowedBridgeOrigins: string[], applyId: string | null = null) {
   return {
     remote_access: {
       enabled: false,
@@ -79,7 +81,7 @@ function remoteAccessStatus(allowedBridgeOrigins: string[]) {
     port: 8791,
     suggestions: ["192.0.2.20"],
     mutation_allowed: true,
-    apply: { state: "ready", reason: null, restored: null },
+    apply: { id: applyId, state: "ready", reason: null, restored: null },
   };
 }
 

--- a/web/src/BridgeDestinationSettings.test.tsx
+++ b/web/src/BridgeDestinationSettings.test.tsx
@@ -1,0 +1,93 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { BridgeDestinationSettings } from "./BridgeDestinationSettings";
+
+const roots: Root[] = [];
+
+afterEach(async () => {
+  await act(async () => {
+    for (const root of roots.splice(0)) root.unmount();
+  });
+  document.body.innerHTML = "";
+  vi.restoreAllMocks();
+});
+
+describe("BridgeDestinationSettings", () => {
+  it("allows saved bridge URLs and reloads after the local bridge is ready", async () => {
+    const requests: RequestInit[] = [];
+    const reloadPage = vi.fn();
+    let allowedBridgeOrigins: string[] = [];
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (_input, init) => {
+      if (init?.method === "POST") {
+        requests.push(init);
+        const body = JSON.parse(String(init.body));
+        allowedBridgeOrigins = body.remote_access.allowed_bridge_origins;
+        return new Response(JSON.stringify({ state: "applying", reason: "restarting" }), {
+          status: 202,
+        });
+      }
+      return new Response(JSON.stringify(remoteAccessStatus(allowedBridgeOrigins)), { status: 200 });
+    });
+
+    const { container } = await render(
+      <BridgeDestinationSettings
+        httpUrl={(path) => path}
+        backends={[{
+          id: "remote-b",
+          name: "Remote B",
+          baseUrl: "http://bridge.example.test:8787",
+        }]}
+        reloadPage={reloadPage}
+      />,
+    );
+    await act(async () => Promise.resolve());
+
+    expect(container.textContent).toContain("Browser permission needed");
+    const allow = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.textContent?.includes("Allow saved bridges"),
+    );
+    await act(async () => {
+      allow?.click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(JSON.parse(String(requests[0]?.body))).toMatchObject({
+      password_action: "keep",
+      remote_access: {
+        enabled: false,
+        allowed_bridge_origins: ["http://bridge.example.test:8787"],
+      },
+    });
+    expect(reloadPage).toHaveBeenCalledOnce();
+  });
+});
+
+function remoteAccessStatus(allowedBridgeOrigins: string[]) {
+  return {
+    remote_access: {
+      enabled: false,
+      accepted_hosts: [],
+      allowed_page_origins: [],
+      allowed_bridge_origins: allowedBridgeOrigins,
+      password_configured: true,
+    },
+    port: 8791,
+    suggestions: ["192.0.2.20"],
+    mutation_allowed: true,
+    apply: { state: "ready", reason: null, restored: null },
+  };
+}
+
+async function render(element: React.ReactElement) {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  roots.push(root);
+  await act(async () => root.render(element));
+  return { container };
+}

--- a/web/src/BridgeDestinationSettings.test.tsx
+++ b/web/src/BridgeDestinationSettings.test.tsx
@@ -17,7 +17,7 @@ afterEach(async () => {
 });
 
 describe("BridgeDestinationSettings", () => {
-  it("allows saved bridge URLs and reloads after the local bridge is ready", async () => {
+  it("allows saved Herdr addresses and reloads after the local service is ready", async () => {
     const requests: RequestInit[] = [];
     const reloadPage = vi.fn();
     let allowedBridgeOrigins: string[] = [];
@@ -46,9 +46,9 @@ describe("BridgeDestinationSettings", () => {
     );
     await act(async () => Promise.resolve());
 
-    expect(container.textContent).toContain("Browser permission needed");
+    expect(container.textContent).toContain("Connection permission needed");
     const allow = Array.from(container.querySelectorAll("button")).find(
-      (button) => button.textContent?.includes("Allow saved bridges"),
+      (button) => button.textContent?.includes("Allow saved connections"),
     );
     await act(async () => {
       allow?.click();

--- a/web/src/BridgeDestinationSettings.tsx
+++ b/web/src/BridgeDestinationSettings.tsx
@@ -1,0 +1,165 @@
+import { useEffect, useMemo, useState } from "react";
+import { AccessOriginList, uniqueHttpOrigins } from "./AccessOriginList";
+import type { BridgeBackendProfile } from "./bridge";
+import type { BridgeHttpUrl } from "./bridgeApi";
+import {
+  allowBridgeDestinations,
+  applyRemoteAccess,
+  fetchRemoteAccess,
+  remoteAccessDraft,
+  remoteAccessMatchesDraft,
+  waitForRemoteAccessReady,
+  type RemoteAccessStatus,
+} from "./remoteAccess";
+
+type Props = {
+  httpUrl: BridgeHttpUrl;
+  backends: readonly BridgeBackendProfile[];
+  reloadPage?: () => void;
+};
+
+export function BridgeDestinationSettings({
+  httpUrl,
+  backends,
+  reloadPage = () => window.location.reload(),
+}: Props) {
+  const [status, setStatus] = useState<RemoteAccessStatus | null>(null);
+  const [destinations, setDestinations] = useState<string[]>([]);
+  const [busy, setBusy] = useState(false);
+  const [message, setMessage] = useState<string | null>(null);
+  const savedOrigins = useMemo(
+    () => uniqueHttpOrigins(backends.map((backend) => backend.baseUrl)),
+    [backends],
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+    void fetchRemoteAccess(httpUrl).then((next) => {
+      if (cancelled) return;
+      setStatus(next);
+      setDestinations(next.remote_access.allowed_bridge_origins);
+    }).catch((error: unknown) => {
+      if (!cancelled) {
+        setMessage(error instanceof Error ? error.message : "Browser permissions unavailable");
+      }
+    });
+    return () => { cancelled = true; };
+  }, [httpUrl]);
+
+  const missingOrigins = status
+    ? savedOrigins.filter((origin) => !status.remote_access.allowed_bridge_origins.includes(origin))
+    : [];
+
+  const applyAndReload = async (nextDestinations: string[]) => {
+    if (!status) return;
+    setBusy(true);
+    setMessage("Saving browser permissions and restarting this bridge…");
+    try {
+      const draft = remoteAccessDraft(status);
+      draft.allowed_bridge_origins = nextDestinations;
+      const apply = await applyRemoteAccess(httpUrl, draft, "keep");
+      if (apply.state === "failed") {
+        throw new Error(apply.reason ?? "The bridge could not apply the browser permissions");
+      }
+      await waitForRemoteAccessReady(
+        httpUrl,
+        (next) => remoteAccessMatchesDraft(
+          next,
+          draft,
+          status.remote_access.password_configured,
+        ),
+      );
+      setMessage("Browser permissions applied. Reloading Herdr World…");
+      setBusy(false);
+      reloadPage();
+    } catch (error) {
+      setMessage(error instanceof Error ? error.message : "Could not apply browser permissions");
+      setBusy(false);
+    }
+  };
+
+  const allowSaved = async () => {
+    setBusy(true);
+    setMessage("Allowing saved bridge URLs and restarting this bridge…");
+    try {
+      const result = await allowBridgeDestinations(httpUrl, savedOrigins);
+      setStatus(result.status);
+      setDestinations(result.status.remote_access.allowed_bridge_origins);
+      if (result.changed) {
+        setMessage("Saved bridges allowed. Reloading Herdr World…");
+        setBusy(false);
+        reloadPage();
+      } else {
+        setMessage("All saved bridge URLs are already allowed.");
+        setBusy(false);
+      }
+    } catch (error) {
+      setMessage(error instanceof Error ? error.message : "Could not allow saved bridge URLs");
+      setBusy(false);
+    }
+  };
+
+  if (!status && !message) return null;
+
+  return (
+    <div className="settings-section bridge-destination-settings">
+      {missingOrigins.length > 0 ? (
+        <div className="bridge-destination-notice" role="status">
+          <div>
+            <strong>Browser permission needed</strong>
+            <span>
+              {missingOrigins.length === 1
+                ? "One saved bridge URL is not yet available to this page."
+                : `${missingOrigins.length} saved bridge URLs are not yet available to this page.`}
+            </span>
+          </div>
+          <button
+            type="button"
+            className="btn btn-primary"
+            disabled={busy || status?.mutation_allowed !== true}
+            onClick={() => void allowSaved()}
+          >
+            {busy ? "Applying…" : "Allow saved bridges & reload"}
+          </button>
+        </div>
+      ) : null}
+
+      <details className="remote-access-advanced">
+        <summary>Advanced browser permissions</summary>
+        <div className="remote-access-advanced-content">
+          <p className="settings-help">
+            Bridge destinations are the exact URLs this page may contact. Saving a new bridge adds
+            its URL automatically; changes require a page reload because browsers keep the policy
+            attached to the loaded document.
+          </p>
+          <AccessOriginList
+            label="Bridge destinations for this page"
+            values={destinations}
+            suggestions={savedOrigins}
+            onChange={setDestinations}
+          />
+          <div className="remote-access-advanced-actions">
+            <button
+              type="button"
+              className="btn"
+              disabled={busy || status?.mutation_allowed !== true}
+              onClick={() => void applyAndReload(destinations)}
+            >
+              {busy ? "Applying…" : "Apply & reload"}
+            </button>
+            <button type="button" className="btn" disabled={busy} onClick={reloadPage}>
+              Reload page
+            </button>
+          </div>
+        </div>
+      </details>
+
+      {message ? <div className="modal-message">{message}</div> : null}
+      {status && !status.mutation_allowed ? (
+        <p className="backend-warning">
+          {status.mutation_reason ?? "This launch cannot update browser permissions."}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/web/src/BridgeDestinationSettings.tsx
+++ b/web/src/BridgeDestinationSettings.tsx
@@ -63,6 +63,7 @@ export function BridgeDestinationSettings({
       }
       await waitForRemoteAccessReady(
         httpUrl,
+        apply.id,
         (next) => remoteAccessMatchesDraft(
           next,
           draft,

--- a/web/src/BridgeDestinationSettings.tsx
+++ b/web/src/BridgeDestinationSettings.tsx
@@ -40,7 +40,7 @@ export function BridgeDestinationSettings({
       setDestinations(next.remote_access.allowed_bridge_origins);
     }).catch((error: unknown) => {
       if (!cancelled) {
-        setMessage(error instanceof Error ? error.message : "Browser permissions unavailable");
+        setMessage(error instanceof Error ? error.message : "Network permissions unavailable");
       }
     });
     return () => { cancelled = true; };
@@ -53,13 +53,13 @@ export function BridgeDestinationSettings({
   const applyAndReload = async (nextDestinations: string[]) => {
     if (!status) return;
     setBusy(true);
-    setMessage("Saving browser permissions and restarting this bridge…");
+    setMessage("Applying network permissions…");
     try {
       const draft = remoteAccessDraft(status);
       draft.allowed_bridge_origins = nextDestinations;
       const apply = await applyRemoteAccess(httpUrl, draft, "keep");
       if (apply.state === "failed") {
-        throw new Error(apply.reason ?? "The bridge could not apply the browser permissions");
+        throw new Error(apply.reason ?? "This Herdr could not apply the network permissions");
       }
       await waitForRemoteAccessReady(
         httpUrl,
@@ -69,32 +69,32 @@ export function BridgeDestinationSettings({
           status.remote_access.password_configured,
         ),
       );
-      setMessage("Browser permissions applied. Reloading Herdr World…");
+      setMessage("Network permissions applied. Reloading Herdr World…");
       setBusy(false);
       reloadPage();
     } catch (error) {
-      setMessage(error instanceof Error ? error.message : "Could not apply browser permissions");
+      setMessage(error instanceof Error ? error.message : "Could not apply network permissions");
       setBusy(false);
     }
   };
 
   const allowSaved = async () => {
     setBusy(true);
-    setMessage("Allowing saved bridge URLs and restarting this bridge…");
+    setMessage("Allowing saved connections…");
     try {
       const result = await allowBridgeDestinations(httpUrl, savedOrigins);
       setStatus(result.status);
       setDestinations(result.status.remote_access.allowed_bridge_origins);
       if (result.changed) {
-        setMessage("Saved bridges allowed. Reloading Herdr World…");
+        setMessage("Saved connections allowed. Reloading Herdr World…");
         setBusy(false);
         reloadPage();
       } else {
-        setMessage("All saved bridge URLs are already allowed.");
+        setMessage("All saved connections are already allowed.");
         setBusy(false);
       }
     } catch (error) {
-      setMessage(error instanceof Error ? error.message : "Could not allow saved bridge URLs");
+      setMessage(error instanceof Error ? error.message : "Could not allow saved connections");
       setBusy(false);
     }
   };
@@ -106,11 +106,11 @@ export function BridgeDestinationSettings({
       {missingOrigins.length > 0 ? (
         <div className="bridge-destination-notice" role="status">
           <div>
-            <strong>Browser permission needed</strong>
+            <strong>Connection permission needed</strong>
             <span>
               {missingOrigins.length === 1
-                ? "One saved bridge URL is not yet available to this page."
-                : `${missingOrigins.length} saved bridge URLs are not yet available to this page.`}
+                ? "One saved Herdr address is not yet available to this page."
+                : `${missingOrigins.length} saved Herdr addresses are not yet available to this page.`}
             </span>
           </div>
           <button
@@ -119,21 +119,21 @@ export function BridgeDestinationSettings({
             disabled={busy || status?.mutation_allowed !== true}
             onClick={() => void allowSaved()}
           >
-            {busy ? "Applying…" : "Allow saved bridges & reload"}
+            {busy ? "Applying…" : "Allow saved connections & reload"}
           </button>
         </div>
       ) : null}
 
       <details className="remote-access-advanced">
-        <summary>Advanced browser permissions</summary>
+        <summary>Advanced network permissions</summary>
         <div className="remote-access-advanced-content">
           <p className="settings-help">
-            Bridge destinations are the exact URLs this page may contact. Saving a new bridge adds
-            its URL automatically; changes require a page reload because browsers keep the policy
-            attached to the loaded document.
+            These are the exact Herdr addresses this page may contact. Adding a connection allows
+            its address automatically; changes require a reload because the browser keeps this
+            security policy with the loaded page.
           </p>
           <AccessOriginList
-            label="Bridge destinations for this page"
+            label="Herdrs this page may connect to"
             values={destinations}
             suggestions={savedOrigins}
             onChange={setDestinations}
@@ -157,7 +157,7 @@ export function BridgeDestinationSettings({
       {message ? <div className="modal-message">{message}</div> : null}
       {status && !status.mutation_allowed ? (
         <p className="backend-warning">
-          {status.mutation_reason ?? "This launch cannot update browser permissions."}
+          {status.mutation_reason ?? "This launch cannot update network permissions."}
         </p>
       ) : null}
     </div>

--- a/web/src/BridgePasswordPrompt.test.tsx
+++ b/web/src/BridgePasswordPrompt.test.tsx
@@ -1,0 +1,51 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { BridgePasswordPrompt } from "./bridge";
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("BridgePasswordPrompt", () => {
+  it("clears and refocuses the password when the queued Herdr changes", async () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    const onSubmit = vi.fn();
+    const onCancel = vi.fn();
+
+    await act(async () => root.render(
+      <BridgePasswordPrompt
+        origin="http://first.example:8787"
+        onCancel={onCancel}
+        onSubmit={onSubmit}
+      />,
+    ));
+    const firstInput = container.querySelector<HTMLInputElement>('input[type="password"]');
+    expect(firstInput).toBe(document.activeElement);
+    await act(async () => {
+      const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")?.set;
+      setter?.call(firstInput, "first-password");
+      firstInput?.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+    expect(container.querySelector<HTMLButtonElement>('button[type="submit"]')?.disabled).toBe(false);
+
+    await act(async () => root.render(
+      <BridgePasswordPrompt
+        origin="http://second.example:8787"
+        onCancel={onCancel}
+        onSubmit={onSubmit}
+      />,
+    ));
+    const secondInput = container.querySelector<HTMLInputElement>('input[type="password"]');
+    expect(secondInput?.value).toBe("");
+    expect(secondInput).toBe(document.activeElement);
+    expect(container.querySelector<HTMLButtonElement>('button[type="submit"]')?.disabled).toBe(true);
+
+    await act(async () => root.unmount());
+  });
+});

--- a/web/src/BridgePasswordPrompt.test.tsx
+++ b/web/src/BridgePasswordPrompt.test.tsx
@@ -20,11 +20,14 @@ describe("BridgePasswordPrompt", () => {
 
     await act(async () => root.render(
       <BridgePasswordPrompt
+        name="First Herdr"
         origin="http://first.example:8787"
         onCancel={onCancel}
         onSubmit={onSubmit}
       />,
     ));
+    expect(container.textContent).toContain("First Herdr");
+    expect(container.textContent).toContain("first.example:8787");
     const firstInput = container.querySelector<HTMLInputElement>('input[type="password"]');
     expect(firstInput).toBe(document.activeElement);
     await act(async () => {
@@ -36,12 +39,15 @@ describe("BridgePasswordPrompt", () => {
 
     await act(async () => root.render(
       <BridgePasswordPrompt
+        name="Second Herdr"
         origin="http://second.example:8787"
         onCancel={onCancel}
         onSubmit={onSubmit}
       />,
     ));
     const secondInput = container.querySelector<HTMLInputElement>('input[type="password"]');
+    expect(container.textContent).toContain("Second Herdr");
+    expect(container.textContent).toContain("second.example:8787");
     expect(secondInput?.value).toBe("");
     expect(secondInput).toBe(document.activeElement);
     expect(container.querySelector<HTMLButtonElement>('button[type="submit"]')?.disabled).toBe(true);

--- a/web/src/BridgePasswordPrompt.test.tsx
+++ b/web/src/BridgePasswordPrompt.test.tsx
@@ -54,4 +54,40 @@ describe("BridgePasswordPrompt", () => {
 
     await act(async () => root.unmount());
   });
+
+  it("contains keyboard focus, cancels with Escape, and restores the previous focus", async () => {
+    const opener = document.createElement("button");
+    const container = document.createElement("div");
+    document.body.append(opener, container);
+    opener.focus();
+    const root = createRoot(container);
+    const onCancel = vi.fn();
+
+    await act(async () => root.render(
+      <BridgePasswordPrompt
+        name="Remote Herdr"
+        origin="http://remote.example:8787"
+        onCancel={onCancel}
+        onSubmit={vi.fn()}
+      />,
+    ));
+
+    const form = container.querySelector<HTMLFormElement>("form");
+    const input = container.querySelector<HTMLInputElement>('input[type="password"]');
+    const cancel = Array.from(container.querySelectorAll<HTMLButtonElement>("button"))
+      .find((button) => button.textContent === "Cancel");
+    cancel?.focus();
+    await act(async () => {
+      cancel?.dispatchEvent(new KeyboardEvent("keydown", { key: "Tab", bubbles: true }));
+    });
+    expect(document.activeElement).toBe(input);
+
+    await act(async () => {
+      form?.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+    });
+    expect(onCancel).toHaveBeenCalledOnce();
+
+    await act(async () => root.unmount());
+    expect(document.activeElement).toBe(opener);
+  });
 });

--- a/web/src/RemoteAccessSettings.test.tsx
+++ b/web/src/RemoteAccessSettings.test.tsx
@@ -1,0 +1,150 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { RemoteAccessSettings } from "./RemoteAccessSettings";
+
+const roots: Root[] = [];
+
+afterEach(async () => {
+  await act(async () => {
+    for (const root of roots.splice(0)) root.unmount();
+  });
+  document.body.innerHTML = "";
+  vi.restoreAllMocks();
+});
+
+describe("RemoteAccessSettings", () => {
+  it("supports unchecked suggestions, a draft, and password apply actions", async () => {
+    const requests: { url: string; init?: RequestInit }[] = [];
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+      requests.push({ url: String(input), init });
+      if (init?.method === "POST") {
+        return new Response(JSON.stringify({ state: "applying", reason: "restarting", restored: null }), { status: 202 });
+      }
+      return new Response(JSON.stringify({
+        remote_access: {
+          enabled: false,
+          accepted_hosts: [],
+          allowed_page_origins: ["http://world.example.test"],
+          allowed_bridge_origins: [],
+          password_configured: false,
+        },
+        port: 4000,
+        suggestions: ["bridge.example.test"],
+        mutation_allowed: true,
+        apply: { state: "ready", reason: null, restored: null },
+      }), { status: 200 });
+    });
+
+    const { container } = await render(
+      <RemoteAccessSettings
+        httpUrl={(path) => path}
+        backends={[{ id: "bridge", name: "Bridge", baseUrl: "http://bridge.example.test:4000" }]}
+      />,
+    );
+    await act(async () => Promise.resolve());
+    expect(container.textContent).toContain("Direct network access");
+    const suggestion = container.querySelector<HTMLInputElement>('input[type="checkbox"]');
+    expect(suggestion?.checked).toBe(false);
+    await act(async () => suggestion?.click());
+    const password = container.querySelector<HTMLInputElement>('input[type="password"]');
+    expect(password).not.toBeNull();
+    await act(async () => {
+      if (password) {
+        const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")?.set;
+        setter?.call(password, "synthetic-password");
+        password.dispatchEvent(new Event("input", { bubbles: true }));
+        password.dispatchEvent(new Event("change", { bubbles: true }));
+      }
+    });
+    const apply = Array.from(container.querySelectorAll("button")).find((button) => button.textContent?.includes("Apply"));
+    await act(async () => apply?.click());
+    const request = requests.find(({ init }) => init?.method === "POST");
+    expect(request).toBeDefined();
+    expect(JSON.parse(String(request?.init?.body))).toMatchObject({
+      password_action: "set",
+      password: "synthetic-password",
+    });
+  });
+
+  it("supports changing a password without persisting it in the draft", async () => {
+    const requests: RequestInit[] = [];
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (_input, init) => {
+      if (init?.method === "POST") {
+        requests.push(init);
+        return new Response(JSON.stringify({ state: "applying", reason: "restarting", restored: null }), { status: 202 });
+      }
+      return new Response(JSON.stringify(remoteAccessStatus(true)), { status: 200 });
+    });
+
+    const { container } = await render(
+      <RemoteAccessSettings httpUrl={(path) => path} backends={[]} />,
+    );
+    await act(async () => Promise.resolve());
+    const password = container.querySelector<HTMLInputElement>('input[aria-label="Change bridge password"]');
+    expect(password).not.toBeNull();
+    await act(async () => {
+      if (password) {
+        const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")?.set;
+        setter?.call(password, "replacement-password");
+        password.dispatchEvent(new Event("input", { bubbles: true }));
+        password.dispatchEvent(new Event("change", { bubbles: true }));
+      }
+    });
+    await act(async () => container.querySelector<HTMLButtonElement>('button[type="button"].btn-primary')?.click());
+    expect(JSON.parse(String(requests[0]?.body))).toMatchObject({
+      password_action: "set",
+      password: "replacement-password",
+    });
+  });
+
+  it("supports removing password protection", async () => {
+    const requests: RequestInit[] = [];
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (_input, init) => {
+      if (init?.method === "POST") {
+        requests.push(init);
+        return new Response(JSON.stringify({ state: "applying", reason: "restarting", restored: null }), { status: 202 });
+      }
+      return new Response(JSON.stringify(remoteAccessStatus(true)), { status: 200 });
+    });
+
+    const { container } = await render(
+      <RemoteAccessSettings httpUrl={(path) => path} backends={[]} />,
+    );
+    await act(async () => Promise.resolve());
+    await act(async () => container.querySelector<HTMLButtonElement>('button.btn-danger')?.click());
+    await act(async () => container.querySelector<HTMLButtonElement>('button[type="button"].btn-primary')?.click());
+    expect(JSON.parse(String(requests[0]?.body))).toMatchObject({
+      password_action: "remove",
+    });
+    expect(JSON.parse(String(requests[0]?.body))).not.toHaveProperty("password");
+  });
+});
+
+function remoteAccessStatus(passwordConfigured: boolean) {
+  return {
+    remote_access: {
+      enabled: false,
+      accepted_hosts: [],
+      allowed_page_origins: ["http://world.example.test"],
+      allowed_bridge_origins: [],
+      password_configured: passwordConfigured,
+    },
+    port: 4000,
+    suggestions: [],
+    mutation_allowed: true,
+    apply: { state: "ready", reason: null, restored: null },
+  };
+}
+
+async function render(element: React.ReactElement) {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  roots.push(root);
+  await act(async () => root.render(element));
+  return { container };
+}

--- a/web/src/RemoteAccessSettings.test.tsx
+++ b/web/src/RemoteAccessSettings.test.tsx
@@ -17,40 +17,42 @@ afterEach(async () => {
 });
 
 describe("RemoteAccessSettings", () => {
-  it("supports unchecked suggestions, a draft, and password apply actions", async () => {
+  it("turns detected host and standard client origins into a simple sharing draft", async () => {
     const requests: { url: string; init?: RequestInit }[] = [];
+    const reloadPage = vi.fn();
+    let currentStatus = remoteAccessStatus(false, ["bridge.example.test"]);
     vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
       requests.push({ url: String(input), init });
       if (init?.method === "POST") {
+        const body = JSON.parse(String(init.body));
+        currentStatus = {
+          ...currentStatus,
+          remote_access: {
+            ...body.remote_access,
+            password_configured: body.password_action === "set",
+          },
+        };
         return new Response(JSON.stringify({ state: "applying", reason: "restarting", restored: null }), { status: 202 });
       }
-      return new Response(JSON.stringify({
-        remote_access: {
-          enabled: false,
-          accepted_hosts: [],
-          allowed_page_origins: ["http://world.example.test"],
-          allowed_bridge_origins: [],
-          password_configured: false,
-        },
-        port: 4000,
-        suggestions: ["bridge.example.test"],
-        mutation_allowed: true,
-        apply: { state: "ready", reason: null, restored: null },
-      }), { status: 200 });
+      return new Response(JSON.stringify(currentStatus), { status: 200 });
     });
 
     const { container } = await render(
       <RemoteAccessSettings
         httpUrl={(path) => path}
-        backends={[{ id: "bridge", name: "Bridge", baseUrl: "http://bridge.example.test:4000" }]}
+        reloadPage={reloadPage}
       />,
     );
     await act(async () => Promise.resolve());
-    expect(container.textContent).toContain("Direct network access");
+    expect(container.textContent).toContain("Share this bridge");
+    expect(container.textContent).toContain("They are not addresses of allowed client devices");
     const suggestion = container.querySelector<HTMLInputElement>('input[type="checkbox"]');
     expect(suggestion?.checked).toBe(false);
-    await act(async () => suggestion?.click());
-    const password = container.querySelector<HTMLInputElement>('input[type="password"]');
+    const share = container.querySelector<HTMLButtonElement>('[role="switch"]');
+    await act(async () => share?.click());
+    const password = container.querySelector<HTMLInputElement>(
+      'input[aria-label="Set this bridge password"]',
+    );
     expect(password).not.toBeNull();
     await act(async () => {
       if (password) {
@@ -61,13 +63,22 @@ describe("RemoteAccessSettings", () => {
       }
     });
     const apply = Array.from(container.querySelectorAll("button")).find((button) => button.textContent?.includes("Apply"));
-    await act(async () => apply?.click());
+    await act(async () => {
+      apply?.click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
     const request = requests.find(({ init }) => init?.method === "POST");
     expect(request).toBeDefined();
     expect(JSON.parse(String(request?.init?.body))).toMatchObject({
       password_action: "set",
       password: "synthetic-password",
+      remote_access: {
+        enabled: true,
+        accepted_hosts: ["bridge.example.test"],
+      },
     });
+    expect(reloadPage).toHaveBeenCalledOnce();
   });
 
   it("supports changing a password without persisting it in the draft", async () => {
@@ -81,10 +92,10 @@ describe("RemoteAccessSettings", () => {
     });
 
     const { container } = await render(
-      <RemoteAccessSettings httpUrl={(path) => path} backends={[]} />,
+      <RemoteAccessSettings httpUrl={(path) => path} reloadPage={() => {}} />,
     );
     await act(async () => Promise.resolve());
-    const password = container.querySelector<HTMLInputElement>('input[aria-label="Change bridge password"]');
+    const password = container.querySelector<HTMLInputElement>('input[aria-label="Change this bridge password"]');
     expect(password).not.toBeNull();
     await act(async () => {
       if (password) {
@@ -94,7 +105,11 @@ describe("RemoteAccessSettings", () => {
         password.dispatchEvent(new Event("change", { bubbles: true }));
       }
     });
-    await act(async () => container.querySelector<HTMLButtonElement>('button[type="button"].btn-primary')?.click());
+    await act(async () => {
+      container.querySelector<HTMLButtonElement>('button[type="button"].btn-primary')?.click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
     expect(JSON.parse(String(requests[0]?.body))).toMatchObject({
       password_action: "set",
       password: "replacement-password",
@@ -103,20 +118,26 @@ describe("RemoteAccessSettings", () => {
 
   it("supports removing password protection", async () => {
     const requests: RequestInit[] = [];
+    let passwordConfigured = true;
     vi.spyOn(globalThis, "fetch").mockImplementation(async (_input, init) => {
       if (init?.method === "POST") {
         requests.push(init);
+        passwordConfigured = false;
         return new Response(JSON.stringify({ state: "applying", reason: "restarting", restored: null }), { status: 202 });
       }
-      return new Response(JSON.stringify(remoteAccessStatus(true)), { status: 200 });
+      return new Response(JSON.stringify(remoteAccessStatus(passwordConfigured)), { status: 200 });
     });
 
     const { container } = await render(
-      <RemoteAccessSettings httpUrl={(path) => path} backends={[]} />,
+      <RemoteAccessSettings httpUrl={(path) => path} reloadPage={() => {}} />,
     );
     await act(async () => Promise.resolve());
     await act(async () => container.querySelector<HTMLButtonElement>('button.btn-danger')?.click());
-    await act(async () => container.querySelector<HTMLButtonElement>('button[type="button"].btn-primary')?.click());
+    await act(async () => {
+      container.querySelector<HTMLButtonElement>('button[type="button"].btn-primary')?.click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
     expect(JSON.parse(String(requests[0]?.body))).toMatchObject({
       password_action: "remove",
     });
@@ -124,7 +145,7 @@ describe("RemoteAccessSettings", () => {
   });
 });
 
-function remoteAccessStatus(passwordConfigured: boolean) {
+function remoteAccessStatus(passwordConfigured: boolean, suggestions: string[] = []) {
   return {
     remote_access: {
       enabled: false,
@@ -134,7 +155,7 @@ function remoteAccessStatus(passwordConfigured: boolean) {
       password_configured: passwordConfigured,
     },
     port: 4000,
-    suggestions: [],
+    suggestions,
     mutation_allowed: true,
     apply: { state: "ready", reason: null, restored: null },
   };

--- a/web/src/RemoteAccessSettings.test.tsx
+++ b/web/src/RemoteAccessSettings.test.tsx
@@ -5,6 +5,7 @@ import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { RemoteAccessSettings } from "./RemoteAccessSettings";
+import type { RemoteAccessStatus } from "./remoteAccess";
 
 const roots: Root[] = [];
 
@@ -31,8 +32,9 @@ describe("RemoteAccessSettings", () => {
             ...body.remote_access,
             password_configured: body.password_action === "set",
           },
+          apply: { id: "apply-1", state: "ready", reason: null, restored: false },
         };
-        return new Response(JSON.stringify({ state: "applying", reason: "restarting", restored: null }), { status: 202 });
+        return new Response(JSON.stringify({ id: "apply-1", state: "applying", reason: "restarting", restored: null }), { status: 202 });
       }
       return new Response(JSON.stringify(currentStatus), { status: 200 });
     });
@@ -83,12 +85,14 @@ describe("RemoteAccessSettings", () => {
 
   it("supports changing a password without persisting it in the draft", async () => {
     const requests: RequestInit[] = [];
+    let applyId: string | null = null;
     vi.spyOn(globalThis, "fetch").mockImplementation(async (_input, init) => {
       if (init?.method === "POST") {
         requests.push(init);
-        return new Response(JSON.stringify({ state: "applying", reason: "restarting", restored: null }), { status: 202 });
+        applyId = "apply-2";
+        return new Response(JSON.stringify({ id: applyId, state: "applying", reason: "restarting", restored: null }), { status: 202 });
       }
-      return new Response(JSON.stringify(remoteAccessStatus(true)), { status: 200 });
+      return new Response(JSON.stringify(remoteAccessStatus(true, [], true, applyId)), { status: 200 });
     });
 
     const { container } = await render(
@@ -119,13 +123,15 @@ describe("RemoteAccessSettings", () => {
   it("supports removing password protection", async () => {
     const requests: RequestInit[] = [];
     let passwordConfigured = true;
+    let applyId: string | null = null;
     vi.spyOn(globalThis, "fetch").mockImplementation(async (_input, init) => {
       if (init?.method === "POST") {
         requests.push(init);
         passwordConfigured = false;
-        return new Response(JSON.stringify({ state: "applying", reason: "restarting", restored: null }), { status: 202 });
+        applyId = "apply-3";
+        return new Response(JSON.stringify({ id: applyId, state: "applying", reason: "restarting", restored: null }), { status: 202 });
       }
-      return new Response(JSON.stringify(remoteAccessStatus(passwordConfigured)), { status: 200 });
+      return new Response(JSON.stringify(remoteAccessStatus(passwordConfigured, [], passwordConfigured, applyId)), { status: 200 });
     });
 
     const { container } = await render(
@@ -148,10 +154,13 @@ describe("RemoteAccessSettings", () => {
     const requests: RequestInit[] = [];
     const status = remoteAccessStatus(false, ["bridge.example.test"], true);
     status.remote_access.allowed_page_origins = [];
+    let applyId: string | null = null;
     vi.spyOn(globalThis, "fetch").mockImplementation(async (_input, init) => {
       if (init?.method === "POST") {
         requests.push(init);
-        return new Response(JSON.stringify({ state: "applying", reason: "restarting", restored: null }), { status: 202 });
+        applyId = "apply-4";
+        status.apply.id = applyId;
+        return new Response(JSON.stringify({ id: applyId, state: "applying", reason: "restarting", restored: null }), { status: 202 });
       }
       return new Response(JSON.stringify(status), { status: 200 });
     });
@@ -177,7 +186,8 @@ function remoteAccessStatus(
   passwordConfigured: boolean,
   suggestions: string[] = [],
   enabled = passwordConfigured,
-) {
+  applyId: string | null = null,
+): RemoteAccessStatus {
   return {
     remote_access: {
       enabled,
@@ -189,7 +199,7 @@ function remoteAccessStatus(
     port: 4000,
     suggestions,
     mutation_allowed: true,
-    apply: { state: "ready", reason: null, restored: null },
+    apply: { id: applyId, state: "ready", reason: null, restored: null },
   };
 }
 

--- a/web/src/RemoteAccessSettings.test.tsx
+++ b/web/src/RemoteAccessSettings.test.tsx
@@ -17,7 +17,7 @@ afterEach(async () => {
 });
 
 describe("RemoteAccessSettings", () => {
-  it("turns detected host and standard client origins into a simple sharing draft", async () => {
+  it("turns a detected address into a simple allow-connections draft", async () => {
     const requests: { url: string; init?: RequestInit }[] = [];
     const reloadPage = vi.fn();
     let currentStatus = remoteAccessStatus(false, ["bridge.example.test"]);
@@ -44,14 +44,14 @@ describe("RemoteAccessSettings", () => {
       />,
     );
     await act(async () => Promise.resolve());
-    expect(container.textContent).toContain("Share this bridge");
-    expect(container.textContent).toContain("They are not addresses of allowed client devices");
+    expect(container.textContent).toContain("Allow connections");
+    expect(container.textContent).toContain("They are not a list of connecting devices");
     const suggestion = container.querySelector<HTMLInputElement>('input[type="checkbox"]');
     expect(suggestion?.checked).toBe(false);
     const share = container.querySelector<HTMLButtonElement>('[role="switch"]');
     await act(async () => share?.click());
     const password = container.querySelector<HTMLInputElement>(
-      'input[aria-label="Set this bridge password"]',
+      'input[aria-label="Set connection password"]',
     );
     expect(password).not.toBeNull();
     await act(async () => {
@@ -95,7 +95,7 @@ describe("RemoteAccessSettings", () => {
       <RemoteAccessSettings httpUrl={(path) => path} reloadPage={() => {}} />,
     );
     await act(async () => Promise.resolve());
-    const password = container.querySelector<HTMLInputElement>('input[aria-label="Change this bridge password"]');
+    const password = container.querySelector<HTMLInputElement>('input[aria-label="Change connection password"]');
     expect(password).not.toBeNull();
     await act(async () => {
       if (password) {
@@ -143,13 +143,45 @@ describe("RemoteAccessSettings", () => {
     });
     expect(JSON.parse(String(requests[0]?.body))).not.toHaveProperty("password");
   });
+
+  it("allows the directly served page without requiring extra page origins", async () => {
+    const requests: RequestInit[] = [];
+    const status = remoteAccessStatus(false, ["bridge.example.test"], true);
+    status.remote_access.allowed_page_origins = [];
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (_input, init) => {
+      if (init?.method === "POST") {
+        requests.push(init);
+        return new Response(JSON.stringify({ state: "applying", reason: "restarting", restored: null }), { status: 202 });
+      }
+      return new Response(JSON.stringify(status), { status: 200 });
+    });
+
+    const { container } = await render(
+      <RemoteAccessSettings httpUrl={(path) => path} reloadPage={() => {}} />,
+    );
+    await act(async () => Promise.resolve());
+    const apply = container.querySelector<HTMLButtonElement>('button[type="button"].btn-primary');
+    expect(apply?.disabled).toBe(false);
+    await act(async () => {
+      apply?.click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(JSON.parse(String(requests[0]?.body))).toMatchObject({
+      remote_access: { enabled: true, allowed_page_origins: [] },
+    });
+  });
 });
 
-function remoteAccessStatus(passwordConfigured: boolean, suggestions: string[] = []) {
+function remoteAccessStatus(
+  passwordConfigured: boolean,
+  suggestions: string[] = [],
+  enabled = passwordConfigured,
+) {
   return {
     remote_access: {
-      enabled: false,
-      accepted_hosts: [],
+      enabled,
+      accepted_hosts: enabled ? ["bridge.example.test"] : [],
       allowed_page_origins: ["http://world.example.test"],
       allowed_bridge_origins: [],
       password_configured: passwordConfigured,

--- a/web/src/RemoteAccessSettings.test.tsx
+++ b/web/src/RemoteAccessSettings.test.tsx
@@ -56,6 +56,7 @@ describe("RemoteAccessSettings", () => {
       'input[aria-label="Set connection password"]',
     );
     expect(password).not.toBeNull();
+    expect(container.textContent).toContain("Off");
     await act(async () => {
       if (password) {
         const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")?.set;
@@ -64,7 +65,10 @@ describe("RemoteAccessSettings", () => {
         password.dispatchEvent(new Event("change", { bubbles: true }));
       }
     });
-    const apply = Array.from(container.querySelectorAll("button")).find((button) => button.textContent?.includes("Apply"));
+    expect(container.textContent).toContain("Set pending");
+    const apply = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.textContent === "Set password & apply",
+    );
     await act(async () => {
       apply?.click();
       await Promise.resolve();
@@ -99,6 +103,12 @@ describe("RemoteAccessSettings", () => {
       <RemoteAccessSettings httpUrl={(path) => path} reloadPage={() => {}} />,
     );
     await act(async () => Promise.resolve());
+    const change = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.textContent === "Change password",
+    );
+    await act(async () => change?.click());
+    expect(container.textContent).toContain("Change pending");
+    expect(container.textContent).toContain("current password remains active");
     const password = container.querySelector<HTMLInputElement>('input[aria-label="Change connection password"]');
     expect(password).not.toBeNull();
     await act(async () => {
@@ -138,9 +148,19 @@ describe("RemoteAccessSettings", () => {
       <RemoteAccessSettings httpUrl={(path) => path} reloadPage={() => {}} />,
     );
     await act(async () => Promise.resolve());
-    await act(async () => container.querySelector<HTMLButtonElement>('button.btn-danger')?.click());
+    const remove = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.textContent === "Remove password",
+    );
+    await act(async () => remove?.click());
+    expect(container.textContent).toContain("Password will be removed");
+    expect(Array.from(container.querySelectorAll("button")).some(
+      (button) => button.textContent === "Remove password",
+    )).toBe(false);
+    const apply = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.textContent === "Remove password & apply",
+    );
     await act(async () => {
-      container.querySelector<HTMLButtonElement>('button[type="button"].btn-primary')?.click();
+      apply?.click();
       await Promise.resolve();
       await Promise.resolve();
     });
@@ -148,6 +168,27 @@ describe("RemoteAccessSettings", () => {
       password_action: "remove",
     });
     expect(JSON.parse(String(requests[0]?.body))).not.toHaveProperty("password");
+  });
+
+  it("can cancel a staged password removal without applying it", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify(remoteAccessStatus(true)), { status: 200 }),
+    );
+    const { container } = await render(
+      <RemoteAccessSettings httpUrl={(path) => path} reloadPage={() => {}} />,
+    );
+    await act(async () => Promise.resolve());
+    const button = (label: string) => Array.from(container.querySelectorAll("button")).find(
+      (candidate) => candidate.textContent === label,
+    );
+
+    await act(async () => button("Remove password")?.click());
+    expect(button("Keep password")).toBeDefined();
+    await act(async () => button("Keep password")?.click());
+
+    expect(button("Remove password")).toBeDefined();
+    expect(container.textContent).toContain("A password is currently set");
+    expect(container.textContent).not.toContain("Password will be removed");
   });
 
   it("allows the directly served page without requiring extra page origins", async () => {

--- a/web/src/RemoteAccessSettings.tsx
+++ b/web/src/RemoteAccessSettings.tsx
@@ -1,5 +1,5 @@
 import { Copy, Plus, Trash2 } from "lucide-react";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import type { BridgeBackendProfile } from "./bridge";
 import type { BridgeHttpUrl } from "./bridgeApi";
 import {
@@ -27,13 +27,19 @@ export function RemoteAccessSettings({ httpUrl, backends }: Props) {
   const [passwordAction, setPasswordAction] = useState<RemotePasswordAction>("keep");
   const [busy, setBusy] = useState(false);
   const [message, setMessage] = useState<string | null>(null);
+  const applyObserved = useRef(false);
 
   const reload = async () => {
     try {
       const next = await fetchRemoteAccess(httpUrl);
       setStatus(next);
       setDraft((current) => current ?? draftFromStatus(next));
-      if (next.apply.state !== "applying") setBusy(false);
+      if (next.apply.state === "applying") {
+        applyObserved.current = true;
+      } else if (applyObserved.current) {
+        applyObserved.current = false;
+        setBusy(false);
+      }
     } catch (error) {
       setMessage(error instanceof Error ? error.message : "Remote access status unavailable");
     }
@@ -88,14 +94,19 @@ export function RemoteAccessSettings({ httpUrl, backends }: Props) {
     return true;
   };
   const save = async () => {
+    applyObserved.current = false;
     setBusy(true);
     setMessage("Settings saved; the bridge is restarting and will reconnect when ready.");
     try {
       const result = await applyRemoteAccess(httpUrl, draft, passwordAction, password || undefined);
+      applyObserved.current = result.state === "applying";
+      setStatus((current) => current ? { ...current, apply: result } : current);
+      if (result.state !== "applying") setBusy(false);
       setPassword("");
       setPasswordAction("keep");
       setMessage(result.reason ?? "Settings saved; waiting for the bridge to become ready.");
     } catch (error) {
+      applyObserved.current = false;
       setBusy(false);
       setMessage(error instanceof Error ? error.message : "Could not apply remote access settings");
     }
@@ -192,6 +203,7 @@ export function RemoteAccessSettings({ httpUrl, backends }: Props) {
       <div className="remote-access-subsection">
         <strong>Password</strong>
         <span className="backend-note">{status.remote_access.password_configured ? "Protected" : "Not set"}</span>
+        {draft.enabled ? <p className="backend-warning">Direct access uses unencrypted HTTP and WebSocket connections. A bridge password protects access, but does not protect passwords or session tokens from a network observer. Use TLS or a trusted VPN.</p> : null}
         {draft.enabled && !status.remote_access.password_configured ? <p className="backend-warning">Anyone who can reach an accepted address may connect until you set a password.</p> : null}
         <div className="remote-access-password-row">
           <input

--- a/web/src/RemoteAccessSettings.tsx
+++ b/web/src/RemoteAccessSettings.tsx
@@ -40,7 +40,7 @@ export function RemoteAccessSettings({
       setDraft(remoteAccessDraft(next));
     }).catch((error: unknown) => {
       if (!cancelled) {
-        setMessage(error instanceof Error ? error.message : "Sharing settings unavailable");
+        setMessage(error instanceof Error ? error.message : "Connection settings unavailable");
       }
     });
     return () => { cancelled = true; };
@@ -91,12 +91,12 @@ export function RemoteAccessSettings({
   };
   const save = async () => {
     setBusy(true);
-    setMessage("Saving sharing settings and restarting this bridge…");
+    setMessage("Applying network settings…");
     try {
       const apply = await applyRemoteAccess(httpUrl, draft, passwordAction, password || undefined);
       setStatus((current) => current ? { ...current, apply } : current);
       if (apply.state === "failed") {
-        throw new Error(apply.reason ?? "The bridge could not apply the sharing settings");
+        throw new Error(apply.reason ?? "This Herdr could not apply the network settings");
       }
       const expectedPasswordConfigured = passwordAction === "set"
         ? true
@@ -110,34 +110,31 @@ export function RemoteAccessSettings({
       setStatus(ready);
       setPassword("");
       setPasswordAction("keep");
-      setMessage("Sharing settings applied. Reloading Herdr World…");
+      setMessage("Network settings applied. Reloading Herdr World…");
       setBusy(false);
       reloadPage();
     } catch (error) {
-      setMessage(error instanceof Error ? error.message : "Could not apply sharing settings");
+      setMessage(error instanceof Error ? error.message : "Could not apply network settings");
     } finally {
       setBusy(false);
     }
   };
 
-  const invalidEnabledDraft = draft.enabled && (
-    draft.accepted_hosts.length === 0 || draft.allowed_page_origins.length === 0
-  );
+  const invalidEnabledDraft = draft.enabled && draft.accepted_hosts.length === 0;
 
   return (
     <div className="settings-section remote-access-settings">
-      <div className="settings-label">Share this bridge</div>
+      <div className="settings-label">Allow connections</div>
       <p className="settings-help">
-        Let another device connect directly to the bridge running on this machine over a trusted
-        LAN or VPN. This is separate from adding other machines under Bridges.
+        Allow Herdr World on other devices to connect to this Herdr over a trusted LAN or VPN.
       </p>
       <div className="settings-row remote-access-toggle-row">
-        <span>Allow other devices to connect</span>
+        <span>Allow connections to this Herdr</span>
         <button
           className="backend-toggle"
           type="button"
           role="switch"
-          aria-label="Allow other devices to connect"
+          aria-label="Allow connections to this Herdr"
           aria-checked={draft.enabled}
           data-on={draft.enabled ? "true" : undefined}
           onClick={toggleSharing}
@@ -147,173 +144,198 @@ export function RemoteAccessSettings({
       </div>
       {!draft.enabled ? (
         <p className="backend-note">
-          This machine accepts local connections only. Its saved sharing settings are retained.
+          Only pages opened locally can connect. Saved network settings are retained.
         </p>
       ) : null}
-
-      <div className="remote-access-subsection">
-        <strong>Addresses for this bridge</strong>
-        <p className="settings-help">
-          These are this machine&apos;s hostname or IP address—the value another device puts in its
-          Bridge URL. They are not addresses of allowed client devices.
-        </p>
-        {draft.accepted_hosts.length === 0 ? (
-          <span className="backend-warning">Add an address for this machine before applying.</span>
-        ) : null}
-        {draft.accepted_hosts.map((host) => (
-          <div className="remote-access-chip" key={host}>
-            <span>{host}</span>
-            <button
-              type="button"
-              aria-label={`Remove ${host}`}
-              onClick={() => setDraft({
-                ...draft,
-                accepted_hosts: draft.accepted_hosts.filter((item) => item !== host),
-              })}
-            >
-              <Trash2 size={13} />
-            </button>
-          </div>
-        ))}
-        {status.suggestions.filter((item) => !draft.accepted_hosts.includes(item)).map((suggestion) => (
-          <label className="remote-access-suggestion" key={suggestion}>
-            <input
-              type="checkbox"
-              checked={selectedSuggestions.includes(suggestion)}
-              onChange={(event) => {
-                setSelectedSuggestions((current) => event.target.checked
-                  ? uniqueValues([...current, suggestion])
-                  : current.filter((item) => item !== suggestion));
-                if (event.target.checked) addAddress(suggestion);
-                else setDraft((current) => current ? {
-                  ...current,
-                  accepted_hosts: current.accepted_hosts.filter((item) => item !== suggestion),
-                } : current);
-              }}
-            />
-            <span>{suggestion}</span>
-            <small>Detected on this machine</small>
-          </label>
-        ))}
-        <div className="remote-access-add-row">
-          <input
-            className="field"
-            aria-label="Add this machine address"
-            placeholder="hostname or IP literal"
-            value={addressInput}
-            onChange={(event) => setAddressInput(event.target.value)}
-          />
-          <button
-            type="button"
-            className="btn"
-            onClick={() => { if (addAddress(addressInput)) setAddressInput(""); }}
-          >
-            Add address
-          </button>
-        </div>
-      </div>
 
       {draft.enabled && address ? (
         <div className="remote-access-address">
-          <span>Bridge URL for other devices</span>
+          <span>Address</span>
           <code>{address}</code>
           <button type="button" className="btn" onClick={() => void copyValue(address)}>
-            <Copy size={13} /> Copy
+            <Copy size={13} /> Copy address
           </button>
         </div>
       ) : null}
 
-      <div className="remote-access-subsection">
-        <strong>Password for this bridge</strong>
-        <span className="backend-note">
-          {status.remote_access.password_configured ? "Protected" : "Not set"}
-        </span>
-        <p className="settings-help">
-          Other devices are asked for this password when they connect. Passwords for bridges you
-          add are not stored; authenticated access lasts until the browser tab closes or the
-          session expires.
-        </p>
-        {draft.enabled ? (
-          <p className="backend-warning">
-            Direct access uses unencrypted HTTP and WebSocket connections. Use only a trusted LAN
-            or VPN; a password controls access but does not encrypt the connection.
+      {draft.enabled && !address ? (
+        <div className="remote-access-subsection">
+          <strong>Address</strong>
+          <p className="settings-help">
+            Enter a hostname or IP address that another device can use to reach this Herdr.
           </p>
-        ) : null}
-        {draft.enabled && !status.remote_access.password_configured ? (
-          <p className="backend-warning">
-            Anyone who can reach this bridge can use it until you set a password.
-          </p>
-        ) : null}
-        <div className="remote-access-password-row">
-          <input
-            className="field"
-            type="password"
-            aria-label={status.remote_access.password_configured
-              ? "Change this bridge password"
-              : "Set this bridge password"}
-            placeholder={status.remote_access.password_configured ? "New password" : "Set password"}
-            autoComplete="new-password"
-            value={password}
-            onChange={(event) => {
-              setPassword(event.target.value);
-              setPasswordAction("set");
-            }}
-          />
-          {status.remote_access.password_configured ? (
+          <div className="remote-access-add-row">
+            <input
+              className="field"
+              aria-label="Herdr address"
+              placeholder="hostname or IP address"
+              value={addressInput}
+              onChange={(event) => setAddressInput(event.target.value)}
+            />
             <button
               type="button"
-              className="btn btn-danger"
-              onClick={() => {
-                setPassword("");
-                setPasswordAction("remove");
-                setMessage("Password protection will be removed when you apply settings.");
-              }}
+              className="btn"
+              onClick={() => { if (addAddress(addressInput)) setAddressInput(""); }}
             >
-              Remove
+              Use address
             </button>
+          </div>
+          <span className="backend-warning">Add an address before applying.</span>
+        </div>
+      ) : null}
+
+      {draft.enabled ? (
+        <div className="remote-access-subsection">
+          <strong>Authentication</strong>
+          <span className="backend-note">
+            {status.remote_access.password_configured ? "Password protected" : "No password"}
+          </span>
+          <p className="backend-warning">
+            Direct connections are not encrypted. Use only a trusted LAN or VPN; a password
+            controls access but does not hide network traffic.
+          </p>
+          {!status.remote_access.password_configured ? (
+            <p className="backend-warning">
+              Anyone who can reach this address can connect until you set a password.
+            </p>
+          ) : null}
+          <div className="remote-access-password-row">
+            <input
+              className="field"
+              type="password"
+              aria-label={status.remote_access.password_configured
+                ? "Change connection password"
+                : "Set connection password"}
+              placeholder={status.remote_access.password_configured ? "New password" : "Set password"}
+              autoComplete="new-password"
+              value={password}
+              onChange={(event) => {
+                setPassword(event.target.value);
+                setPasswordAction("set");
+              }}
+            />
+            {status.remote_access.password_configured ? (
+              <button
+                type="button"
+                className="btn btn-danger"
+                onClick={() => {
+                  setPassword("");
+                  setPasswordAction("remove");
+                  setMessage("Password protection will be removed when you apply changes.");
+                }}
+              >
+                Remove
+              </button>
+            ) : null}
+          </div>
+          {status.remote_access.password_configured ? (
+            <span className="backend-note">
+              Enter a new password to change it, or remove password protection.
+            </span>
           ) : null}
         </div>
-        {status.remote_access.password_configured ? (
-          <span className="backend-note">
-            Enter a new password to change it, or Remove to disable protection.
-          </span>
-        ) : null}
-      </div>
+      ) : null}
 
       <details className="remote-access-advanced">
-        <summary>Advanced browser permissions</summary>
+        <summary>Advanced network permissions</summary>
         <div className="remote-access-advanced-content">
           <p className="settings-help">
-            Add another Herdr World page&apos;s exact URL when it needs to call this bridge. Pages
-            loaded directly from this bridge are already allowed.
+            These restrictions control which addresses this Herdr answers to and which web pages
+            may connect. They are not a list of connecting devices.
           </p>
+          <div className="remote-access-permission-list">
+            <span>Addresses this Herdr responds to</span>
+            {draft.accepted_hosts.map((host) => (
+              <div className="remote-access-chip" key={host}>
+                <span>{host}</span>
+                <button
+                  type="button"
+                  aria-label={`Remove ${host}`}
+                  onClick={() => setDraft({
+                    ...draft,
+                    accepted_hosts: draft.accepted_hosts.filter((item) => item !== host),
+                  })}
+                >
+                  <Trash2 size={13} />
+                </button>
+              </div>
+            ))}
+            {status.suggestions.filter((item) => !draft.accepted_hosts.includes(item)).map((suggestion) => (
+              <label className="remote-access-suggestion" key={suggestion}>
+                <input
+                  type="checkbox"
+                  checked={selectedSuggestions.includes(suggestion)}
+                  onChange={(event) => {
+                    setSelectedSuggestions((current) => event.target.checked
+                      ? uniqueValues([...current, suggestion])
+                      : current.filter((item) => item !== suggestion));
+                    if (event.target.checked) addAddress(suggestion);
+                    else setDraft((current) => current ? {
+                      ...current,
+                      accepted_hosts: current.accepted_hosts.filter((item) => item !== suggestion),
+                    } : current);
+                  }}
+                />
+                <span>{suggestion}</span>
+                <small>Detected</small>
+              </label>
+            ))}
+            <div className="remote-access-add-row">
+              <input
+                className="field"
+                aria-label="Add address this Herdr responds to"
+                placeholder="hostname or IP address"
+                value={addressInput}
+                onChange={(event) => setAddressInput(event.target.value)}
+              />
+              <button
+                type="button"
+                className="btn"
+                onClick={() => { if (addAddress(addressInput)) setAddressInput(""); }}
+              >
+                Add address
+              </button>
+            </div>
+          </div>
           <AccessOriginList
-            label="Additional client page origins"
+            label="Web pages allowed to connect"
             values={draft.allowed_page_origins}
             suggestions={clientOriginSuggestions}
             onChange={(values) => setDraft({ ...draft, allowed_page_origins: values })}
           />
+          <p className="settings-help">
+            A page opened from this Herdr is allowed automatically. Add an exact page address only
+            when Herdr World is loaded from somewhere else.
+          </p>
         </div>
       </details>
+
+      {draft.enabled && status.mutation_allowed ? (
+        <p className="backend-note">
+          Applying changes briefly disconnects remote pages. They may need to enter the password
+          again after this Herdr restarts.
+        </p>
+      ) : null}
 
       <div
         className={`remote-access-apply remote-access-apply-${busy ? "applying" : status.apply.state}`}
         role="status"
       >
-        <strong>{busy ? "Applying sharing settings" : applyLabel(status.apply.state)}</strong>
+        <strong>{busy ? "Applying network settings" : applyLabel(status.apply.state)}</strong>
         <span>
-          {status.apply.reason ?? message ?? (status.mutation_allowed
-            ? "Ready to apply."
-            : status.mutation_reason ?? "Settings are read-only in this launch.")}
+          {busy
+            ? "The connection service is restarting."
+            : status.apply.state === "failed"
+              ? status.apply.reason ?? message ?? "The previous settings were kept."
+              : message ?? (status.mutation_allowed
+                ? "Ready to apply changes."
+                : status.mutation_reason ?? "Settings are read-only in this launch.")}
         </span>
       </div>
       {!status.mutation_allowed ? (
         <p className="backend-warning">
           {status.mutation_reason ?? "This launch cannot safely apply settings."}
         </p>
-      ) : null}
-      {message && status.apply.state !== "applying" ? (
-        <div className="modal-message">{message}</div>
       ) : null}
       <div className="modal-actions">
         <button
@@ -322,7 +344,7 @@ export function RemoteAccessSettings({
           disabled={busy || !status.mutation_allowed || invalidEnabledDraft}
           onClick={() => void save()}
         >
-          {busy ? "Applying…" : "Apply"}
+          {busy ? "Applying…" : "Apply changes"}
         </button>
       </div>
     </div>
@@ -335,10 +357,10 @@ function uniqueValues(values: readonly string[]) {
 
 function applyLabel(state: RemoteAccessStatus["apply"]["state"]) {
   return state === "applying"
-    ? "Service restarting"
+    ? "Applying network settings"
     : state === "failed"
-      ? "Apply failed"
-      : "Bridge ready";
+      ? "Could not apply changes"
+      : "Network ready";
 }
 
 async function copyValue(value: string) {

--- a/web/src/RemoteAccessSettings.tsx
+++ b/web/src/RemoteAccessSettings.tsx
@@ -105,6 +105,7 @@ export function RemoteAccessSettings({
           : status.remote_access.password_configured;
       const ready = await waitForRemoteAccessReady(
         httpUrl,
+        apply.id,
         (next) => remoteAccessMatchesDraft(next, draft, expectedPasswordConfigured),
       );
       setStatus(ready);

--- a/web/src/RemoteAccessSettings.tsx
+++ b/web/src/RemoteAccessSettings.tsx
@@ -1,0 +1,285 @@
+import { Copy, Plus, Trash2 } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import type { BridgeBackendProfile } from "./bridge";
+import type { BridgeHttpUrl } from "./bridgeApi";
+import {
+  applyRemoteAccess,
+  bridgeAddress,
+  fetchRemoteAccess,
+  type RemoteAccessDraft,
+  type RemoteAccessStatus,
+  type RemotePasswordAction,
+} from "./remoteAccess";
+
+type Props = {
+  httpUrl: BridgeHttpUrl;
+  backends: readonly BridgeBackendProfile[];
+};
+
+export function RemoteAccessSettings({ httpUrl, backends }: Props) {
+  const [status, setStatus] = useState<RemoteAccessStatus | null>(null);
+  const [draft, setDraft] = useState<RemoteAccessDraft | null>(null);
+  const [addressInput, setAddressInput] = useState("");
+  const [pageOriginInput, setPageOriginInput] = useState("");
+  const [bridgeOriginInput, setBridgeOriginInput] = useState("");
+  const [selectedSuggestions, setSelectedSuggestions] = useState<string[]>([]);
+  const [password, setPassword] = useState("");
+  const [passwordAction, setPasswordAction] = useState<RemotePasswordAction>("keep");
+  const [busy, setBusy] = useState(false);
+  const [message, setMessage] = useState<string | null>(null);
+
+  const reload = async () => {
+    try {
+      const next = await fetchRemoteAccess(httpUrl);
+      setStatus(next);
+      setDraft((current) => current ?? draftFromStatus(next));
+      if (next.apply.state !== "applying") setBusy(false);
+    } catch (error) {
+      setMessage(error instanceof Error ? error.message : "Remote access status unavailable");
+    }
+  };
+
+  useEffect(() => {
+    let cancelled = false;
+    void fetchRemoteAccess(httpUrl).then((next) => {
+      if (cancelled) return;
+      setStatus(next);
+      setDraft(draftFromStatus(next));
+    }).catch((error: unknown) => {
+      if (!cancelled) setMessage(error instanceof Error ? error.message : "Remote access status unavailable");
+    });
+    return () => { cancelled = true; };
+  }, [httpUrl]);
+
+  useEffect(() => {
+    if (!busy) return;
+    const timer = window.setInterval(() => { void reload(); }, 750);
+    return () => window.clearInterval(timer);
+  }, [busy, httpUrl]);
+
+  const pageOriginSuggestions = useMemo(() => {
+    const values = [
+      globalThis.location?.origin,
+      "http://localhost",
+      "http://127.0.0.1:8787",
+    ];
+    return uniqueOrigins(values);
+  }, []);
+  const bridgeOriginSuggestions = useMemo(
+    () => uniqueOrigins(backends.map((backend) => backend.baseUrl)),
+    [backends],
+  );
+
+  if (!status || !draft) {
+    return (
+      <div className="settings-section settings-section-flat">
+        {message ?? "Loading remote access…"}
+      </div>
+    );
+  }
+
+  const address = draft.accepted_hosts[0]
+    ? bridgeAddress(draft.accepted_hosts[0], status.port)
+    : null;
+  const addToList = (field: "accepted_hosts" | "allowed_page_origins" | "allowed_bridge_origins", raw: string) => {
+    const value = raw.trim();
+    if (!value || draft[field].includes(value)) return false;
+    setDraft({ ...draft, [field]: [...draft[field], value] });
+    return true;
+  };
+  const save = async () => {
+    setBusy(true);
+    setMessage("Settings saved; the bridge is restarting and will reconnect when ready.");
+    try {
+      const result = await applyRemoteAccess(httpUrl, draft, passwordAction, password || undefined);
+      setPassword("");
+      setPasswordAction("keep");
+      setMessage(result.reason ?? "Settings saved; waiting for the bridge to become ready.");
+    } catch (error) {
+      setBusy(false);
+      setMessage(error instanceof Error ? error.message : "Could not apply remote access settings");
+    }
+  };
+
+  const applyState = busy ? "applying" : status.apply.state;
+
+  return (
+    <div className="settings-section remote-access-settings">
+      <div className="settings-label">Direct network access</div>
+      <p className="settings-help">
+        LAN/VPN access uses the existing direct HTTP and WebSocket bridge. It is not a firewall or
+        source-address allow-list; use a VPN, SSH, or TLS for untrusted networks.
+      </p>
+      <div className="settings-row remote-access-toggle-row">
+        <span>Allow direct network connections</span>
+        <button
+          className="backend-toggle"
+          type="button"
+          role="switch"
+          aria-label="Allow direct network connections"
+          aria-checked={draft.enabled}
+          data-on={draft.enabled ? "true" : undefined}
+          onClick={() => setDraft({ ...draft, enabled: !draft.enabled })}
+        >
+          <span aria-hidden="true" />
+        </button>
+      </div>
+      {!draft.enabled ? <p className="backend-note">This bridge is available only locally. Saved addresses remain available for later.</p> : null}
+
+      <div className="remote-access-subsection">
+        <strong>Accepted addresses</strong>
+        {draft.accepted_hosts.length === 0 ? <span className="backend-note">None selected</span> : null}
+        {draft.accepted_hosts.map((host) => (
+          <div className="remote-access-chip" key={host}>
+            <span>{host}</span>
+            <button type="button" aria-label={`Remove ${host}`} onClick={() => setDraft({ ...draft, accepted_hosts: draft.accepted_hosts.filter((item) => item !== host) })}>
+              <Trash2 size={13} />
+            </button>
+          </div>
+        ))}
+        {draft.enabled ? (
+          <div className="remote-access-add-row">
+            <input className="field" aria-label="Add address" placeholder="hostname or IP literal" value={addressInput} onChange={(event) => setAddressInput(event.target.value)} />
+            <button type="button" className="btn" onClick={() => { if (addToList("accepted_hosts", addressInput)) setAddressInput(""); }}>Add address</button>
+          </div>
+        ) : null}
+        {status.suggestions.filter((item) => !draft.accepted_hosts.includes(item)).map((suggestion) => (
+          <label className="remote-access-suggestion" key={suggestion}>
+            <input
+              type="checkbox"
+              checked={selectedSuggestions.includes(suggestion)}
+              onChange={(event) => {
+                setSelectedSuggestions((current) => event.target.checked ? [...current, suggestion] : current.filter((item) => item !== suggestion));
+                if (event.target.checked) addToList("accepted_hosts", suggestion);
+                else setDraft((current) => current ? { ...current, accepted_hosts: current.accepted_hosts.filter((item) => item !== suggestion) } : current);
+              }}
+            />
+            <span>{suggestion}</span>
+            <small>Suggested address</small>
+          </label>
+        ))}
+      </div>
+
+      <div className="remote-access-subsection">
+        <strong>Browser permissions</strong>
+        <p className="settings-help">Allowed page origins protect calls into this bridge. Allowed bridge destinations control where this page may connect over HTTP/WebSocket.</p>
+        <PermissionList
+          label="Allowed page origins"
+          values={draft.allowed_page_origins}
+          suggestions={pageOriginSuggestions}
+          input={pageOriginInput}
+          onInput={setPageOriginInput}
+          onChange={(values) => setDraft({ ...draft, allowed_page_origins: values })}
+        />
+        <PermissionList
+          label="Allowed bridge destinations"
+          values={draft.allowed_bridge_origins}
+          suggestions={bridgeOriginSuggestions}
+          input={bridgeOriginInput}
+          onInput={setBridgeOriginInput}
+          onChange={(values) => setDraft({ ...draft, allowed_bridge_origins: values })}
+        />
+      </div>
+
+      {address ? (
+        <div className="remote-access-address">
+          <span>Connection URL</span>
+          <code>{address}</code>
+          <button type="button" className="btn" onClick={() => void copyValue(address)}><Copy size={13} /> Copy</button>
+        </div>
+      ) : null}
+
+      <div className="remote-access-subsection">
+        <strong>Password</strong>
+        <span className="backend-note">{status.remote_access.password_configured ? "Protected" : "Not set"}</span>
+        {draft.enabled && !status.remote_access.password_configured ? <p className="backend-warning">Anyone who can reach an accepted address may connect until you set a password.</p> : null}
+        <div className="remote-access-password-row">
+          <input
+            className="field"
+            type="password"
+            aria-label={status.remote_access.password_configured ? "Change bridge password" : "Set bridge password"}
+            placeholder={status.remote_access.password_configured ? "New password" : "Set password"}
+            autoComplete="new-password"
+            value={password}
+            onChange={(event) => { setPassword(event.target.value); setPasswordAction("set"); }}
+          />
+          {status.remote_access.password_configured ? <button type="button" className="btn btn-danger" onClick={() => { setPassword(""); setPasswordAction("remove"); setMessage("Password protection will be removed when you apply settings."); }}>Remove</button> : null}
+        </div>
+        {status.remote_access.password_configured ? <span className="backend-note">Enter a new password to change it, or Remove to disable protection.</span> : null}
+      </div>
+
+      <div className={`remote-access-apply remote-access-apply-${applyState}`} role="status">
+        <strong>{busy ? "Settings saved; waiting to apply" : applyLabel(status.apply.state)}</strong>
+        <span>{status.apply.reason ?? message ?? (status.mutation_allowed ? "Ready to apply." : status.mutation_reason ?? "Settings are read-only in this launch.")}</span>
+      </div>
+      {!status.mutation_allowed ? <p className="backend-warning">{status.mutation_reason ?? "This launch cannot safely apply settings."}</p> : null}
+      {message && status.apply.state !== "applying" ? <div className="modal-message">{message}</div> : null}
+      <div className="modal-actions">
+        <button type="button" className="btn btn-primary" disabled={busy || !status.mutation_allowed} onClick={() => void save()}>{busy ? "Applying…" : "Apply"}</button>
+      </div>
+    </div>
+  );
+}
+
+function PermissionList({ label, values, suggestions, input, onInput, onChange }: {
+  label: string;
+  values: string[];
+  suggestions: string[];
+  input: string;
+  onInput: (value: string) => void;
+  onChange: (values: string[]) => void;
+}) {
+  return (
+    <div className="remote-access-permission-list">
+      <span>{label}</span>
+      {values.map((value) => <div className="remote-access-chip" key={value}><span>{value}</span><button type="button" aria-label={`Remove ${value}`} onClick={() => onChange(values.filter((item) => item !== value))}><Trash2 size={13} /></button></div>)}
+      {suggestions.filter((item) => !values.includes(item)).map((suggestion) => (
+        <label className="remote-access-suggestion" key={suggestion}>
+          <input type="checkbox" checked={false} onChange={(event) => { if (event.target.checked) onChange([...values, suggestion]); }} />
+          <span>{suggestion}</span><small>Suggested</small>
+        </label>
+      ))}
+      <div className="remote-access-add-row">
+        <input className="field" aria-label={`Add ${label.toLowerCase()}`} placeholder="http(s)://host:port" value={input} onChange={(event) => onInput(event.target.value)} />
+        <button type="button" className="btn" onClick={() => { const value = input.trim(); if (value && !values.includes(value)) { onChange([...values, value]); onInput(""); } }}><Plus size={13} /> Add</button>
+      </div>
+    </div>
+  );
+}
+
+function draftFromStatus(status: RemoteAccessStatus): RemoteAccessDraft {
+  return {
+    enabled: status.remote_access.enabled,
+    accepted_hosts: status.remote_access.accepted_hosts,
+    allowed_page_origins: status.remote_access.allowed_page_origins,
+    allowed_bridge_origins: status.remote_access.allowed_bridge_origins,
+  };
+}
+
+function uniqueOrigins(values: readonly (string | undefined)[]) {
+  const origins: string[] = [];
+  for (const value of values) {
+    if (!value) continue;
+    try {
+      const parsed = new URL(value);
+      if ((parsed.protocol === "http:" || parsed.protocol === "https:") && parsed.pathname === "/" && !parsed.username && !parsed.password && !parsed.search && !parsed.hash) {
+        if (!origins.includes(parsed.origin)) origins.push(parsed.origin);
+      }
+    } catch {
+      // Suggestions are optional and untrusted profile values are ignored.
+    }
+  }
+  return origins.slice(0, 8);
+}
+
+function applyLabel(state: RemoteAccessStatus["apply"]["state"]) {
+  return state === "applying" ? "Service restarting" : state === "failed" ? "Apply failed" : "Bridge ready";
+}
+
+async function copyValue(value: string) {
+  try {
+    await navigator.clipboard.writeText(value);
+  } catch {
+    // Copy is a convenience; the address remains selectable.
+  }
+}

--- a/web/src/RemoteAccessSettings.tsx
+++ b/web/src/RemoteAccessSettings.tsx
@@ -230,7 +230,8 @@ export function RemoteAccessSettings({
         </span>
         <p className="settings-help">
           Other devices are asked for this password when they connect. Passwords for bridges you
-          add are requested under Bridges and are kept only for the current app session.
+          add are not stored; authenticated access lasts until the browser tab closes or the
+          session expires.
         </p>
         {draft.enabled ? (
           <p className="backend-warning">

--- a/web/src/RemoteAccessSettings.tsx
+++ b/web/src/RemoteAccessSettings.tsx
@@ -1,11 +1,14 @@
-import { Copy, Plus, Trash2 } from "lucide-react";
-import { useEffect, useMemo, useRef, useState } from "react";
-import type { BridgeBackendProfile } from "./bridge";
+import { Copy, Trash2 } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import { AccessOriginList, uniqueHttpOrigins } from "./AccessOriginList";
 import type { BridgeHttpUrl } from "./bridgeApi";
 import {
   applyRemoteAccess,
   bridgeAddress,
   fetchRemoteAccess,
+  remoteAccessDraft,
+  remoteAccessMatchesDraft,
+  waitForRemoteAccessReady,
   type RemoteAccessDraft,
   type RemoteAccessStatus,
   type RemotePasswordAction,
@@ -13,73 +16,47 @@ import {
 
 type Props = {
   httpUrl: BridgeHttpUrl;
-  backends: readonly BridgeBackendProfile[];
+  reloadPage?: () => void;
 };
 
-export function RemoteAccessSettings({ httpUrl, backends }: Props) {
+export function RemoteAccessSettings({
+  httpUrl,
+  reloadPage = () => window.location.reload(),
+}: Props) {
   const [status, setStatus] = useState<RemoteAccessStatus | null>(null);
   const [draft, setDraft] = useState<RemoteAccessDraft | null>(null);
   const [addressInput, setAddressInput] = useState("");
-  const [pageOriginInput, setPageOriginInput] = useState("");
-  const [bridgeOriginInput, setBridgeOriginInput] = useState("");
   const [selectedSuggestions, setSelectedSuggestions] = useState<string[]>([]);
   const [password, setPassword] = useState("");
   const [passwordAction, setPasswordAction] = useState<RemotePasswordAction>("keep");
   const [busy, setBusy] = useState(false);
   const [message, setMessage] = useState<string | null>(null);
-  const applyObserved = useRef(false);
-
-  const reload = async () => {
-    try {
-      const next = await fetchRemoteAccess(httpUrl);
-      setStatus(next);
-      setDraft((current) => current ?? draftFromStatus(next));
-      if (next.apply.state === "applying") {
-        applyObserved.current = true;
-      } else if (applyObserved.current) {
-        applyObserved.current = false;
-        setBusy(false);
-      }
-    } catch (error) {
-      setMessage(error instanceof Error ? error.message : "Remote access status unavailable");
-    }
-  };
 
   useEffect(() => {
     let cancelled = false;
     void fetchRemoteAccess(httpUrl).then((next) => {
       if (cancelled) return;
       setStatus(next);
-      setDraft(draftFromStatus(next));
+      setDraft(remoteAccessDraft(next));
     }).catch((error: unknown) => {
-      if (!cancelled) setMessage(error instanceof Error ? error.message : "Remote access status unavailable");
+      if (!cancelled) {
+        setMessage(error instanceof Error ? error.message : "Sharing settings unavailable");
+      }
     });
     return () => { cancelled = true; };
   }, [httpUrl]);
 
-  useEffect(() => {
-    if (!busy) return;
-    const timer = window.setInterval(() => { void reload(); }, 750);
-    return () => window.clearInterval(timer);
-  }, [busy, httpUrl]);
-
-  const pageOriginSuggestions = useMemo(() => {
-    const values = [
-      globalThis.location?.origin,
-      "http://localhost",
-      "http://127.0.0.1:8787",
-    ];
-    return uniqueOrigins(values);
-  }, []);
-  const bridgeOriginSuggestions = useMemo(
-    () => uniqueOrigins(backends.map((backend) => backend.baseUrl)),
-    [backends],
-  );
+  const clientOriginSuggestions = useMemo(() => uniqueHttpOrigins([
+    globalThis.location?.origin,
+    "http://127.0.0.1:8787",
+    "http://localhost:8787",
+    "http://localhost",
+  ]), []);
 
   if (!status || !draft) {
     return (
       <div className="settings-section settings-section-flat">
-        {message ?? "Loading remote access…"}
+        {message ?? "Loading sharing settings…"}
       </div>
     );
   }
@@ -87,205 +64,280 @@ export function RemoteAccessSettings({ httpUrl, backends }: Props) {
   const address = draft.accepted_hosts[0]
     ? bridgeAddress(draft.accepted_hosts[0], status.port)
     : null;
-  const addToList = (field: "accepted_hosts" | "allowed_page_origins" | "allowed_bridge_origins", raw: string) => {
+  const addAddress = (raw: string) => {
     const value = raw.trim();
-    if (!value || draft[field].includes(value)) return false;
-    setDraft({ ...draft, [field]: [...draft[field], value] });
+    if (!value || draft.accepted_hosts.includes(value)) return false;
+    setDraft({ ...draft, accepted_hosts: [...draft.accepted_hosts, value] });
     return true;
   };
+  const toggleSharing = () => {
+    if (draft.enabled) {
+      setDraft({ ...draft, enabled: false });
+      return;
+    }
+    const acceptedHosts = draft.accepted_hosts.length > 0
+      ? draft.accepted_hosts
+      : status.suggestions.slice(0, 1);
+    const allowedPageOrigins = draft.allowed_page_origins.length > 0
+      ? draft.allowed_page_origins
+      : clientOriginSuggestions;
+    setSelectedSuggestions((current) => uniqueValues([...current, ...acceptedHosts]));
+    setDraft({
+      ...draft,
+      enabled: true,
+      accepted_hosts: acceptedHosts,
+      allowed_page_origins: allowedPageOrigins,
+    });
+  };
   const save = async () => {
-    applyObserved.current = false;
     setBusy(true);
-    setMessage("Settings saved; the bridge is restarting and will reconnect when ready.");
+    setMessage("Saving sharing settings and restarting this bridge…");
     try {
-      const result = await applyRemoteAccess(httpUrl, draft, passwordAction, password || undefined);
-      applyObserved.current = result.state === "applying";
-      setStatus((current) => current ? { ...current, apply: result } : current);
-      if (result.state !== "applying") setBusy(false);
+      const apply = await applyRemoteAccess(httpUrl, draft, passwordAction, password || undefined);
+      setStatus((current) => current ? { ...current, apply } : current);
+      if (apply.state === "failed") {
+        throw new Error(apply.reason ?? "The bridge could not apply the sharing settings");
+      }
+      const expectedPasswordConfigured = passwordAction === "set"
+        ? true
+        : passwordAction === "remove"
+          ? false
+          : status.remote_access.password_configured;
+      const ready = await waitForRemoteAccessReady(
+        httpUrl,
+        (next) => remoteAccessMatchesDraft(next, draft, expectedPasswordConfigured),
+      );
+      setStatus(ready);
       setPassword("");
       setPasswordAction("keep");
-      setMessage(result.reason ?? "Settings saved; waiting for the bridge to become ready.");
-    } catch (error) {
-      applyObserved.current = false;
+      setMessage("Sharing settings applied. Reloading Herdr World…");
       setBusy(false);
-      setMessage(error instanceof Error ? error.message : "Could not apply remote access settings");
+      reloadPage();
+    } catch (error) {
+      setMessage(error instanceof Error ? error.message : "Could not apply sharing settings");
+    } finally {
+      setBusy(false);
     }
   };
 
-  const applyState = busy ? "applying" : status.apply.state;
+  const invalidEnabledDraft = draft.enabled && (
+    draft.accepted_hosts.length === 0 || draft.allowed_page_origins.length === 0
+  );
 
   return (
     <div className="settings-section remote-access-settings">
-      <div className="settings-label">Direct network access</div>
+      <div className="settings-label">Share this bridge</div>
       <p className="settings-help">
-        LAN/VPN access uses the existing direct HTTP and WebSocket bridge. It is not a firewall or
-        source-address allow-list; use a VPN, SSH, or TLS for untrusted networks.
+        Let another device connect directly to the bridge running on this machine over a trusted
+        LAN or VPN. This is separate from adding other machines under Bridges.
       </p>
       <div className="settings-row remote-access-toggle-row">
-        <span>Allow direct network connections</span>
+        <span>Allow other devices to connect</span>
         <button
           className="backend-toggle"
           type="button"
           role="switch"
-          aria-label="Allow direct network connections"
+          aria-label="Allow other devices to connect"
           aria-checked={draft.enabled}
           data-on={draft.enabled ? "true" : undefined}
-          onClick={() => setDraft({ ...draft, enabled: !draft.enabled })}
+          onClick={toggleSharing}
         >
           <span aria-hidden="true" />
         </button>
       </div>
-      {!draft.enabled ? <p className="backend-note">This bridge is available only locally. Saved addresses remain available for later.</p> : null}
+      {!draft.enabled ? (
+        <p className="backend-note">
+          This machine accepts local connections only. Its saved sharing settings are retained.
+        </p>
+      ) : null}
 
       <div className="remote-access-subsection">
-        <strong>Accepted addresses</strong>
-        {draft.accepted_hosts.length === 0 ? <span className="backend-note">None selected</span> : null}
+        <strong>Addresses for this bridge</strong>
+        <p className="settings-help">
+          These are this machine&apos;s hostname or IP address—the value another device puts in its
+          Bridge URL. They are not addresses of allowed client devices.
+        </p>
+        {draft.accepted_hosts.length === 0 ? (
+          <span className="backend-warning">Add an address for this machine before applying.</span>
+        ) : null}
         {draft.accepted_hosts.map((host) => (
           <div className="remote-access-chip" key={host}>
             <span>{host}</span>
-            <button type="button" aria-label={`Remove ${host}`} onClick={() => setDraft({ ...draft, accepted_hosts: draft.accepted_hosts.filter((item) => item !== host) })}>
+            <button
+              type="button"
+              aria-label={`Remove ${host}`}
+              onClick={() => setDraft({
+                ...draft,
+                accepted_hosts: draft.accepted_hosts.filter((item) => item !== host),
+              })}
+            >
               <Trash2 size={13} />
             </button>
           </div>
         ))}
-        {draft.enabled ? (
-          <div className="remote-access-add-row">
-            <input className="field" aria-label="Add address" placeholder="hostname or IP literal" value={addressInput} onChange={(event) => setAddressInput(event.target.value)} />
-            <button type="button" className="btn" onClick={() => { if (addToList("accepted_hosts", addressInput)) setAddressInput(""); }}>Add address</button>
-          </div>
-        ) : null}
         {status.suggestions.filter((item) => !draft.accepted_hosts.includes(item)).map((suggestion) => (
           <label className="remote-access-suggestion" key={suggestion}>
             <input
               type="checkbox"
               checked={selectedSuggestions.includes(suggestion)}
               onChange={(event) => {
-                setSelectedSuggestions((current) => event.target.checked ? [...current, suggestion] : current.filter((item) => item !== suggestion));
-                if (event.target.checked) addToList("accepted_hosts", suggestion);
-                else setDraft((current) => current ? { ...current, accepted_hosts: current.accepted_hosts.filter((item) => item !== suggestion) } : current);
+                setSelectedSuggestions((current) => event.target.checked
+                  ? uniqueValues([...current, suggestion])
+                  : current.filter((item) => item !== suggestion));
+                if (event.target.checked) addAddress(suggestion);
+                else setDraft((current) => current ? {
+                  ...current,
+                  accepted_hosts: current.accepted_hosts.filter((item) => item !== suggestion),
+                } : current);
               }}
             />
             <span>{suggestion}</span>
-            <small>Suggested address</small>
+            <small>Detected on this machine</small>
           </label>
         ))}
+        <div className="remote-access-add-row">
+          <input
+            className="field"
+            aria-label="Add this machine address"
+            placeholder="hostname or IP literal"
+            value={addressInput}
+            onChange={(event) => setAddressInput(event.target.value)}
+          />
+          <button
+            type="button"
+            className="btn"
+            onClick={() => { if (addAddress(addressInput)) setAddressInput(""); }}
+          >
+            Add address
+          </button>
+        </div>
       </div>
 
-      <div className="remote-access-subsection">
-        <strong>Browser permissions</strong>
-        <p className="settings-help">Allowed page origins protect calls into this bridge. Allowed bridge destinations control where this page may connect over HTTP/WebSocket.</p>
-        <PermissionList
-          label="Allowed page origins"
-          values={draft.allowed_page_origins}
-          suggestions={pageOriginSuggestions}
-          input={pageOriginInput}
-          onInput={setPageOriginInput}
-          onChange={(values) => setDraft({ ...draft, allowed_page_origins: values })}
-        />
-        <PermissionList
-          label="Allowed bridge destinations"
-          values={draft.allowed_bridge_origins}
-          suggestions={bridgeOriginSuggestions}
-          input={bridgeOriginInput}
-          onInput={setBridgeOriginInput}
-          onChange={(values) => setDraft({ ...draft, allowed_bridge_origins: values })}
-        />
-      </div>
-
-      {address ? (
+      {draft.enabled && address ? (
         <div className="remote-access-address">
-          <span>Connection URL</span>
+          <span>Bridge URL for other devices</span>
           <code>{address}</code>
-          <button type="button" className="btn" onClick={() => void copyValue(address)}><Copy size={13} /> Copy</button>
+          <button type="button" className="btn" onClick={() => void copyValue(address)}>
+            <Copy size={13} /> Copy
+          </button>
         </div>
       ) : null}
 
       <div className="remote-access-subsection">
-        <strong>Password</strong>
-        <span className="backend-note">{status.remote_access.password_configured ? "Protected" : "Not set"}</span>
-        {draft.enabled ? <p className="backend-warning">Direct access uses unencrypted HTTP and WebSocket connections. A bridge password protects access, but does not protect passwords or session tokens from a network observer. Use TLS or a trusted VPN.</p> : null}
-        {draft.enabled && !status.remote_access.password_configured ? <p className="backend-warning">Anyone who can reach an accepted address may connect until you set a password.</p> : null}
+        <strong>Password for this bridge</strong>
+        <span className="backend-note">
+          {status.remote_access.password_configured ? "Protected" : "Not set"}
+        </span>
+        <p className="settings-help">
+          Other devices are asked for this password when they connect. Passwords for bridges you
+          add are requested under Bridges and are kept only for the current app session.
+        </p>
+        {draft.enabled ? (
+          <p className="backend-warning">
+            Direct access uses unencrypted HTTP and WebSocket connections. Use only a trusted LAN
+            or VPN; a password controls access but does not encrypt the connection.
+          </p>
+        ) : null}
+        {draft.enabled && !status.remote_access.password_configured ? (
+          <p className="backend-warning">
+            Anyone who can reach this bridge can use it until you set a password.
+          </p>
+        ) : null}
         <div className="remote-access-password-row">
           <input
             className="field"
             type="password"
-            aria-label={status.remote_access.password_configured ? "Change bridge password" : "Set bridge password"}
+            aria-label={status.remote_access.password_configured
+              ? "Change this bridge password"
+              : "Set this bridge password"}
             placeholder={status.remote_access.password_configured ? "New password" : "Set password"}
             autoComplete="new-password"
             value={password}
-            onChange={(event) => { setPassword(event.target.value); setPasswordAction("set"); }}
+            onChange={(event) => {
+              setPassword(event.target.value);
+              setPasswordAction("set");
+            }}
           />
-          {status.remote_access.password_configured ? <button type="button" className="btn btn-danger" onClick={() => { setPassword(""); setPasswordAction("remove"); setMessage("Password protection will be removed when you apply settings."); }}>Remove</button> : null}
+          {status.remote_access.password_configured ? (
+            <button
+              type="button"
+              className="btn btn-danger"
+              onClick={() => {
+                setPassword("");
+                setPasswordAction("remove");
+                setMessage("Password protection will be removed when you apply settings.");
+              }}
+            >
+              Remove
+            </button>
+          ) : null}
         </div>
-        {status.remote_access.password_configured ? <span className="backend-note">Enter a new password to change it, or Remove to disable protection.</span> : null}
+        {status.remote_access.password_configured ? (
+          <span className="backend-note">
+            Enter a new password to change it, or Remove to disable protection.
+          </span>
+        ) : null}
       </div>
 
-      <div className={`remote-access-apply remote-access-apply-${applyState}`} role="status">
-        <strong>{busy ? "Settings saved; waiting to apply" : applyLabel(status.apply.state)}</strong>
-        <span>{status.apply.reason ?? message ?? (status.mutation_allowed ? "Ready to apply." : status.mutation_reason ?? "Settings are read-only in this launch.")}</span>
+      <details className="remote-access-advanced">
+        <summary>Advanced browser permissions</summary>
+        <div className="remote-access-advanced-content">
+          <p className="settings-help">
+            Client web app origins are the exact URLs from which a browser may call this bridge.
+            Change these only when a client loads Herdr World from a non-standard URL.
+          </p>
+          <AccessOriginList
+            label="Client web app origins"
+            values={draft.allowed_page_origins}
+            suggestions={clientOriginSuggestions}
+            onChange={(values) => setDraft({ ...draft, allowed_page_origins: values })}
+          />
+        </div>
+      </details>
+
+      <div
+        className={`remote-access-apply remote-access-apply-${busy ? "applying" : status.apply.state}`}
+        role="status"
+      >
+        <strong>{busy ? "Applying sharing settings" : applyLabel(status.apply.state)}</strong>
+        <span>
+          {status.apply.reason ?? message ?? (status.mutation_allowed
+            ? "Ready to apply."
+            : status.mutation_reason ?? "Settings are read-only in this launch.")}
+        </span>
       </div>
-      {!status.mutation_allowed ? <p className="backend-warning">{status.mutation_reason ?? "This launch cannot safely apply settings."}</p> : null}
-      {message && status.apply.state !== "applying" ? <div className="modal-message">{message}</div> : null}
+      {!status.mutation_allowed ? (
+        <p className="backend-warning">
+          {status.mutation_reason ?? "This launch cannot safely apply settings."}
+        </p>
+      ) : null}
+      {message && status.apply.state !== "applying" ? (
+        <div className="modal-message">{message}</div>
+      ) : null}
       <div className="modal-actions">
-        <button type="button" className="btn btn-primary" disabled={busy || !status.mutation_allowed} onClick={() => void save()}>{busy ? "Applying…" : "Apply"}</button>
+        <button
+          type="button"
+          className="btn btn-primary"
+          disabled={busy || !status.mutation_allowed || invalidEnabledDraft}
+          onClick={() => void save()}
+        >
+          {busy ? "Applying…" : "Apply"}
+        </button>
       </div>
     </div>
   );
 }
 
-function PermissionList({ label, values, suggestions, input, onInput, onChange }: {
-  label: string;
-  values: string[];
-  suggestions: string[];
-  input: string;
-  onInput: (value: string) => void;
-  onChange: (values: string[]) => void;
-}) {
-  return (
-    <div className="remote-access-permission-list">
-      <span>{label}</span>
-      {values.map((value) => <div className="remote-access-chip" key={value}><span>{value}</span><button type="button" aria-label={`Remove ${value}`} onClick={() => onChange(values.filter((item) => item !== value))}><Trash2 size={13} /></button></div>)}
-      {suggestions.filter((item) => !values.includes(item)).map((suggestion) => (
-        <label className="remote-access-suggestion" key={suggestion}>
-          <input type="checkbox" checked={false} onChange={(event) => { if (event.target.checked) onChange([...values, suggestion]); }} />
-          <span>{suggestion}</span><small>Suggested</small>
-        </label>
-      ))}
-      <div className="remote-access-add-row">
-        <input className="field" aria-label={`Add ${label.toLowerCase()}`} placeholder="http(s)://host:port" value={input} onChange={(event) => onInput(event.target.value)} />
-        <button type="button" className="btn" onClick={() => { const value = input.trim(); if (value && !values.includes(value)) { onChange([...values, value]); onInput(""); } }}><Plus size={13} /> Add</button>
-      </div>
-    </div>
-  );
-}
-
-function draftFromStatus(status: RemoteAccessStatus): RemoteAccessDraft {
-  return {
-    enabled: status.remote_access.enabled,
-    accepted_hosts: status.remote_access.accepted_hosts,
-    allowed_page_origins: status.remote_access.allowed_page_origins,
-    allowed_bridge_origins: status.remote_access.allowed_bridge_origins,
-  };
-}
-
-function uniqueOrigins(values: readonly (string | undefined)[]) {
-  const origins: string[] = [];
-  for (const value of values) {
-    if (!value) continue;
-    try {
-      const parsed = new URL(value);
-      if ((parsed.protocol === "http:" || parsed.protocol === "https:") && parsed.pathname === "/" && !parsed.username && !parsed.password && !parsed.search && !parsed.hash) {
-        if (!origins.includes(parsed.origin)) origins.push(parsed.origin);
-      }
-    } catch {
-      // Suggestions are optional and untrusted profile values are ignored.
-    }
-  }
-  return origins.slice(0, 8);
+function uniqueValues(values: readonly string[]) {
+  return [...new Set(values)];
 }
 
 function applyLabel(state: RemoteAccessStatus["apply"]["state"]) {
-  return state === "applying" ? "Service restarting" : state === "failed" ? "Apply failed" : "Bridge ready";
+  return state === "applying"
+    ? "Service restarting"
+    : state === "failed"
+      ? "Apply failed"
+      : "Bridge ready";
 }
 
 async function copyValue(value: string) {

--- a/web/src/RemoteAccessSettings.tsx
+++ b/web/src/RemoteAccessSettings.tsx
@@ -284,11 +284,11 @@ export function RemoteAccessSettings({
         <summary>Advanced browser permissions</summary>
         <div className="remote-access-advanced-content">
           <p className="settings-help">
-            Client web app origins are the exact URLs from which a browser may call this bridge.
-            Change these only when a client loads Herdr World from a non-standard URL.
+            Add another Herdr World page&apos;s exact URL when it needs to call this bridge. Pages
+            loaded directly from this bridge are already allowed.
           </p>
           <AccessOriginList
-            label="Client web app origins"
+            label="Additional client page origins"
             values={draft.allowed_page_origins}
             suggestions={clientOriginSuggestions}
             onChange={(values) => setDraft({ ...draft, allowed_page_origins: values })}

--- a/web/src/RemoteAccessSettings.tsx
+++ b/web/src/RemoteAccessSettings.tsx
@@ -122,6 +122,18 @@ export function RemoteAccessSettings({
   };
 
   const invalidEnabledDraft = draft.enabled && draft.accepted_hosts.length === 0;
+  const passwordConfigured = status.remote_access.password_configured;
+  const passwordState = passwordAction === "remove"
+    ? "Removal pending"
+    : passwordAction === "set"
+      ? passwordConfigured ? "Change pending" : "Set pending"
+      : passwordConfigured ? "On" : "Off";
+  const applyActionLabel = passwordAction === "remove"
+    ? "Remove password & apply"
+    : passwordAction === "set"
+      ? passwordConfigured ? "Change password & apply" : "Set password & apply"
+      : "Apply changes";
+  const invalidPassword = passwordAction === "set" && !password;
 
   return (
     <div className="settings-section remote-access-settings">
@@ -186,54 +198,115 @@ export function RemoteAccessSettings({
       ) : null}
 
       {draft.enabled ? (
-        <div className="remote-access-subsection">
-          <strong>Authentication</strong>
-          <span className="backend-note">
-            {status.remote_access.password_configured ? "Password protected" : "No password"}
-          </span>
+        <div className="remote-access-subsection remote-access-authentication">
+          <div className="remote-access-password-heading">
+            <strong>Password protection</strong>
+            <span
+              className="remote-access-password-state"
+              data-state={passwordState === "On" ? "on" : passwordState === "Off" ? "off" : "pending"}
+            >
+              {passwordState}
+            </span>
+          </div>
+
+          {passwordConfigured && passwordAction === "keep" ? (
+            <>
+              <p className="settings-help">
+                A password is currently set. Connections must enter it, but it cannot be displayed
+                here.
+              </p>
+              <div className="remote-access-password-actions">
+                <button
+                  type="button"
+                  className="btn"
+                  onClick={() => {
+                    setPassword("");
+                    setPasswordAction("set");
+                    setMessage(null);
+                  }}
+                >
+                  Change password
+                </button>
+                <button
+                  type="button"
+                  className="btn btn-danger"
+                  onClick={() => {
+                    setPassword("");
+                    setPasswordAction("remove");
+                    setMessage(null);
+                  }}
+                >
+                  Remove password
+                </button>
+              </div>
+            </>
+          ) : null}
+
+          {passwordAction === "remove" ? (
+            <div className="remote-access-password-pending" role="status">
+              <div>
+                <strong>Password will be removed</strong>
+                <span>Anyone who can reach this address will be able to connect after you apply.</span>
+              </div>
+              <button
+                type="button"
+                className="btn"
+                onClick={() => {
+                  setPassword("");
+                  setPasswordAction("keep");
+                  setMessage(null);
+                }}
+              >
+                Keep password
+              </button>
+            </div>
+          ) : null}
+
+          {passwordAction === "set" || !passwordConfigured ? (
+            <div className="remote-access-password-editor">
+              <label className="field-label">
+                <span>{passwordConfigured ? "New password" : "Set a password"}</span>
+                <input
+                  className="field"
+                  type="password"
+                  aria-label={passwordConfigured
+                    ? "Change connection password"
+                    : "Set connection password"}
+                  placeholder="Enter a new password"
+                  autoComplete="new-password"
+                  value={password}
+                  onChange={(event) => {
+                    setPassword(event.target.value);
+                    setPasswordAction(event.target.value ? "set" : passwordConfigured ? "set" : "keep");
+                  }}
+                />
+              </label>
+              <span className="backend-note">
+                {passwordConfigured
+                  ? "The current password remains active until you apply this change."
+                  : "Without a password, anyone who can reach this address can connect."}
+              </span>
+              {passwordConfigured ? (
+                <div className="remote-access-password-actions">
+                  <button
+                    type="button"
+                    className="btn"
+                    onClick={() => {
+                      setPassword("");
+                      setPasswordAction("keep");
+                    }}
+                  >
+                    Cancel password change
+                  </button>
+                </div>
+              ) : null}
+            </div>
+          ) : null}
+
           <p className="backend-warning">
             Direct connections are not encrypted. Use only a trusted LAN or VPN; a password
             controls access but does not hide network traffic.
           </p>
-          {!status.remote_access.password_configured ? (
-            <p className="backend-warning">
-              Anyone who can reach this address can connect until you set a password.
-            </p>
-          ) : null}
-          <div className="remote-access-password-row">
-            <input
-              className="field"
-              type="password"
-              aria-label={status.remote_access.password_configured
-                ? "Change connection password"
-                : "Set connection password"}
-              placeholder={status.remote_access.password_configured ? "New password" : "Set password"}
-              autoComplete="new-password"
-              value={password}
-              onChange={(event) => {
-                setPassword(event.target.value);
-                setPasswordAction("set");
-              }}
-            />
-            {status.remote_access.password_configured ? (
-              <button
-                type="button"
-                className="btn btn-danger"
-                onClick={() => {
-                  setPassword("");
-                  setPasswordAction("remove");
-                  setMessage("Password protection will be removed when you apply changes.");
-                }}
-              >
-                Remove
-              </button>
-            ) : null}
-          </div>
-          {status.remote_access.password_configured ? (
-            <span className="backend-note">
-              Enter a new password to change it, or remove password protection.
-            </span>
-          ) : null}
         </div>
       ) : null}
 
@@ -342,10 +415,10 @@ export function RemoteAccessSettings({
         <button
           type="button"
           className="btn btn-primary"
-          disabled={busy || !status.mutation_allowed || invalidEnabledDraft}
+          disabled={busy || !status.mutation_allowed || invalidEnabledDraft || invalidPassword}
           onClick={() => void save()}
         >
-          {busy ? "Applying…" : "Apply changes"}
+          {busy ? "Applying…" : applyActionLabel}
         </button>
       </div>
     </div>

--- a/web/src/TerminalView.tsx
+++ b/web/src/TerminalView.tsx
@@ -12,6 +12,7 @@ import {
 import { useCallback, useEffect, useId, useLayoutEffect, useRef, useState } from "react";
 import type { ChangeEvent, ClipboardEvent, DragEvent, KeyboardEvent, RefObject } from "react";
 import { autosizeMobileCommandTextarea } from "./mobileCommandTextarea";
+import { authenticatedFetch, bridgeWebSocketProtocols } from "./bridgeApi";
 import { ConfirmDialog } from "./overlays";
 import { addNativeResumeHandler } from "./native";
 import { shellQuote } from "./shell";
@@ -855,14 +856,16 @@ export function TerminalView({
       reconnectScheduledForSocket.clear();
       const currentSocketGeneration = socketGeneration + 1;
       socketGeneration = currentSocketGeneration;
+      const nextSocketUrl = terminalSocketUrl(
+        wsUrlRef.current,
+        terminalId,
+        initialSize,
+        terminalOutputCoalesceMs,
+        terminalOutputGzipSupported(),
+      );
       const nextSocket = new WebSocket(
-        terminalSocketUrl(
-          wsUrlRef.current,
-          terminalId,
-          initialSize,
-          terminalOutputCoalesceMs,
-          terminalOutputGzipSupported(),
-        ),
+        nextSocketUrl,
+        bridgeWebSocketProtocols(nextSocketUrl),
       );
       let gzipOutputAcknowledged = false;
       const outputDecoder = createTerminalOutputFrameDecoder(
@@ -2083,7 +2086,7 @@ async function uploadFile(
   if (overwrite) {
     params.set("overwrite", "true");
   }
-  const response = await fetch(httpUrl("/api/uploads", params), {
+  const response = await authenticatedFetch(httpUrl("/api/uploads", params), {
     method: "POST",
     headers: file.blob.type ? { "content-type": file.blob.type } : undefined,
     body: file.blob,

--- a/web/src/bridge.test.ts
+++ b/web/src/bridge.test.ts
@@ -18,6 +18,7 @@ import {
   SAME_ORIGIN_BRIDGE_ID,
   sameOriginHostLabel,
 } from "./bridge";
+import { BridgeDiagnosticError } from "./bridgeApi";
 
 afterEach(() => {
   vi.unstubAllGlobals();
@@ -342,6 +343,16 @@ describe("capabilities", () => {
     expect(capabilityRetryDelayMs(1)).toBe(2000);
     expect(capabilityRetryDelayMs(3)).toBe(8000);
     expect(capabilityRetryDelayMs(10)).toBe(10000);
+  });
+
+  it("retains bounded policy and API diagnostics for the bridge test flow", () => {
+    expect(capabilityProbeFailure(new BridgeDiagnosticError("Host or Origin policy rejected the request"))).toEqual({
+      blocked: true,
+      state: "offline",
+      capabilities: null,
+      error: "Host or Origin policy rejected the request",
+      retry: true,
+    });
   });
 
   it("parses optional compatibility fields", () => {

--- a/web/src/bridge.test.ts
+++ b/web/src/bridge.test.ts
@@ -326,14 +326,14 @@ describe("capabilities", () => {
       blocked: true,
       state: "incompatible",
       capabilities: null,
-      error: "Bridge is not compatible with this web app",
+      error: "This Herdr is not compatible with this web app",
       retry: false,
     });
     expect(capabilityProbeFailure(new Error("network down"))).toEqual({
       blocked: true,
       state: "offline",
       capabilities: null,
-      error: "Bridge unavailable",
+      error: "Connection unavailable",
       retry: true,
     });
   });
@@ -509,7 +509,7 @@ describe("capabilities", () => {
     );
 
     await expect(probeBridgeBaseUrl("192.0.2.20:4000")).rejects.toThrow(
-      /Bridge terminal attach failed: terminal attach failed: terminal missing/iu,
+      /Connection terminal attach failed: terminal attach failed: terminal missing/iu,
     );
     fetchMock.mockRestore();
   });
@@ -526,7 +526,7 @@ describe("capabilities", () => {
     ));
 
     await expect(probeBridgeBaseUrl("192.0.2.20:4000")).rejects.toThrow(
-      /add http:\/\/192\.0\.2\.30:8791 under Share this machine/iu,
+      /Network → Allow connections → Advanced network permissions/iu,
     );
     fetchMock.mockRestore();
   });

--- a/web/src/bridge.test.ts
+++ b/web/src/bridge.test.ts
@@ -467,7 +467,7 @@ describe("capabilities", () => {
     );
     expect(sockets).toEqual([
       "ws://192.0.2.20:4000/ws/events",
-      "ws://192.0.2.20:4000/ws/terminal?terminal_id=terminal-test&cols=80&rows=24&takeover=false&coalesce_ms=16",
+      "ws://192.0.2.20:4000/ws/terminal?terminal_id=terminal-test&takeover=false&probe=true",
     ]);
 
     fetchMock.mockRestore();

--- a/web/src/bridge.test.ts
+++ b/web/src/bridge.test.ts
@@ -514,6 +514,23 @@ describe("capabilities", () => {
     fetchMock.mockRestore();
   });
 
+  it("identifies the exact client page origin when target policy rejects it", async () => {
+    vi.stubGlobal("location", { origin: "http://192.0.2.30:8791" });
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => (
+      new Response(
+        String(input).endsWith("/api/capabilities")
+          ? JSON.stringify(compatibleCapabilities())
+          : JSON.stringify({ error: "cross-origin requests are not allowed" }),
+        { status: String(input).endsWith("/api/capabilities") ? 200 : 403 },
+      )
+    ));
+
+    await expect(probeBridgeBaseUrl("192.0.2.20:4000")).rejects.toThrow(
+      /add http:\/\/192\.0\.2\.30:8791 under Share this machine/iu,
+    );
+    fetchMock.mockRestore();
+  });
+
   it("reports a WebSocket upgrade failure separately from HTTP reachability", async () => {
     const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
       const url = String(input);

--- a/web/src/bridge.test.ts
+++ b/web/src/bridge.test.ts
@@ -442,7 +442,7 @@ describe("capabilities", () => {
       "WebSocket",
       class ProbeWebSocket {
         onopen: (() => void) | null = null;
-        onmessage: (() => void) | null = null;
+        onmessage: ((event: { data: string }) => void) | null = null;
         onerror: (() => void) | null = null;
         onclose: (() => void) | null = null;
 
@@ -450,7 +450,9 @@ describe("capabilities", () => {
           sockets.push(url);
           queueMicrotask(() => {
             this.onopen?.();
-            if (url.includes("/ws/terminal")) this.onmessage?.();
+            if (url.includes("/ws/terminal")) {
+              this.onmessage?.({ data: JSON.stringify({ type: "attach_ready" }) });
+            }
           });
         }
 
@@ -470,6 +472,45 @@ describe("capabilities", () => {
       "ws://192.0.2.20:4000/ws/terminal?terminal_id=terminal-test&takeover=false&probe=true",
     ]);
 
+    fetchMock.mockRestore();
+  });
+
+  it("reports terminal attach failure frames instead of treating them as ready", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = String(input);
+      return new Response(
+        url.endsWith("/api/capabilities")
+          ? JSON.stringify(compatibleCapabilities())
+          : JSON.stringify({ panes: [{ terminal_id: "terminal-test" }] }),
+        { status: 200 },
+      );
+    });
+    vi.stubGlobal(
+      "WebSocket",
+      class ClosedTerminalWebSocket {
+        onopen: (() => void) | null = null;
+        onmessage: ((event: { data: string }) => void) | null = null;
+        onerror: (() => void) | null = null;
+        onclose: (() => void) | null = null;
+
+        constructor(url: string) {
+          queueMicrotask(() => {
+            this.onopen?.();
+            if (url.includes("/ws/terminal")) {
+              this.onmessage?.({
+                data: JSON.stringify({ type: "closed", reason: "terminal attach failed: terminal missing" }),
+              });
+            }
+          });
+        }
+
+        close() {}
+      },
+    );
+
+    await expect(probeBridgeBaseUrl("192.0.2.20:4000")).rejects.toThrow(
+      /Bridge terminal attach failed: terminal attach failed: terminal missing/iu,
+    );
     fetchMock.mockRestore();
   });
 

--- a/web/src/bridge.test.ts
+++ b/web/src/bridge.test.ts
@@ -428,8 +428,36 @@ describe("capabilities", () => {
 
   it("probes configured bridge capabilities", async () => {
     const response = compatibleCapabilities({ commands: ["pane.move"] });
-    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      new Response(JSON.stringify(response), { status: 200 }),
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = String(input);
+      return new Response(
+        url.endsWith("/api/capabilities")
+          ? JSON.stringify(response)
+          : JSON.stringify({ panes: [{ terminal_id: "terminal-test" }] }),
+        { status: 200 },
+      );
+    });
+    const sockets: string[] = [];
+    vi.stubGlobal(
+      "WebSocket",
+      class ProbeWebSocket {
+        onopen: (() => void) | null = null;
+        onmessage: (() => void) | null = null;
+        onerror: (() => void) | null = null;
+        onclose: (() => void) | null = null;
+
+        constructor(url: string) {
+          sockets.push(url);
+          queueMicrotask(() => {
+            this.onopen?.();
+            if (url.includes("/ws/terminal")) this.onmessage?.();
+          });
+        }
+
+        close() {
+          this.onclose?.();
+        }
+      },
     );
 
     await expect(probeBridgeBaseUrl("192.0.2.20:4000")).resolves.toEqual(response);
@@ -437,7 +465,43 @@ describe("capabilities", () => {
       "http://192.0.2.20:4000/api/capabilities",
       expect.objectContaining({ signal: expect.any(AbortSignal) }),
     );
+    expect(sockets).toEqual([
+      "ws://192.0.2.20:4000/ws/events",
+      "ws://192.0.2.20:4000/ws/terminal?terminal_id=terminal-test&cols=80&rows=24&takeover=false&coalesce_ms=16",
+    ]);
 
+    fetchMock.mockRestore();
+  });
+
+  it("reports a WebSocket upgrade failure separately from HTTP reachability", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = String(input);
+      return new Response(
+        url.endsWith("/api/capabilities")
+          ? JSON.stringify(compatibleCapabilities())
+          : JSON.stringify({ panes: [] }),
+        { status: 200 },
+      );
+    });
+    vi.stubGlobal(
+      "WebSocket",
+      class FailingWebSocket {
+        onopen: (() => void) | null = null;
+        onmessage: (() => void) | null = null;
+        onerror: (() => void) | null = null;
+        onclose: (() => void) | null = null;
+
+        constructor() {
+          queueMicrotask(() => this.onerror?.());
+        }
+
+        close() {}
+      },
+    );
+
+    await expect(probeBridgeBaseUrl("192.0.2.20:4000")).rejects.toThrow(
+      /WebSocket upgrade failed/iu,
+    );
     fetchMock.mockRestore();
   });
 

--- a/web/src/bridge.tsx
+++ b/web/src/bridge.tsx
@@ -1319,8 +1319,14 @@ function probeBridgeWebSocket(
         socket.close();
       }
     };
-    socket.onmessage = () => {
-      finish();
+    socket.onmessage = (event) => {
+      if (!waitForMessage) {
+        finish();
+        socket.close();
+        return;
+      }
+      const diagnostic = terminalProbeMessageError(label, event.data);
+      finish(diagnostic ?? undefined);
       socket.close();
     };
     socket.onerror = () => {
@@ -1334,6 +1340,28 @@ function probeBridgeWebSocket(
       }
     };
   });
+}
+
+function terminalProbeMessageError(label: string, data: unknown): Error | null {
+  if (typeof data !== "string") {
+    return new BridgeDiagnosticError(`${label} returned a malformed readiness frame`);
+  }
+  let value: unknown;
+  try {
+    value = JSON.parse(data);
+  } catch {
+    return new BridgeDiagnosticError(`${label} returned a malformed readiness frame`);
+  }
+  if (!isRecord(value) || typeof value.type !== "string") {
+    return new BridgeDiagnosticError(`${label} returned an unexpected readiness frame`);
+  }
+  if (value.type === "attach_ready") {
+    return null;
+  }
+  if (value.type === "closed" && typeof value.reason === "string" && value.reason.trim()) {
+    return new BridgeDiagnosticError(`${label} failed: ${value.reason.trim()}`);
+  }
+  return new BridgeDiagnosticError(`${label} returned an unexpected readiness frame (${value.type})`);
 }
 
 function capabilityHttpError(status: number) {

--- a/web/src/bridge.tsx
+++ b/web/src/bridge.tsx
@@ -1367,7 +1367,12 @@ function terminalProbeMessageError(label: string, data: unknown): Error | null {
 
 function capabilityHttpError(status: number) {
   if (status === 401) return "Password required or rejected by the bridge";
-  if (status === 403) return "Host or Origin policy rejected the request; check the bridge's allowed page origin";
+  if (status === 403) {
+    const pageOrigin = globalThis.location?.origin;
+    return pageOrigin
+      ? `Bridge policy rejected this page. On the target machine, add ${pageOrigin} under Share this machine → Advanced browser permissions.`
+      : "Bridge policy rejected this page; check the target bridge's additional client page origins";
+  }
   if (status === 404) return "Bridge API is unavailable at this address";
   return `Bridge API request failed (${status})`;
 }

--- a/web/src/bridge.tsx
+++ b/web/src/bridge.tsx
@@ -182,7 +182,9 @@ export function BridgeProvider({ children }: { children: ReactNode }) {
   const [probeRetryTokens, setProbeRetryTokens] = useState<Record<string, number>>({});
   const [resumeToken, setResumeToken] = useState(0);
   const storeEditedRef = useRef(false);
+  const passwordPromptSequenceRef = useRef(0);
   const [passwordPrompts, setPasswordPrompts] = useState<{
+    id: number;
     origin: string;
     resolve: (password: string | null) => void;
   }[]>([]);
@@ -193,7 +195,11 @@ export function BridgeProvider({ children }: { children: ReactNode }) {
     setBridgePasswordPromptHandler(
       (origin) =>
         new Promise<string | null>((resolve) => {
-          setPasswordPrompts((current) => [...current, { origin, resolve }]);
+          passwordPromptSequenceRef.current += 1;
+          setPasswordPrompts((current) => [
+            ...current,
+            { id: passwordPromptSequenceRef.current, origin, resolve },
+          ]);
         }),
     );
     return () => setBridgePasswordPromptHandler(null);
@@ -520,6 +526,7 @@ export function BridgeProvider({ children }: { children: ReactNode }) {
       ))}
       {passwordPrompts[0] ? (
         <BridgePasswordPrompt
+          key={passwordPrompts[0].id}
           origin={passwordPrompts[0].origin}
           onCancel={() => {
             passwordPrompts[0].resolve(null);
@@ -535,7 +542,7 @@ export function BridgeProvider({ children }: { children: ReactNode }) {
   );
 }
 
-function BridgePasswordPrompt({
+export function BridgePasswordPrompt({
   origin,
   onCancel,
   onSubmit,
@@ -547,7 +554,10 @@ function BridgePasswordPrompt({
   const [password, setPassword] = useState("");
   const inputRef = useRef<HTMLInputElement | null>(null);
 
-  useEffect(() => inputRef.current?.focus(), []);
+  useEffect(() => {
+    setPassword("");
+    inputRef.current?.focus();
+  }, [origin]);
 
   return (
     <div className="overlay-root bridge-auth-overlay">

--- a/web/src/bridge.tsx
+++ b/web/src/bridge.tsx
@@ -13,6 +13,7 @@ import { Preferences } from "@capacitor/preferences";
 import {
   BridgeAuthenticationError,
   BridgeDiagnosticError,
+  bridgeWebSocketProtocols,
   setBridgePasswordPromptHandler,
 } from "./bridgeApi";
 import { fetchWithTimeout } from "./fetchWithTimeout";
@@ -1240,7 +1241,101 @@ export async function probeBridgeBaseUrl(baseUrl: string): Promise<BridgeCapabil
   if (!snapshot.ok) {
     throw new BridgeDiagnosticError(capabilityHttpError(snapshot.status));
   }
+  let snapshotValue: unknown;
+  try {
+    snapshotValue = await snapshot.json();
+  } catch {
+    throw new BridgeDiagnosticError("Bridge snapshot response is malformed");
+  }
+  if (!isRecord(snapshotValue)) {
+    throw new BridgeDiagnosticError("Bridge snapshot response is malformed");
+  }
+
+  await probeBridgeWebSocket(normalized, "/ws/events", "Bridge WebSocket upgrade");
+  const terminalId = firstTerminalId(snapshotValue);
+  if (terminalId) {
+    const query = new URLSearchParams({
+      terminal_id: terminalId,
+      cols: "80",
+      rows: "24",
+      takeover: "false",
+      coalesce_ms: "16",
+    });
+    await probeBridgeWebSocket(
+      normalized,
+      "/ws/terminal",
+      "Bridge terminal attach",
+      query,
+      true,
+    );
+  }
   return capabilities;
+}
+
+function firstTerminalId(snapshot: Record<string, unknown>) {
+  if (!Array.isArray(snapshot.panes)) return null;
+  const pane = snapshot.panes.find(
+    (value): value is Record<string, unknown> =>
+      isRecord(value) && typeof value.terminal_id === "string" && value.terminal_id.length > 0,
+  );
+  return pane ? pane.terminal_id as string : null;
+}
+
+function probeBridgeWebSocket(
+  baseUrl: string,
+  path: string,
+  label: string,
+  query?: URLSearchParams,
+  waitForMessage = false,
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (typeof WebSocket === "undefined") {
+      reject(new BridgeDiagnosticError(`${label} is unavailable in this browser`));
+      return;
+    }
+    const url = buildWsUrl(baseUrl, path, query);
+    let settled = false;
+    const timer = globalThis.setTimeout(() => finish(new BridgeDiagnosticError(
+      `${label} timed out; check the bridge's Host, Origin, and password settings`,
+    )), 5000);
+    const finish = (error?: Error) => {
+      if (settled) return;
+      settled = true;
+      globalThis.clearTimeout(timer);
+      if (error) {
+        reject(error);
+      } else {
+        resolve();
+      }
+    };
+    let socket: WebSocket;
+    try {
+      socket = new WebSocket(url, bridgeWebSocketProtocols(url));
+    } catch {
+      finish(new BridgeDiagnosticError(`${label} could not be opened; check the bridge address`));
+      return;
+    }
+    socket.onopen = () => {
+      if (!waitForMessage) {
+        finish();
+        socket.close();
+      }
+    };
+    socket.onmessage = () => {
+      finish();
+      socket.close();
+    };
+    socket.onerror = () => {
+      finish(new BridgeDiagnosticError(
+        `${label} failed; check the bridge's Host, Origin, and password settings`,
+      ));
+    };
+    socket.onclose = () => {
+      if (!settled) {
+        finish(new BridgeDiagnosticError(`${label} closed before it was ready`));
+      }
+    };
+  });
 }
 
 function capabilityHttpError(status: number) {

--- a/web/src/bridge.tsx
+++ b/web/src/bridge.tsx
@@ -1256,10 +1256,8 @@ export async function probeBridgeBaseUrl(baseUrl: string): Promise<BridgeCapabil
   if (terminalId) {
     const query = new URLSearchParams({
       terminal_id: terminalId,
-      cols: "80",
-      rows: "24",
       takeover: "false",
-      coalesce_ms: "16",
+      probe: "true",
     });
     await probeBridgeWebSocket(
       normalized,

--- a/web/src/bridge.tsx
+++ b/web/src/bridge.tsx
@@ -569,7 +569,8 @@ function BridgePasswordPrompt({
       >
         <div id="bridge-auth-title" className="modal-title">Bridge password</div>
         <p className="backend-note">
-          Enter the password for {origin}. It stays in memory for this browser session only.
+          Enter the password for {origin}. The password is not stored; authenticated access lasts
+          for this browser tab, including refreshes, until the session expires.
         </p>
         <label className="field-label">
           <span>Password</span>

--- a/web/src/bridge.tsx
+++ b/web/src/bridge.tsx
@@ -554,7 +554,7 @@ function BridgePasswordPrompt({
       <button
         className="overlay-scrim"
         type="button"
-        aria-label="Cancel bridge authentication"
+        aria-label="Cancel connection"
         onClick={onCancel}
       />
       <form
@@ -567,10 +567,10 @@ function BridgePasswordPrompt({
           if (password) onSubmit(password);
         }}
       >
-        <div id="bridge-auth-title" className="modal-title">Bridge password</div>
+        <div id="bridge-auth-title" className="modal-title">Connect to Herdr</div>
         <p className="backend-note">
-          Enter the password for {origin}. The password is not stored; authenticated access lasts
-          for this browser tab, including refreshes, until the session expires.
+          Enter the password for the Herdr at {origin}. The password is not stored. You may be asked
+          again if that Herdr restarts, the session expires, or this browser tab closes.
         </p>
         <label className="field-label">
           <span>Password</span>
@@ -1072,23 +1072,23 @@ function isNativeApp() {
 export function normalizeBridgeBaseUrl(input: string): string {
   const trimmed = input.trim();
   if (!trimmed) {
-    throw new Error("Enter a bridge URL");
+    throw new Error("Enter a Herdr address");
   }
   const withScheme = /^[a-z][a-z0-9+.-]*:\/\//iu.test(trimmed) ? trimmed : `http://${trimmed}`;
   let url: URL;
   try {
     url = new URL(withScheme);
   } catch {
-    throw new Error("Bridge URL is invalid");
+    throw new Error("Herdr address is invalid");
   }
   if (url.protocol !== "http:" && url.protocol !== "https:") {
-    throw new Error("Bridge URL must use http or https");
+    throw new Error("Herdr address must use http or https");
   }
   if (url.username || url.password) {
-    throw new Error("Bridge URL must not include credentials");
+    throw new Error("Herdr address must not include credentials");
   }
   if ((url.pathname && url.pathname !== "/") || url.search || url.hash) {
-    throw new Error("Bridge URL must not include a path, query, or fragment");
+    throw new Error("Herdr address must not include a path, query, or fragment");
   }
   validateBridgeHost(url.hostname);
   return url.origin;
@@ -1097,7 +1097,7 @@ export function normalizeBridgeBaseUrl(input: string): string {
 function validateBridgeHost(hostname: string) {
   const host = stripIpv6Brackets(hostname).toLowerCase();
   if (!host) {
-    throw new Error("Bridge URL must include a host");
+    throw new Error("Herdr address must include a host");
   }
   if (parseIpv4(host)) {
     return;
@@ -1106,7 +1106,7 @@ function validateBridgeHost(hostname: string) {
     return;
   }
   if (!isValidHostname(host)) {
-    throw new Error("Bridge hostname is invalid");
+    throw new Error("Herdr hostname is invalid");
   }
 }
 
@@ -1252,7 +1252,7 @@ export async function probeBridgeBaseUrl(baseUrl: string): Promise<BridgeCapabil
     throw new BridgeDiagnosticError("Bridge snapshot response is malformed");
   }
 
-  await probeBridgeWebSocket(normalized, "/ws/events", "Bridge WebSocket upgrade");
+  await probeBridgeWebSocket(normalized, "/ws/events", "Connection WebSocket upgrade");
   const terminalId = firstTerminalId(snapshotValue);
   if (terminalId) {
     const query = new URLSearchParams({
@@ -1263,7 +1263,7 @@ export async function probeBridgeBaseUrl(baseUrl: string): Promise<BridgeCapabil
     await probeBridgeWebSocket(
       normalized,
       "/ws/terminal",
-      "Bridge terminal attach",
+      "Connection terminal attach",
       query,
       true,
     );
@@ -1295,7 +1295,7 @@ function probeBridgeWebSocket(
     const url = buildWsUrl(baseUrl, path, query);
     let settled = false;
     const timer = globalThis.setTimeout(() => finish(new BridgeDiagnosticError(
-      `${label} timed out; check the bridge's Host, Origin, and password settings`,
+      `${label} timed out; check the Herdr address, network permissions, and password`,
     )), 5000);
     const finish = (error?: Error) => {
       if (settled) return;
@@ -1311,7 +1311,7 @@ function probeBridgeWebSocket(
     try {
       socket = new WebSocket(url, bridgeWebSocketProtocols(url));
     } catch {
-      finish(new BridgeDiagnosticError(`${label} could not be opened; check the bridge address`));
+      finish(new BridgeDiagnosticError(`${label} could not be opened; check the Herdr address`));
       return;
     }
     socket.onopen = () => {
@@ -1332,7 +1332,7 @@ function probeBridgeWebSocket(
     };
     socket.onerror = () => {
       finish(new BridgeDiagnosticError(
-        `${label} failed; check the bridge's Host, Origin, and password settings`,
+        `${label} failed; check the Herdr address, network permissions, and password`,
       ));
     };
     socket.onclose = () => {
@@ -1366,15 +1366,15 @@ function terminalProbeMessageError(label: string, data: unknown): Error | null {
 }
 
 function capabilityHttpError(status: number) {
-  if (status === 401) return "Password required or rejected by the bridge";
+  if (status === 401) return "Password required or rejected by this Herdr";
   if (status === 403) {
     const pageOrigin = globalThis.location?.origin;
     return pageOrigin
-      ? `Bridge policy rejected this page. On the target machine, add ${pageOrigin} under Share this machine → Advanced browser permissions.`
-      : "Bridge policy rejected this page; check the target bridge's additional client page origins";
+      ? `This Herdr does not allow the current page. On the target Herdr, add ${pageOrigin} under Network → Allow connections → Advanced network permissions.`
+      : "This Herdr does not allow the current page; check its advanced network permissions";
   }
-  if (status === 404) return "Bridge API is unavailable at this address";
-  return `Bridge API request failed (${status})`;
+  if (status === 404) return "Herdr is unavailable at this address";
+  return `Herdr connection request failed (${status})`;
 }
 
 export type CapabilityProbeOutcome = {
@@ -1415,7 +1415,7 @@ export function capabilityProbeFailure(error: unknown): CapabilityProbeOutcome {
     blocked: true,
     state: contractFailure ? "incompatible" : "offline",
     capabilities: null,
-    error: contractFailure || authenticationFailure || diagnosticFailure ? error.message : "Bridge unavailable",
+    error: contractFailure || authenticationFailure || diagnosticFailure ? error.message : "Connection unavailable",
     retry: !contractFailure,
   };
 }
@@ -1515,7 +1515,7 @@ function compatibilityError(capabilities: BridgeCapabilities) {
     typeof capabilities.web_compat === "number" &&
     capabilities.web_compat < APP_MIN_WEB_COMPAT
   ) {
-    return "Bridge is not compatible with this web app";
+    return "This Herdr is not compatible with this web app";
   }
   return null;
 }

--- a/web/src/bridge.tsx
+++ b/web/src/bridge.tsx
@@ -527,6 +527,9 @@ export function BridgeProvider({ children }: { children: ReactNode }) {
       {passwordPrompts[0] ? (
         <BridgePasswordPrompt
           key={passwordPrompts[0].id}
+          name={store.backends.find(
+            (backend) => backend.baseUrl === passwordPrompts[0].origin,
+          )?.name ?? "Herdr"}
           origin={passwordPrompts[0].origin}
           onCancel={() => {
             passwordPrompts[0].resolve(null);
@@ -543,16 +546,19 @@ export function BridgeProvider({ children }: { children: ReactNode }) {
 }
 
 export function BridgePasswordPrompt({
+  name,
   origin,
   onCancel,
   onSubmit,
 }: {
+  name: string;
   origin: string;
   onCancel: () => void;
   onSubmit: (password: string) => void;
 }) {
   const [password, setPassword] = useState("");
   const inputRef = useRef<HTMLInputElement | null>(null);
+  const address = new URL(origin).host;
 
   useEffect(() => {
     setPassword("");
@@ -578,10 +584,12 @@ export function BridgePasswordPrompt({
         }}
       >
         <div id="bridge-auth-title" className="modal-title">Connect to Herdr</div>
-        <p className="backend-note">
-          Enter the password for the Herdr at {origin}. The password is not stored. You may be asked
-          again if that Herdr restarts, the session expires, or this browser tab closes.
-        </p>
+        <div className="bridge-auth-target" aria-label={`Connection destination: ${name}, ${address}`}>
+          <span>Password for</span>
+          <strong>{name}</strong>
+          <code>{address}</code>
+        </div>
+        <p className="backend-note">The password is not stored in Herdr World.</p>
         <label className="field-label">
           <span>Password</span>
           <input

--- a/web/src/bridge.tsx
+++ b/web/src/bridge.tsx
@@ -10,6 +10,11 @@ import {
 import type { ReactNode } from "react";
 import { Capacitor } from "@capacitor/core";
 import { Preferences } from "@capacitor/preferences";
+import {
+  BridgeAuthenticationError,
+  BridgeDiagnosticError,
+  setBridgePasswordPromptHandler,
+} from "./bridgeApi";
 import { fetchWithTimeout } from "./fetchWithTimeout";
 import { normalizeHostProfileId, normalizeHostProfileLabel } from "./hostProfile";
 import { addNativeResumeHandler } from "./native";
@@ -76,6 +81,11 @@ export type BridgeCapabilities = {
   };
   web_compat?: number;
   min_android_app_compat?: number;
+  authentication?: {
+    required: boolean;
+    session: "bearer";
+    local_peer_bypass: boolean;
+  };
   observability?: BridgeObservabilityCapability;
 };
 
@@ -171,8 +181,22 @@ export function BridgeProvider({ children }: { children: ReactNode }) {
   const [probeRetryTokens, setProbeRetryTokens] = useState<Record<string, number>>({});
   const [resumeToken, setResumeToken] = useState(0);
   const storeEditedRef = useRef(false);
+  const [passwordPrompts, setPasswordPrompts] = useState<{
+    origin: string;
+    resolve: (password: string | null) => void;
+  }[]>([]);
 
   const sameOriginAvailable = defaultBridgeMode() === "same-origin";
+
+  useEffect(() => {
+    setBridgePasswordPromptHandler(
+      (origin) =>
+        new Promise<string | null>((resolve) => {
+          setPasswordPrompts((current) => [...current, { origin, resolve }]);
+        }),
+    );
+    return () => setBridgePasswordPromptHandler(null);
+  }, []);
 
   useEffect(() => {
     let cancelled = false;
@@ -493,7 +517,76 @@ export function BridgeProvider({ children }: { children: ReactNode }) {
           }
         />
       ))}
+      {passwordPrompts[0] ? (
+        <BridgePasswordPrompt
+          origin={passwordPrompts[0].origin}
+          onCancel={() => {
+            passwordPrompts[0].resolve(null);
+            setPasswordPrompts((current) => current.slice(1));
+          }}
+          onSubmit={(password) => {
+            passwordPrompts[0].resolve(password);
+            setPasswordPrompts((current) => current.slice(1));
+          }}
+        />
+      ) : null}
     </BridgeContext.Provider>
+  );
+}
+
+function BridgePasswordPrompt({
+  origin,
+  onCancel,
+  onSubmit,
+}: {
+  origin: string;
+  onCancel: () => void;
+  onSubmit: (password: string) => void;
+}) {
+  const [password, setPassword] = useState("");
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  useEffect(() => inputRef.current?.focus(), []);
+
+  return (
+    <div className="overlay-root bridge-auth-overlay">
+      <button
+        className="overlay-scrim"
+        type="button"
+        aria-label="Cancel bridge authentication"
+        onClick={onCancel}
+      />
+      <form
+        className="modal bridge-auth-modal"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="bridge-auth-title"
+        onSubmit={(event) => {
+          event.preventDefault();
+          if (password) onSubmit(password);
+        }}
+      >
+        <div id="bridge-auth-title" className="modal-title">Bridge password</div>
+        <p className="backend-note">
+          Enter the password for {origin}. It stays in memory for this browser session only.
+        </p>
+        <label className="field-label">
+          <span>Password</span>
+          <input
+            ref={inputRef}
+            className="field"
+            type="password"
+            value={password}
+            autoComplete="current-password"
+            onChange={(event) => setPassword(event.target.value)}
+          />
+        </label>
+        <div className="modal-actions">
+          <button type="button" className="btn" onClick={onCancel}>Cancel</button>
+          <button type="submit" className="btn btn-primary" disabled={!password}>Connect</button>
+        </div>
+      </form>
+    </div>
   );
 }
 
@@ -1125,7 +1218,7 @@ export async function fetchCapabilities(
 ): Promise<BridgeCapabilities> {
   const response = await fetchWithTimeout(httpUrl("/api/capabilities"));
   if (!response.ok) {
-    throw new Error(`capabilities failed: ${response.status}`);
+    throw new BridgeDiagnosticError(capabilityHttpError(response.status));
   }
   let value: unknown;
   try {
@@ -1143,7 +1236,18 @@ export async function probeBridgeBaseUrl(baseUrl: string): Promise<BridgeCapabil
   if (error) {
     throw new Error(error);
   }
+  const snapshot = await fetchWithTimeout(buildHttpUrl(normalized, "/api/snapshot"));
+  if (!snapshot.ok) {
+    throw new BridgeDiagnosticError(capabilityHttpError(snapshot.status));
+  }
   return capabilities;
+}
+
+function capabilityHttpError(status: number) {
+  if (status === 401) return "Password required or rejected by the bridge";
+  if (status === 403) return "Host or Origin policy rejected the request; check the bridge's allowed page origin";
+  if (status === 404) return "Bridge API is unavailable at this address";
+  return `Bridge API request failed (${status})`;
 }
 
 export type CapabilityProbeOutcome = {
@@ -1178,11 +1282,13 @@ export function capabilityProbeSuccess(
 
 export function capabilityProbeFailure(error: unknown): CapabilityProbeOutcome {
   const contractFailure = error instanceof CapabilityContractError;
+  const authenticationFailure = error instanceof BridgeAuthenticationError;
+  const diagnosticFailure = error instanceof BridgeDiagnosticError;
   return {
     blocked: true,
     state: contractFailure ? "incompatible" : "offline",
     capabilities: null,
-    error: contractFailure ? error.message : "Bridge unavailable",
+    error: contractFailure || authenticationFailure || diagnosticFailure ? error.message : "Bridge unavailable",
     retry: !contractFailure,
   };
 }
@@ -1223,6 +1329,18 @@ export function parseCapabilities(value: unknown): BridgeCapabilities {
     web_compat: typeof value.web_compat === "number" ? value.web_compat : undefined,
     min_android_app_compat:
       typeof value.min_android_app_compat === "number" ? value.min_android_app_compat : undefined,
+    ...(isRecord(value.authentication) &&
+    typeof value.authentication.required === "boolean" &&
+    value.authentication.session === "bearer" &&
+    typeof value.authentication.local_peer_bypass === "boolean"
+      ? {
+          authentication: {
+            required: value.authentication.required as boolean,
+            session: "bearer" as const,
+            local_peer_bypass: value.authentication.local_peer_bypass as boolean,
+          },
+        }
+      : {}),
     agent_activity:
       isRecord(value.agent_activity) && value.agent_activity.version === 1
         ? { version: 1 }

--- a/web/src/bridge.tsx
+++ b/web/src/bridge.tsx
@@ -20,6 +20,7 @@ import { fetchWithTimeout } from "./fetchWithTimeout";
 import { normalizeHostProfileId, normalizeHostProfileLabel } from "./hostProfile";
 import { addNativeResumeHandler } from "./native";
 import { officeDebug } from "./officeDebug";
+import { trapFocusWithin, useFocusReturn } from "./overlayFocus";
 import {
   parseObservabilityCapability,
   type BridgeObservabilityCapability,
@@ -559,6 +560,7 @@ export function BridgePasswordPrompt({
   const [password, setPassword] = useState("");
   const inputRef = useRef<HTMLInputElement | null>(null);
   const address = new URL(origin).host;
+  useFocusReturn();
 
   useEffect(() => {
     setPassword("");
@@ -570,6 +572,7 @@ export function BridgePasswordPrompt({
       <button
         className="overlay-scrim"
         type="button"
+        tabIndex={-1}
         aria-label="Cancel connection"
         onClick={onCancel}
       />
@@ -581,6 +584,14 @@ export function BridgePasswordPrompt({
         onSubmit={(event) => {
           event.preventDefault();
           if (password) onSubmit(password);
+        }}
+        onKeyDown={(event) => {
+          if (event.key === "Escape") {
+            event.preventDefault();
+            onCancel();
+            return;
+          }
+          trapFocusWithin(event);
         }}
       >
         <div id="bridge-auth-title" className="modal-title">Connect to Herdr</div>

--- a/web/src/bridgeApi.test.ts
+++ b/web/src/bridgeApi.test.ts
@@ -104,6 +104,54 @@ describe("authenticated bridge requests", () => {
     expect(fetchMock.mock.calls.filter(([input]) => String(input).endsWith("/api/auth/session"))).toHaveLength(1);
   });
 
+  it("does not let a delayed 401 discard a newer authenticated session", async () => {
+    const tokenA = "a".repeat(64);
+    const tokenB = "b".repeat(64);
+    let sessionCount = 0;
+    let releaseDelayed = () => {};
+    let markDelayedStarted = () => {};
+    const delayedStarted = new Promise<void>((resolve) => { markDelayedStarted = resolve; });
+    const delayedResponse = new Promise<void>((resolve) => { releaseDelayed = resolve; });
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+      const url = String(input);
+      const authorization = new Headers(init?.headers).get("authorization");
+      if (url.endsWith("/api/auth/session")) {
+        sessionCount += 1;
+        return new Response(JSON.stringify({ token: sessionCount === 1 ? tokenA : tokenB }), {
+          status: 200,
+        });
+      }
+      if (url.endsWith("/api/delayed") && authorization === `Bearer ${tokenA}`) {
+        markDelayedStarted();
+        await delayedResponse;
+        return new Response(null, { status: 401 });
+      }
+      if (url.endsWith("/api/rotate") && authorization === `Bearer ${tokenA}`) {
+        return new Response(null, { status: 401 });
+      }
+      return new Response("{}", {
+        status: authorization === `Bearer ${tokenA}` || authorization === `Bearer ${tokenB}`
+          ? 200
+          : 401,
+      });
+    });
+    const prompt = vi.fn(async () => "synthetic-password");
+    setBridgePasswordPromptHandler(prompt);
+
+    await authenticatedFetch(`${bridgeUrl}/api/snapshot`);
+    const delayed = authenticatedFetch(`${bridgeUrl}/api/delayed`);
+    await delayedStarted;
+    await expect(authenticatedFetch(`${bridgeUrl}/api/rotate`)).resolves.toHaveProperty("status", 200);
+    releaseDelayed();
+    await expect(delayed).resolves.toHaveProperty("status", 200);
+
+    expect(prompt).toHaveBeenCalledTimes(2);
+    expect(sessionCount).toBe(2);
+    expect(bridgeWebSocketProtocols(`${bridgeUrl}/ws/events`)).toEqual([
+      `herdr-world-auth.${tokenB}`,
+    ]);
+  });
+
   it("clears an invalidated session and prompts again instead of staying offline", async () => {
     let snapshotRequests = 0;
     let sessions = 0;

--- a/web/src/bridgeApi.test.ts
+++ b/web/src/bridgeApi.test.ts
@@ -13,10 +13,12 @@ afterEach(() => {
   clearBridgeSession(bridgeUrl);
   setBridgePasswordPromptHandler(null);
   vi.restoreAllMocks();
+  vi.unstubAllGlobals();
 });
 
 describe("authenticated bridge requests", () => {
-  it("prompts once, keeps the session in memory, and retries a protected request", async () => {
+  it("prompts once, keeps a tab-scoped session, and retries a protected request", async () => {
+    const storage = installSessionStorage();
     const calls: { url: string; init?: RequestInit }[] = [];
     const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
       const url = String(input);
@@ -46,7 +48,31 @@ describe("authenticated bridge requests", () => {
     expect(bridgeWebSocketProtocols("ws://192.0.2.20:4000/ws/events")).toEqual([
       `herdr-world-auth.${"a".repeat(64)}`,
     ]);
+    expect(storage.setItem).toHaveBeenCalledWith(
+      `herdrWeb.bridgeSession.v1:${encodeURIComponent(bridgeUrl)}`,
+      "a".repeat(64),
+    );
     expect(fetchMock).toHaveBeenCalled();
+  });
+
+  it("restores a bridge session after a page reload without prompting again", async () => {
+    const reloadedBridgeUrl = "http://192.0.2.21:4000";
+    const token = "c".repeat(64);
+    installSessionStorage(new Map([
+      [`herdrWeb.bridgeSession.v1:${encodeURIComponent(reloadedBridgeUrl)}`, token],
+    ]));
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(async (_input, init) => (
+      new Response(null, {
+        status: new Headers(init?.headers).get("authorization") === `Bearer ${token}` ? 200 : 401,
+      })
+    ));
+    const prompt = vi.fn(async () => "synthetic-password");
+    setBridgePasswordPromptHandler(prompt);
+
+    await expect(authenticatedFetch(`${reloadedBridgeUrl}/api/snapshot`)).resolves.toHaveProperty("status", 200);
+    expect(prompt).not.toHaveBeenCalled();
+    expect(fetchMock).toHaveBeenCalledOnce();
+    clearBridgeSession(reloadedBridgeUrl);
   });
 
   it("shares one prompt and authentication request across concurrent 401 responses", async () => {
@@ -135,3 +161,13 @@ describe("authenticated bridge requests", () => {
     expect(fetchMock).toHaveBeenCalled();
   });
 });
+
+function installSessionStorage(values = new Map<string, string>()) {
+  const storage = {
+    getItem: vi.fn((key: string) => values.get(key) ?? null),
+    setItem: vi.fn((key: string, value: string) => values.set(key, value)),
+    removeItem: vi.fn((key: string) => values.delete(key)),
+  };
+  vi.stubGlobal("sessionStorage", storage);
+  return storage;
+}

--- a/web/src/bridgeApi.test.ts
+++ b/web/src/bridgeApi.test.ts
@@ -3,6 +3,7 @@ import {
   authenticatedFetch,
   bridgeWebSocketProtocols,
   clearBridgeSession,
+  refreshBridgeAuthentication,
   setBridgePasswordPromptHandler,
 } from "./bridgeApi";
 
@@ -42,6 +43,9 @@ describe("authenticated bridge requests", () => {
     expect(bridgeWebSocketProtocols(`${bridgeUrl}/ws/events`)).toEqual([
       `herdr-world-auth.${"a".repeat(64)}`,
     ]);
+    expect(bridgeWebSocketProtocols("ws://192.0.2.20:4000/ws/events")).toEqual([
+      `herdr-world-auth.${"a".repeat(64)}`,
+    ]);
     expect(fetchMock).toHaveBeenCalled();
   });
 
@@ -69,5 +73,36 @@ describe("authenticated bridge requests", () => {
     await authenticatedFetch(`${bridgeUrl}/api/snapshot`);
     expect(prompt).toHaveBeenCalledTimes(2);
     expect(sessions).toBe(2);
+  });
+
+  it("reauthenticates after a WebSocket session expires", async () => {
+    let sessionCount = 0;
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+      const url = String(input);
+      if (url.endsWith("/api/auth/session")) {
+        sessionCount += 1;
+        return new Response(JSON.stringify({ token: `token-${sessionCount}`.padEnd(32, "x") }), {
+          status: 200,
+        });
+      }
+      if (url.endsWith("/api/auth/status")) {
+        return new Response(JSON.stringify({ required: true, authenticated: false }), { status: 200 });
+      }
+      return new Response(null, {
+        status: new Headers(init?.headers).has("authorization") ? 200 : 401,
+      });
+    });
+    const prompt = vi.fn()
+      .mockResolvedValueOnce("first-password")
+      .mockResolvedValueOnce("second-password");
+    setBridgePasswordPromptHandler(prompt);
+
+    await authenticatedFetch(`${bridgeUrl}/api/snapshot`);
+    await expect(refreshBridgeAuthentication("ws://192.0.2.20:4000/ws/events")).resolves.toBe(true);
+    expect(prompt).toHaveBeenCalledTimes(2);
+    expect(bridgeWebSocketProtocols("ws://192.0.2.20:4000/ws/events")).toEqual([
+      `herdr-world-auth.${"token-2".padEnd(32, "x")}`,
+    ]);
+    expect(fetchMock).toHaveBeenCalled();
   });
 });

--- a/web/src/bridgeApi.test.ts
+++ b/web/src/bridgeApi.test.ts
@@ -49,6 +49,35 @@ describe("authenticated bridge requests", () => {
     expect(fetchMock).toHaveBeenCalled();
   });
 
+  it("shares one prompt and authentication request across concurrent 401 responses", async () => {
+    let releaseAuthentication = () => {};
+    const authenticationStarted = new Promise<void>((resolve) => {
+      releaseAuthentication = resolve;
+    });
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+      const url = String(input);
+      if (url.endsWith("/api/auth/session")) {
+        await authenticationStarted;
+        return new Response(JSON.stringify({ token: "b".repeat(64) }), { status: 200 });
+      }
+      if (!new Headers(init?.headers).has("authorization")) {
+        return new Response(null, { status: 401 });
+      }
+      return new Response("{}", { status: 200 });
+    });
+    const prompt = vi.fn(async () => "synthetic-password");
+    setBridgePasswordPromptHandler(prompt);
+
+    const first = authenticatedFetch(`${bridgeUrl}/api/snapshot`);
+    const second = authenticatedFetch(`${bridgeUrl}/api/notes`);
+    await vi.waitFor(() => expect(prompt).toHaveBeenCalledOnce());
+    releaseAuthentication?.();
+
+    await expect(Promise.all([first, second])).resolves.toHaveLength(2);
+    expect(prompt).toHaveBeenCalledOnce();
+    expect(fetchMock.mock.calls.filter(([input]) => String(input).endsWith("/api/auth/session"))).toHaveLength(1);
+  });
+
   it("clears an invalidated session and prompts again instead of staying offline", async () => {
     let snapshotRequests = 0;
     let sessions = 0;

--- a/web/src/bridgeApi.test.ts
+++ b/web/src/bridgeApi.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  authenticatedFetch,
+  bridgeWebSocketProtocols,
+  clearBridgeSession,
+  setBridgePasswordPromptHandler,
+} from "./bridgeApi";
+
+const bridgeUrl = "http://192.0.2.20:4000";
+
+afterEach(() => {
+  clearBridgeSession(bridgeUrl);
+  setBridgePasswordPromptHandler(null);
+  vi.restoreAllMocks();
+});
+
+describe("authenticated bridge requests", () => {
+  it("prompts once, keeps the session in memory, and retries a protected request", async () => {
+    const calls: { url: string; init?: RequestInit }[] = [];
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+      const url = String(input);
+      calls.push({ url, init });
+      if (url.endsWith("/api/auth/session")) {
+        return new Response(JSON.stringify({ token: "a".repeat(64) }), { status: 200 });
+      }
+      if (!new Headers(init?.headers).has("authorization")) {
+        return new Response(JSON.stringify({ error: "password required" }), { status: 401 });
+      }
+      return new Response(JSON.stringify({ panes: [] }), { status: 200 });
+    });
+    const prompt = vi.fn(async () => "synthetic-password");
+    setBridgePasswordPromptHandler(prompt);
+
+    await expect(authenticatedFetch(`${bridgeUrl}/api/snapshot`)).resolves.toHaveProperty("status", 200);
+    expect(prompt).toHaveBeenCalledOnce();
+    expect(calls.map(({ url }) => url)).toEqual([
+      `${bridgeUrl}/api/snapshot`,
+      `${bridgeUrl}/api/auth/session`,
+      `${bridgeUrl}/api/snapshot`,
+    ]);
+    expect(calls[1].init?.credentials).toBeUndefined();
+    expect(bridgeWebSocketProtocols(`${bridgeUrl}/ws/events`)).toEqual([
+      `herdr-world-auth.${"a".repeat(64)}`,
+    ]);
+    expect(fetchMock).toHaveBeenCalled();
+  });
+
+  it("clears an invalidated session and prompts again instead of staying offline", async () => {
+    let snapshotRequests = 0;
+    let sessions = 0;
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.endsWith("/api/auth/session")) {
+        sessions += 1;
+        return new Response(JSON.stringify({ token: `token-${sessions}`.padEnd(32, "x") }), { status: 200 });
+      }
+      snapshotRequests += 1;
+      if (snapshotRequests === 1 || snapshotRequests === 3) {
+        return new Response(null, { status: 401 });
+      }
+      return new Response("{}", { status: 200 });
+    });
+    const prompt = vi.fn()
+      .mockResolvedValueOnce("first-password")
+      .mockResolvedValueOnce("second-password");
+    setBridgePasswordPromptHandler(prompt);
+
+    await authenticatedFetch(`${bridgeUrl}/api/snapshot`);
+    await authenticatedFetch(`${bridgeUrl}/api/snapshot`);
+    expect(prompt).toHaveBeenCalledTimes(2);
+    expect(sessions).toBe(2);
+  });
+});

--- a/web/src/bridgeApi.ts
+++ b/web/src/bridgeApi.ts
@@ -6,7 +6,7 @@ type AuthenticatedFetchOptions = {
 };
 
 const bridgeSessions = new Map<string, string>();
-const pendingPasswordPrompts = new Map<string, Promise<string | null>>();
+const pendingAuthentications = new Map<string, Promise<void>>();
 const bridgeReauthenticationNeeded = new Set<string>();
 let passwordPromptHandler: PasswordPromptHandler | null = null;
 
@@ -55,17 +55,7 @@ export async function authenticatedFetch(
 
   bridgeSessions.delete(origin);
   bridgeReauthenticationNeeded.add(origin);
-  let prompt = pendingPasswordPrompts.get(origin);
-  if (!prompt) {
-    prompt = passwordPromptHandler ? passwordPromptHandler(origin) : Promise.resolve(null);
-    pendingPasswordPrompts.set(origin, prompt);
-  }
-  const password = await prompt;
-  pendingPasswordPrompts.delete(origin);
-  if (password === null) {
-    throw new BridgeAuthenticationError();
-  }
-  await authenticateBridge(origin, password, init.signal ?? undefined, timeoutMs);
+  await authenticateBridgeSession(origin, init.signal ?? undefined, timeoutMs);
   const retry = await fetchWithSession(input, init, origin, timeoutMs);
   if (retry.status === 401) {
     bridgeSessions.delete(origin);
@@ -104,17 +94,42 @@ export async function refreshBridgeAuthentication(input: string | URL): Promise<
 
   bridgeSessions.delete(origin);
   bridgeReauthenticationNeeded.add(origin);
-  let prompt = pendingPasswordPrompts.get(origin);
-  if (!prompt) {
-    prompt = passwordPromptHandler ? passwordPromptHandler(origin) : Promise.resolve(null);
-    pendingPasswordPrompts.set(origin, prompt);
-  }
-  const password = await prompt;
-  pendingPasswordPrompts.delete(origin);
-  if (password === null) throw new BridgeAuthenticationError();
-  await authenticateBridge(origin, password);
+  await authenticateBridgeSession(origin);
   bridgeReauthenticationNeeded.delete(origin);
   return true;
+}
+
+function authenticateBridgeSession(
+  origin: string,
+  callerSignal?: AbortSignal,
+  timeoutMs?: number,
+): Promise<void> {
+  const existing = pendingAuthentications.get(origin);
+  if (existing) {
+    return existing;
+  }
+  const created = (async () => {
+    const password = passwordPromptHandler
+      ? await passwordPromptHandler(origin)
+      : null;
+    if (password === null) {
+      throw new BridgeAuthenticationError();
+    }
+    await authenticateBridge(origin, password, callerSignal, timeoutMs);
+    bridgeReauthenticationNeeded.delete(origin);
+  })();
+  pendingAuthentications.set(origin, created);
+  void created.then(
+    () => clearPendingAuthentication(origin, created),
+    () => clearPendingAuthentication(origin, created),
+  );
+  return created;
+}
+
+function clearPendingAuthentication(origin: string, pending: Promise<void>) {
+  if (pendingAuthentications.get(origin) === pending) {
+    pendingAuthentications.delete(origin);
+  }
 }
 
 async function fetchWithSession(

--- a/web/src/bridgeApi.ts
+++ b/web/src/bridgeApi.ts
@@ -1,6 +1,9 @@
 export type BridgeHttpUrl = (path: string, query?: URLSearchParams) => string;
 
 type PasswordPromptHandler = (origin: string) => Promise<string | null>;
+type AuthenticatedFetchOptions = {
+  timeoutMs?: number;
+};
 
 const bridgeSessions = new Map<string, string>();
 const pendingPasswordPrompts = new Map<string, Promise<string | null>>();
@@ -42,9 +45,10 @@ export function bridgeWebSocketProtocols(input: string | URL): string[] {
 export async function authenticatedFetch(
   input: RequestInfo | URL,
   init: RequestInit = {},
+  { timeoutMs }: AuthenticatedFetchOptions = {},
 ): Promise<Response> {
   const origin = bridgeOrigin(input);
-  const first = await fetchWithSession(input, init, origin);
+  const first = await fetchWithSession(input, init, origin, timeoutMs);
   if (first.status !== 401 || !origin || isAuthenticationEndpoint(input)) {
     return first;
   }
@@ -61,8 +65,8 @@ export async function authenticatedFetch(
   if (password === null) {
     throw new BridgeAuthenticationError();
   }
-  await authenticateBridge(origin, password);
-  const retry = await fetchWithSession(input, init, origin);
+  await authenticateBridge(origin, password, init.signal ?? undefined, timeoutMs);
+  const retry = await fetchWithSession(input, init, origin, timeoutMs);
   if (retry.status === 401) {
     bridgeSessions.delete(origin);
     bridgeReauthenticationNeeded.add(origin);
@@ -117,25 +121,54 @@ async function fetchWithSession(
   input: RequestInfo | URL,
   init: RequestInit,
   origin: string | null,
+  timeoutMs?: number,
 ) {
   const headers = new Headers(init.headers);
   const token = origin ? bridgeSessions.get(origin) : undefined;
   if (token) headers.set("authorization", `Bearer ${token}`);
-  return fetch(input, { ...init, headers });
+  if (timeoutMs === undefined) return fetch(input, { ...init, headers });
+
+  const controller = new AbortController();
+  const abortFromCaller = () => controller.abort(init.signal?.reason);
+  if (init.signal?.aborted) {
+    abortFromCaller();
+  } else {
+    init.signal?.addEventListener("abort", abortFromCaller, { once: true });
+  }
+  const timer = globalThis.setTimeout(() => {
+    controller.abort(abortError());
+  }, timeoutMs);
+  try {
+    return await fetch(input, { ...init, headers, signal: controller.signal });
+  } finally {
+    globalThis.clearTimeout(timer);
+    init.signal?.removeEventListener("abort", abortFromCaller);
+  }
 }
 
-async function authenticateBridge(origin: string, password: string) {
+function abortError() {
+  return typeof DOMException === "function"
+    ? new DOMException("Bridge request timed out", "AbortError")
+    : undefined;
+}
+
+async function authenticateBridge(
+  origin: string,
+  password: string,
+  callerSignal?: AbortSignal,
+  timeoutMs?: number,
+) {
   if (new TextEncoder().encode(password).length > 1024) {
     throw new BridgeAuthenticationError("Bridge password is too long");
   }
   let response: Response;
   try {
-    response = await fetch(`${origin}/api/auth/session`, {
+    response = await fetchWithSession(`${origin}/api/auth/session`, {
       method: "POST",
       headers: { "content-type": "application/json" },
       body: JSON.stringify({ password }),
-      signal: AbortSignal.timeout(5000),
-    });
+      signal: callerSignal,
+    }, null, timeoutMs ?? 5000);
   } catch {
     throw new BridgeAuthenticationError("Bridge authentication is unavailable");
   } finally {

--- a/web/src/bridgeApi.ts
+++ b/web/src/bridgeApi.ts
@@ -4,6 +4,7 @@ type PasswordPromptHandler = (origin: string) => Promise<string | null>;
 
 const bridgeSessions = new Map<string, string>();
 const pendingPasswordPrompts = new Map<string, Promise<string | null>>();
+const bridgeReauthenticationNeeded = new Set<string>();
 let passwordPromptHandler: PasswordPromptHandler | null = null;
 
 export class BridgeAuthenticationError extends Error {
@@ -26,7 +27,10 @@ export function setBridgePasswordPromptHandler(handler: PasswordPromptHandler | 
 
 export function clearBridgeSession(input: string | URL) {
   const origin = bridgeOrigin(input);
-  if (origin) bridgeSessions.delete(origin);
+  if (origin) {
+    bridgeSessions.delete(origin);
+    bridgeReauthenticationNeeded.delete(origin);
+  }
 }
 
 export function bridgeWebSocketProtocols(input: string | URL): string[] {
@@ -46,6 +50,7 @@ export async function authenticatedFetch(
   }
 
   bridgeSessions.delete(origin);
+  bridgeReauthenticationNeeded.add(origin);
   let prompt = pendingPasswordPrompts.get(origin);
   if (!prompt) {
     prompt = passwordPromptHandler ? passwordPromptHandler(origin) : Promise.resolve(null);
@@ -60,9 +65,52 @@ export async function authenticatedFetch(
   const retry = await fetchWithSession(input, init, origin);
   if (retry.status === 401) {
     bridgeSessions.delete(origin);
+    bridgeReauthenticationNeeded.add(origin);
     throw new BridgeAuthenticationError();
   }
   return retry;
+}
+
+/**
+ * Check a session after a WebSocket reconnect. Browsers do not expose the
+ * handshake's HTTP 401 to WebSocket clients, so a failed socket alone cannot
+ * trigger the normal password prompt. The status endpoint lets us distinguish
+ * an expired bridge session from a temporarily unavailable bridge.
+ */
+export async function refreshBridgeAuthentication(input: string | URL): Promise<boolean> {
+  const origin = bridgeOrigin(input);
+  if (!origin || (!bridgeSessions.has(origin) && !bridgeReauthenticationNeeded.has(origin))) {
+    return false;
+  }
+  let response: Response;
+  try {
+    response = await fetchWithSession(`${origin}/api/auth/status`, {}, origin);
+  } catch {
+    return false;
+  }
+  if (!response.ok) return false;
+  const payload = (await response.json().catch(() => null)) as {
+    required?: unknown;
+    authenticated?: unknown;
+  } | null;
+  if (payload?.required !== true || payload.authenticated === true) {
+    bridgeReauthenticationNeeded.delete(origin);
+    return false;
+  }
+
+  bridgeSessions.delete(origin);
+  bridgeReauthenticationNeeded.add(origin);
+  let prompt = pendingPasswordPrompts.get(origin);
+  if (!prompt) {
+    prompt = passwordPromptHandler ? passwordPromptHandler(origin) : Promise.resolve(null);
+    pendingPasswordPrompts.set(origin, prompt);
+  }
+  const password = await prompt;
+  pendingPasswordPrompts.delete(origin);
+  if (password === null) throw new BridgeAuthenticationError();
+  await authenticateBridge(origin, password);
+  bridgeReauthenticationNeeded.delete(origin);
+  return true;
 }
 
 async function fetchWithSession(
@@ -107,8 +155,12 @@ async function authenticateBridge(origin: string, password: string) {
 
 function bridgeOrigin(input: string | URL | RequestInfo): string | null {
   try {
-    if (typeof Request !== "undefined" && input instanceof Request) return new URL(input.url).origin;
-    return new URL(String(input), globalThis.location?.origin ?? "http://localhost").origin;
+    const url = typeof Request !== "undefined" && input instanceof Request
+      ? new URL(input.url)
+      : new URL(String(input), globalThis.location?.origin ?? "http://localhost");
+    if (url.protocol === "ws:") url.protocol = "http:";
+    if (url.protocol === "wss:") url.protocol = "https:";
+    return url.origin;
   } catch {
     return null;
   }

--- a/web/src/bridgeApi.ts
+++ b/web/src/bridgeApi.ts
@@ -8,6 +8,7 @@ type AuthenticatedFetchOptions = {
 const bridgeSessions = new Map<string, string>();
 const pendingAuthentications = new Map<string, Promise<void>>();
 const bridgeReauthenticationNeeded = new Set<string>();
+const bridgeSessionStoragePrefix = "herdrWeb.bridgeSession.v1:";
 let passwordPromptHandler: PasswordPromptHandler | null = null;
 
 export class BridgeAuthenticationError extends Error {
@@ -31,14 +32,14 @@ export function setBridgePasswordPromptHandler(handler: PasswordPromptHandler | 
 export function clearBridgeSession(input: string | URL) {
   const origin = bridgeOrigin(input);
   if (origin) {
-    bridgeSessions.delete(origin);
+    forgetBridgeSession(origin);
     bridgeReauthenticationNeeded.delete(origin);
   }
 }
 
 export function bridgeWebSocketProtocols(input: string | URL): string[] {
   const origin = bridgeOrigin(input);
-  const token = origin ? bridgeSessions.get(origin) : undefined;
+  const token = origin ? bridgeSession(origin) : undefined;
   return token ? [`herdr-world-auth.${token}`] : [];
 }
 
@@ -53,12 +54,12 @@ export async function authenticatedFetch(
     return first;
   }
 
-  bridgeSessions.delete(origin);
+  forgetBridgeSession(origin);
   bridgeReauthenticationNeeded.add(origin);
   await authenticateBridgeSession(origin, init.signal ?? undefined, timeoutMs);
   const retry = await fetchWithSession(input, init, origin, timeoutMs);
   if (retry.status === 401) {
-    bridgeSessions.delete(origin);
+    forgetBridgeSession(origin);
     bridgeReauthenticationNeeded.add(origin);
     throw new BridgeAuthenticationError();
   }
@@ -73,7 +74,7 @@ export async function authenticatedFetch(
  */
 export async function refreshBridgeAuthentication(input: string | URL): Promise<boolean> {
   const origin = bridgeOrigin(input);
-  if (!origin || (!bridgeSessions.has(origin) && !bridgeReauthenticationNeeded.has(origin))) {
+  if (!origin || (!bridgeSession(origin) && !bridgeReauthenticationNeeded.has(origin))) {
     return false;
   }
   let response: Response;
@@ -92,7 +93,7 @@ export async function refreshBridgeAuthentication(input: string | URL): Promise<
     return false;
   }
 
-  bridgeSessions.delete(origin);
+  forgetBridgeSession(origin);
   bridgeReauthenticationNeeded.add(origin);
   await authenticateBridgeSession(origin);
   bridgeReauthenticationNeeded.delete(origin);
@@ -139,7 +140,7 @@ async function fetchWithSession(
   timeoutMs?: number,
 ) {
   const headers = new Headers(init.headers);
-  const token = origin ? bridgeSessions.get(origin) : undefined;
+  const token = origin ? bridgeSession(origin) : undefined;
   if (token) headers.set("authorization", `Bearer ${token}`);
   if (timeoutMs === undefined) return fetch(input, { ...init, headers });
 
@@ -195,10 +196,63 @@ async function authenticateBridge(
     );
   }
   const payload = (await response.json().catch(() => null)) as { token?: unknown } | null;
-  if (!payload || typeof payload.token !== "string" || payload.token.length < 32) {
+  if (!payload || !isBridgeSessionToken(payload.token)) {
     throw new BridgeAuthenticationError("Bridge authentication response is invalid");
   }
-  bridgeSessions.set(origin, payload.token);
+  rememberBridgeSession(origin, payload.token);
+}
+
+function bridgeSession(origin: string): string | undefined {
+  const current = bridgeSessions.get(origin);
+  if (current) return current;
+
+  const storage = bridgeSessionStorage();
+  if (!storage) return undefined;
+  try {
+    const stored = storage.getItem(bridgeSessionStorageKey(origin));
+    if (!isBridgeSessionToken(stored)) {
+      if (stored !== null) storage.removeItem(bridgeSessionStorageKey(origin));
+      return undefined;
+    }
+    bridgeSessions.set(origin, stored);
+    return stored;
+  } catch {
+    return undefined;
+  }
+}
+
+function rememberBridgeSession(origin: string, token: string) {
+  bridgeSessions.set(origin, token);
+  try {
+    bridgeSessionStorage()?.setItem(bridgeSessionStorageKey(origin), token);
+  } catch {
+    // Storage may be unavailable; the in-memory session still works until reload.
+  }
+}
+
+function forgetBridgeSession(origin: string) {
+  bridgeSessions.delete(origin);
+  try {
+    bridgeSessionStorage()?.removeItem(bridgeSessionStorageKey(origin));
+  } catch {
+    // Storage may be unavailable or blocked.
+  }
+}
+
+function bridgeSessionStorage(): Storage | null {
+  try {
+    return typeof globalThis.sessionStorage === "undefined" ? null : globalThis.sessionStorage;
+  } catch {
+    return null;
+  }
+}
+
+function bridgeSessionStorageKey(origin: string) {
+  return `${bridgeSessionStoragePrefix}${encodeURIComponent(origin)}`;
+}
+
+function isBridgeSessionToken(value: unknown): value is string {
+  return typeof value === "string" && value.length >= 32 && value.length <= 64;
 }
 
 function bridgeOrigin(input: string | URL | RequestInfo): string | null {

--- a/web/src/bridgeApi.ts
+++ b/web/src/bridgeApi.ts
@@ -4,8 +4,17 @@ type PasswordPromptHandler = (origin: string) => Promise<string | null>;
 type AuthenticatedFetchOptions = {
   timeoutMs?: number;
 };
+type BridgeSessionSnapshot = {
+  token: string | undefined;
+  generation: number;
+};
+type SessionFetchResult = {
+  response: Response;
+  session: BridgeSessionSnapshot | null;
+};
 
 const bridgeSessions = new Map<string, string>();
+const bridgeSessionGenerations = new Map<string, number>();
 const pendingAuthentications = new Map<string, Promise<void>>();
 const bridgeReauthenticationNeeded = new Set<string>();
 const bridgeSessionStoragePrefix = "herdrWeb.bridgeSession.v1:";
@@ -50,20 +59,34 @@ export async function authenticatedFetch(
 ): Promise<Response> {
   const origin = bridgeOrigin(input);
   const first = await fetchWithSession(input, init, origin, timeoutMs);
-  if (first.status !== 401 || !origin || isAuthenticationEndpoint(input)) {
-    return first;
+  if (first.response.status !== 401 || !origin || isAuthenticationEndpoint(input)) {
+    return first.response;
   }
 
-  forgetBridgeSession(origin);
+  const currentUnauthorized = await invalidateCurrentUnauthorized(
+    input,
+    init,
+    origin,
+    timeoutMs,
+    first,
+  );
+  if (currentUnauthorized.response.status !== 401) return currentUnauthorized.response;
   bridgeReauthenticationNeeded.add(origin);
   await authenticateBridgeSession(origin, init.signal ?? undefined, timeoutMs);
   const retry = await fetchWithSession(input, init, origin, timeoutMs);
-  if (retry.status === 401) {
-    forgetBridgeSession(origin);
+  if (retry.response.status === 401) {
+    const currentRetry = await invalidateCurrentUnauthorized(
+      input,
+      init,
+      origin,
+      timeoutMs,
+      retry,
+    );
+    if (currentRetry.response.status !== 401) return currentRetry.response;
     bridgeReauthenticationNeeded.add(origin);
     throw new BridgeAuthenticationError();
   }
-  return retry;
+  return retry.response;
 }
 
 /**
@@ -77,27 +100,31 @@ export async function refreshBridgeAuthentication(input: string | URL): Promise<
   if (!origin || (!bridgeSession(origin) && !bridgeReauthenticationNeeded.has(origin))) {
     return false;
   }
-  let response: Response;
-  try {
-    response = await fetchWithSession(`${origin}/api/auth/status`, {}, origin);
-  } catch {
-    return false;
-  }
-  if (!response.ok) return false;
-  const payload = (await response.json().catch(() => null)) as {
-    required?: unknown;
-    authenticated?: unknown;
-  } | null;
-  if (payload?.required !== true || payload.authenticated === true) {
-    bridgeReauthenticationNeeded.delete(origin);
-    return false;
-  }
+  while (true) {
+    let attempt: SessionFetchResult;
+    try {
+      attempt = await fetchWithSession(`${origin}/api/auth/status`, {}, origin);
+    } catch {
+      return false;
+    }
+    if (!attempt.response.ok) return false;
+    const payload = (await attempt.response.json().catch(() => null)) as {
+      required?: unknown;
+      authenticated?: unknown;
+    } | null;
+    if (payload?.required !== true || payload.authenticated === true) {
+      bridgeReauthenticationNeeded.delete(origin);
+      return false;
+    }
+    if (!attempt.session || !forgetBridgeSession(origin, attempt.session)) {
+      continue;
+    }
 
-  forgetBridgeSession(origin);
-  bridgeReauthenticationNeeded.add(origin);
-  await authenticateBridgeSession(origin);
-  bridgeReauthenticationNeeded.delete(origin);
-  return true;
+    bridgeReauthenticationNeeded.add(origin);
+    await authenticateBridgeSession(origin);
+    bridgeReauthenticationNeeded.delete(origin);
+    return true;
+  }
 }
 
 function authenticateBridgeSession(
@@ -138,11 +165,14 @@ async function fetchWithSession(
   init: RequestInit,
   origin: string | null,
   timeoutMs?: number,
-) {
+): Promise<SessionFetchResult> {
   const headers = new Headers(init.headers);
-  const token = origin ? bridgeSession(origin) : undefined;
+  const session = origin ? bridgeSessionSnapshot(origin) : null;
+  const token = session?.token;
   if (token) headers.set("authorization", `Bearer ${token}`);
-  if (timeoutMs === undefined) return fetch(input, { ...init, headers });
+  if (timeoutMs === undefined) {
+    return { response: await fetch(input, { ...init, headers }), session };
+  }
 
   const controller = new AbortController();
   const abortFromCaller = () => controller.abort(init.signal?.reason);
@@ -155,7 +185,10 @@ async function fetchWithSession(
     controller.abort(abortError());
   }, timeoutMs);
   try {
-    return await fetch(input, { ...init, headers, signal: controller.signal });
+    return {
+      response: await fetch(input, { ...init, headers, signal: controller.signal }),
+      session,
+    };
   } finally {
     globalThis.clearTimeout(timer);
     init.signal?.removeEventListener("abort", abortFromCaller);
@@ -179,12 +212,12 @@ async function authenticateBridge(
   }
   let response: Response;
   try {
-    response = await fetchWithSession(`${origin}/api/auth/session`, {
+    response = (await fetchWithSession(`${origin}/api/auth/session`, {
       method: "POST",
       headers: { "content-type": "application/json" },
       body: JSON.stringify({ password }),
       signal: callerSignal,
-    }, null, timeoutMs ?? 5000);
+    }, null, timeoutMs ?? 5000)).response;
   } catch {
     throw new BridgeAuthenticationError("Herdr authentication is unavailable");
   } finally {
@@ -215,6 +248,7 @@ function bridgeSession(origin: string): string | undefined {
       return undefined;
     }
     bridgeSessions.set(origin, stored);
+    advanceBridgeSessionGeneration(origin);
     return stored;
   } catch {
     return undefined;
@@ -223,6 +257,7 @@ function bridgeSession(origin: string): string | undefined {
 
 function rememberBridgeSession(origin: string, token: string) {
   bridgeSessions.set(origin, token);
+  advanceBridgeSessionGeneration(origin);
   try {
     bridgeSessionStorage()?.setItem(bridgeSessionStorageKey(origin), token);
   } catch {
@@ -230,13 +265,48 @@ function rememberBridgeSession(origin: string, token: string) {
   }
 }
 
-function forgetBridgeSession(origin: string) {
+function forgetBridgeSession(origin: string, expected?: BridgeSessionSnapshot) {
+  if (expected && (
+    (bridgeSessionGenerations.get(origin) ?? 0) !== expected.generation ||
+    bridgeSessions.get(origin) !== expected.token
+  )) {
+    return false;
+  }
   bridgeSessions.delete(origin);
+  advanceBridgeSessionGeneration(origin);
   try {
     bridgeSessionStorage()?.removeItem(bridgeSessionStorageKey(origin));
   } catch {
     // Storage may be unavailable or blocked.
   }
+  return true;
+}
+
+function bridgeSessionSnapshot(origin: string): BridgeSessionSnapshot {
+  const token = bridgeSession(origin);
+  return {
+    token,
+    generation: bridgeSessionGenerations.get(origin) ?? 0,
+  };
+}
+
+function advanceBridgeSessionGeneration(origin: string) {
+  bridgeSessionGenerations.set(origin, (bridgeSessionGenerations.get(origin) ?? 0) + 1);
+}
+
+async function invalidateCurrentUnauthorized(
+  input: RequestInfo | URL,
+  init: RequestInit,
+  origin: string,
+  timeoutMs: number | undefined,
+  initial: SessionFetchResult,
+) {
+  let attempt = initial;
+  while (attempt.response.status === 401) {
+    if (attempt.session && forgetBridgeSession(origin, attempt.session)) return attempt;
+    attempt = await fetchWithSession(input, init, origin, timeoutMs);
+  }
+  return attempt;
 }
 
 function bridgeSessionStorage(): Storage | null {

--- a/web/src/bridgeApi.ts
+++ b/web/src/bridgeApi.ts
@@ -1,5 +1,128 @@
 export type BridgeHttpUrl = (path: string, query?: URLSearchParams) => string;
 
+type PasswordPromptHandler = (origin: string) => Promise<string | null>;
+
+const bridgeSessions = new Map<string, string>();
+const pendingPasswordPrompts = new Map<string, Promise<string | null>>();
+let passwordPromptHandler: PasswordPromptHandler | null = null;
+
+export class BridgeAuthenticationError extends Error {
+  constructor(message = "Bridge password required or rejected") {
+    super(message);
+    this.name = "BridgeAuthenticationError";
+  }
+}
+
+export class BridgeDiagnosticError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "BridgeDiagnosticError";
+  }
+}
+
+export function setBridgePasswordPromptHandler(handler: PasswordPromptHandler | null) {
+  passwordPromptHandler = handler;
+}
+
+export function clearBridgeSession(input: string | URL) {
+  const origin = bridgeOrigin(input);
+  if (origin) bridgeSessions.delete(origin);
+}
+
+export function bridgeWebSocketProtocols(input: string | URL): string[] {
+  const origin = bridgeOrigin(input);
+  const token = origin ? bridgeSessions.get(origin) : undefined;
+  return token ? [`herdr-world-auth.${token}`] : [];
+}
+
+export async function authenticatedFetch(
+  input: RequestInfo | URL,
+  init: RequestInit = {},
+): Promise<Response> {
+  const origin = bridgeOrigin(input);
+  const first = await fetchWithSession(input, init, origin);
+  if (first.status !== 401 || !origin || isAuthenticationEndpoint(input)) {
+    return first;
+  }
+
+  bridgeSessions.delete(origin);
+  let prompt = pendingPasswordPrompts.get(origin);
+  if (!prompt) {
+    prompt = passwordPromptHandler ? passwordPromptHandler(origin) : Promise.resolve(null);
+    pendingPasswordPrompts.set(origin, prompt);
+  }
+  const password = await prompt;
+  pendingPasswordPrompts.delete(origin);
+  if (password === null) {
+    throw new BridgeAuthenticationError();
+  }
+  await authenticateBridge(origin, password);
+  const retry = await fetchWithSession(input, init, origin);
+  if (retry.status === 401) {
+    bridgeSessions.delete(origin);
+    throw new BridgeAuthenticationError();
+  }
+  return retry;
+}
+
+async function fetchWithSession(
+  input: RequestInfo | URL,
+  init: RequestInit,
+  origin: string | null,
+) {
+  const headers = new Headers(init.headers);
+  const token = origin ? bridgeSessions.get(origin) : undefined;
+  if (token) headers.set("authorization", `Bearer ${token}`);
+  return fetch(input, { ...init, headers });
+}
+
+async function authenticateBridge(origin: string, password: string) {
+  if (new TextEncoder().encode(password).length > 1024) {
+    throw new BridgeAuthenticationError("Bridge password is too long");
+  }
+  let response: Response;
+  try {
+    response = await fetch(`${origin}/api/auth/session`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ password }),
+      signal: AbortSignal.timeout(5000),
+    });
+  } catch {
+    throw new BridgeAuthenticationError("Bridge authentication is unavailable");
+  } finally {
+    password = "";
+  }
+  if (!response.ok) {
+    throw new BridgeAuthenticationError(
+      response.status === 429 ? "Too many bridge password attempts; retry shortly" : undefined,
+    );
+  }
+  const payload = (await response.json().catch(() => null)) as { token?: unknown } | null;
+  if (!payload || typeof payload.token !== "string" || payload.token.length < 32) {
+    throw new BridgeAuthenticationError("Bridge authentication response is invalid");
+  }
+  bridgeSessions.set(origin, payload.token);
+}
+
+function bridgeOrigin(input: string | URL | RequestInfo): string | null {
+  try {
+    if (typeof Request !== "undefined" && input instanceof Request) return new URL(input.url).origin;
+    return new URL(String(input), globalThis.location?.origin ?? "http://localhost").origin;
+  } catch {
+    return null;
+  }
+}
+
+function isAuthenticationEndpoint(input: RequestInfo | URL) {
+  try {
+    const value = typeof Request !== "undefined" && input instanceof Request ? input.url : String(input);
+    return new URL(value, globalThis.location?.origin ?? "http://localhost").pathname.startsWith("/api/auth/");
+  } catch {
+    return false;
+  }
+}
+
 export async function apiErrorMessage(response: Response): Promise<string | null> {
   try {
     const parsed = (await response.json()) as { error?: unknown };

--- a/web/src/bridgeApi.ts
+++ b/web/src/bridgeApi.ts
@@ -12,7 +12,7 @@ const bridgeSessionStoragePrefix = "herdrWeb.bridgeSession.v1:";
 let passwordPromptHandler: PasswordPromptHandler | null = null;
 
 export class BridgeAuthenticationError extends Error {
-  constructor(message = "Bridge password required or rejected") {
+  constructor(message = "Password required or rejected by this Herdr") {
     super(message);
     this.name = "BridgeAuthenticationError";
   }
@@ -164,7 +164,7 @@ async function fetchWithSession(
 
 function abortError() {
   return typeof DOMException === "function"
-    ? new DOMException("Bridge request timed out", "AbortError")
+    ? new DOMException("Herdr connection timed out", "AbortError")
     : undefined;
 }
 
@@ -175,7 +175,7 @@ async function authenticateBridge(
   timeoutMs?: number,
 ) {
   if (new TextEncoder().encode(password).length > 1024) {
-    throw new BridgeAuthenticationError("Bridge password is too long");
+    throw new BridgeAuthenticationError("Password is too long");
   }
   let response: Response;
   try {
@@ -186,18 +186,18 @@ async function authenticateBridge(
       signal: callerSignal,
     }, null, timeoutMs ?? 5000);
   } catch {
-    throw new BridgeAuthenticationError("Bridge authentication is unavailable");
+    throw new BridgeAuthenticationError("Herdr authentication is unavailable");
   } finally {
     password = "";
   }
   if (!response.ok) {
     throw new BridgeAuthenticationError(
-      response.status === 429 ? "Too many bridge password attempts; retry shortly" : undefined,
+      response.status === 429 ? "Too many password attempts; retry shortly" : undefined,
     );
   }
   const payload = (await response.json().catch(() => null)) as { token?: unknown } | null;
   if (!payload || !isBridgeSessionToken(payload.token)) {
-    throw new BridgeAuthenticationError("Bridge authentication response is invalid");
+    throw new BridgeAuthenticationError("Herdr authentication response is invalid");
   }
   rememberBridgeSession(origin, payload.token);
 }

--- a/web/src/commands.ts
+++ b/web/src/commands.ts
@@ -1,6 +1,6 @@
 // Mutating commands proxied through the bridge's allow-listed /api/command.
 
-import type { BridgeHttpUrl } from "./bridgeApi";
+import { authenticatedFetch, type BridgeHttpUrl } from "./bridgeApi";
 import type { LaunchSpec, SplitDirection } from "./launch";
 
 export type CommandResult = { type?: string; [key: string]: unknown };
@@ -26,7 +26,7 @@ async function runCommand(
   method: string,
   params: Record<string, unknown>,
 ): Promise<CommandResult> {
-  const response = await fetch(httpUrl("/api/command"), {
+  const response = await authenticatedFetch(httpUrl("/api/command"), {
     method: "POST",
     headers: { "content-type": "application/json" },
     body: JSON.stringify({ method, params }),
@@ -50,7 +50,7 @@ async function runLaunchPreset(
   httpUrl: BridgeHttpUrl,
   body: Record<string, unknown>,
 ): Promise<LaunchPresetResult> {
-  const response = await fetch(httpUrl("/api/launcher-presets/launch"), {
+  const response = await authenticatedFetch(httpUrl("/api/launcher-presets/launch"), {
     method: "POST",
     headers: { "content-type": "application/json" },
     body: JSON.stringify(body),

--- a/web/src/fetchWithTimeout.test.ts
+++ b/web/src/fetchWithTimeout.test.ts
@@ -1,7 +1,10 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { clearBridgeSession, setBridgePasswordPromptHandler } from "./bridgeApi";
 import { fetchWithTimeout } from "./fetchWithTimeout";
 
 afterEach(() => {
+  clearBridgeSession("http://localhost");
+  setBridgePasswordPromptHandler(null);
   vi.unstubAllGlobals();
   vi.useRealTimers();
 });
@@ -50,5 +53,24 @@ describe("fetchWithTimeout", () => {
     await rejection;
     await vi.advanceTimersByTimeAsync(5000);
     expect(fetchMock).toHaveBeenCalledOnce();
+  });
+
+  it("does not spend the network timeout while waiting for a password prompt", async () => {
+    let authenticated = false;
+    vi.stubGlobal("fetch", vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.endsWith("/api/auth/session")) {
+        authenticated = true;
+        return new Response(JSON.stringify({ token: "t".repeat(64) }), { status: 200 });
+      }
+      return new Response(null, { status: authenticated ? 200 : 401 });
+    }));
+    setBridgePasswordPromptHandler(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 30));
+      return "synthetic-password";
+    });
+
+    await expect(fetchWithTimeout("http://localhost/api/snapshot", { timeoutMs: 5 }))
+      .resolves.toHaveProperty("status", 200);
   });
 });

--- a/web/src/fetchWithTimeout.ts
+++ b/web/src/fetchWithTimeout.ts
@@ -8,30 +8,7 @@ export type FetchWithTimeoutInit = RequestInit & {
 
 export async function fetchWithTimeout(
   input: RequestInfo | URL,
-  { timeoutMs = BRIDGE_FETCH_TIMEOUT_MS, signal, ...init }: FetchWithTimeoutInit = {},
+  { timeoutMs = BRIDGE_FETCH_TIMEOUT_MS, ...init }: FetchWithTimeoutInit = {},
 ) {
-  const controller = new AbortController();
-  const abortFromCaller = () => {
-    controller.abort(signal?.reason);
-  };
-  if (signal?.aborted) {
-    abortFromCaller();
-  } else {
-    signal?.addEventListener("abort", abortFromCaller, { once: true });
-  }
-  const timer = globalThis.setTimeout(() => {
-    controller.abort(abortError());
-  }, timeoutMs);
-  try {
-    return await authenticatedFetch(input, { ...init, signal: controller.signal });
-  } finally {
-    globalThis.clearTimeout(timer);
-    signal?.removeEventListener("abort", abortFromCaller);
-  }
-}
-
-function abortError() {
-  return typeof DOMException === "function"
-    ? new DOMException("Bridge request timed out", "AbortError")
-    : undefined;
+  return authenticatedFetch(input, init, { timeoutMs });
 }

--- a/web/src/fetchWithTimeout.ts
+++ b/web/src/fetchWithTimeout.ts
@@ -1,3 +1,5 @@
+import { authenticatedFetch } from "./bridgeApi";
+
 export const BRIDGE_FETCH_TIMEOUT_MS = 5000;
 
 export type FetchWithTimeoutInit = RequestInit & {
@@ -21,7 +23,7 @@ export async function fetchWithTimeout(
     controller.abort(abortError());
   }, timeoutMs);
   try {
-    return await fetch(input, { ...init, signal: controller.signal });
+    return await authenticatedFetch(input, { ...init, signal: controller.signal });
   } finally {
     globalThis.clearTimeout(timer);
     signal?.removeEventListener("abort", abortFromCaller);

--- a/web/src/remoteAccess.test.ts
+++ b/web/src/remoteAccess.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { bridgeAddress, parseRemoteAccessStatus } from "./remoteAccess";
+
+describe("remote access response handling", () => {
+  it("keeps host policies directional and formats IPv6 addresses safely", () => {
+    const status = parseRemoteAccessStatus({
+      remote_access: {
+        enabled: true,
+        accepted_hosts: ["[2001:db8::20]"],
+        allowed_page_origins: ["https://world.example.test"],
+        allowed_bridge_origins: ["http://bridge.example.test:4000"],
+        password_configured: true,
+      },
+      port: 4000,
+      suggestions: ["2001:db8::20"],
+      mutation_allowed: true,
+      apply: { state: "ready", reason: "bridge ready", restored: false },
+    });
+
+    expect(status.remote_access.accepted_hosts).toEqual(["[2001:db8::20]"]);
+    expect(status.remote_access.allowed_page_origins).toEqual(["https://world.example.test"]);
+    expect(status.remote_access.allowed_bridge_origins).toEqual(["http://bridge.example.test:4000"]);
+    expect(bridgeAddress("2001:db8::20", 4000)).toBe("http://[2001:db8::20]:4000");
+  });
+
+  it("rejects malformed or unbounded controller responses", () => {
+    expect(() => parseRemoteAccessStatus({})).toThrow(/malformed/iu);
+    expect(() => parseRemoteAccessStatus({
+      remote_access: {
+        enabled: false,
+        accepted_hosts: ["x".repeat(513)],
+        allowed_page_origins: [],
+        allowed_bridge_origins: [],
+        password_configured: false,
+      },
+      port: 4000,
+      suggestions: [],
+      apply: { state: "ready" },
+    })).toThrow(/malformed/iu);
+  });
+});

--- a/web/src/remoteAccess.test.ts
+++ b/web/src/remoteAccess.test.ts
@@ -1,5 +1,9 @@
-import { describe, expect, it } from "vitest";
-import { bridgeAddress, parseRemoteAccessStatus } from "./remoteAccess";
+import { describe, expect, it, vi } from "vitest";
+import {
+  bridgeAddress,
+  parseRemoteAccessStatus,
+  waitForRemoteAccessReady,
+} from "./remoteAccess";
 
 describe("remote access response handling", () => {
   it("keeps host policies directional and formats IPv6 addresses safely", () => {
@@ -38,4 +42,42 @@ describe("remote access response handling", () => {
       apply: { state: "ready" },
     })).toThrow(/malformed/iu);
   });
+
+  it("does not accept a stale ready status before the requested policy appears", async () => {
+    let allowedBridgeOrigins: string[] = [];
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(async () => {
+      const response = statusResponse(allowedBridgeOrigins);
+      allowedBridgeOrigins = ["http://bridge.example.test:4000"];
+      return new Response(JSON.stringify(response), { status: 200 });
+    });
+
+    const status = await waitForRemoteAccessReady(
+      (path) => path,
+      (next) => next.remote_access.allowed_bridge_origins.length === 1,
+      100,
+      0,
+    );
+
+    expect(status.remote_access.allowed_bridge_origins).toEqual([
+      "http://bridge.example.test:4000",
+    ]);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    fetchMock.mockRestore();
+  });
 });
+
+function statusResponse(allowedBridgeOrigins: string[]) {
+  return {
+    remote_access: {
+      enabled: false,
+      accepted_hosts: [],
+      allowed_page_origins: [],
+      allowed_bridge_origins: allowedBridgeOrigins,
+      password_configured: false,
+    },
+    port: 4000,
+    suggestions: [],
+    mutation_allowed: true,
+    apply: { state: "ready" },
+  };
+}

--- a/web/src/remoteAccess.test.ts
+++ b/web/src/remoteAccess.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
   bridgeAddress,
   parseRemoteAccessStatus,
+  type RemoteAccessStatus,
   waitForRemoteAccessReady,
 } from "./remoteAccess";
 
@@ -18,7 +19,7 @@ describe("remote access response handling", () => {
       port: 4000,
       suggestions: ["2001:db8::20"],
       mutation_allowed: true,
-      apply: { state: "ready", reason: "bridge ready", restored: false },
+      apply: { id: null, state: "ready", reason: "bridge ready", restored: false },
     });
 
     expect(status.remote_access.accepted_hosts).toEqual(["[2001:db8::20]"]);
@@ -39,7 +40,7 @@ describe("remote access response handling", () => {
       },
       port: 4000,
       suggestions: [],
-      apply: { state: "ready" },
+      apply: { id: null, state: "ready" },
     })).toThrow(/malformed/iu);
   });
 
@@ -53,6 +54,7 @@ describe("remote access response handling", () => {
 
     const status = await waitForRemoteAccessReady(
       (path) => path,
+      "requested-apply",
       (next) => next.remote_access.allowed_bridge_origins.length === 1,
       100,
       0,
@@ -64,9 +66,54 @@ describe("remote access response handling", () => {
     expect(fetchMock).toHaveBeenCalledTimes(2);
     fetchMock.mockRestore();
   });
+
+  it("waits for the requested password-only apply instead of accepting an older ready state", async () => {
+    const statuses = [
+      statusResponse([], { id: "older-apply", state: "ready" }),
+      statusResponse([], { id: "requested-apply", state: "applying" }),
+      statusResponse([], { id: "requested-apply", state: "ready" }),
+    ];
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(async () => (
+      new Response(JSON.stringify(statuses.shift()), { status: 200 })
+    ));
+
+    await expect(waitForRemoteAccessReady(
+      (path) => path,
+      "requested-apply",
+      () => true,
+      100,
+      0,
+    )).resolves.toMatchObject({ apply: { id: "requested-apply", state: "ready" } });
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("ignores an earlier failed apply while waiting for a retry", async () => {
+    const statuses = [
+      statusResponse([], { id: "failed-apply", state: "failed", reason: "old failure" }),
+      statusResponse([], { id: "retry-apply", state: "ready" }),
+    ];
+    vi.spyOn(globalThis, "fetch").mockImplementation(async () => (
+      new Response(JSON.stringify(statuses.shift()), { status: 200 })
+    ));
+
+    await expect(waitForRemoteAccessReady(
+      (path) => path,
+      "retry-apply",
+      () => true,
+      100,
+      0,
+    )).resolves.toMatchObject({ apply: { id: "retry-apply", state: "ready" } });
+  });
 });
 
-function statusResponse(allowedBridgeOrigins: string[]) {
+function statusResponse(
+  allowedBridgeOrigins: string[],
+  apply: RemoteAccessStatus["apply"] = {
+    id: "requested-apply",
+    state: "ready",
+    reason: null,
+  },
+) {
   return {
     remote_access: {
       enabled: false,
@@ -78,6 +125,6 @@ function statusResponse(allowedBridgeOrigins: string[]) {
     port: 4000,
     suggestions: [],
     mutation_allowed: true,
-    apply: { state: "ready" },
+    apply,
   };
 }

--- a/web/src/remoteAccess.ts
+++ b/web/src/remoteAccess.ts
@@ -15,11 +15,14 @@ export type RemoteAccessStatus = {
   suggestions: string[];
   mutation_allowed: boolean;
   mutation_reason?: string | null;
-  apply: {
-    state: "applying" | "ready" | "failed";
-    reason?: string | null;
-    restored?: boolean | null;
-  };
+  apply: RemoteAccessApplyStatus;
+};
+
+export type RemoteAccessApplyStatus = {
+  id: string | null;
+  state: "applying" | "ready" | "failed";
+  reason?: string | null;
+  restored?: boolean | null;
 };
 
 export type RemoteAccessDraft = Omit<RemoteAccessModel, "password_configured">;
@@ -40,7 +43,7 @@ export async function applyRemoteAccess(
   draft: RemoteAccessDraft,
   passwordAction: RemotePasswordAction,
   password?: string,
-) {
+): Promise<RemoteAccessApplyStatus & { id: string }> {
   const response = await fetchWithTimeout(httpUrl("/api/local/remote-access"), {
     method: "POST",
     headers: { "content-type": "application/json" },
@@ -51,7 +54,9 @@ export async function applyRemoteAccess(
     }),
   });
   if (!response.ok) throw new Error((await apiErrorMessage(response)) ?? `Remote access failed (${response.status})`);
-  return (await response.json()) as RemoteAccessStatus["apply"];
+  const apply = parseApplyStatus(await response.json());
+  if (!apply.id) throw new Error("Remote access response is missing its apply identifier");
+  return { ...apply, id: apply.id };
 }
 
 export function remoteAccessDraft(status: RemoteAccessStatus): RemoteAccessDraft {
@@ -65,6 +70,7 @@ export function remoteAccessDraft(status: RemoteAccessStatus): RemoteAccessDraft
 
 export async function waitForRemoteAccessReady(
   httpUrl: BridgeHttpUrl,
+  applyId: string,
   expected: (status: RemoteAccessStatus) => boolean = () => true,
   timeoutMs = APPLY_TIMEOUT_MS,
   pollIntervalMs = APPLY_POLL_INTERVAL_MS,
@@ -78,8 +84,12 @@ export async function waitForRemoteAccessReady(
     } catch (error) {
       lastError = error;
     }
-    if (status?.apply.state === "ready" && expected(status)) return status;
-    if (status?.apply.state === "failed") {
+    if (status?.apply.id !== applyId) {
+      await new Promise((resolve) => globalThis.setTimeout(resolve, pollIntervalMs));
+      continue;
+    }
+    if (status.apply.state === "ready" && expected(status)) return status;
+    if (status.apply.state === "failed") {
       throw new Error(status.apply.reason ?? "The bridge could not apply the settings");
     }
     await new Promise((resolve) => globalThis.setTimeout(resolve, pollIntervalMs));
@@ -125,6 +135,7 @@ export async function allowBridgeDestinations(
   }
   const ready = await waitForRemoteAccessReady(
     httpUrl,
+    apply.id,
     (next) => additions.every(
       (origin) => next.remote_access.allowed_bridge_origins.includes(origin),
     ),
@@ -149,10 +160,7 @@ export function parseRemoteAccessStatus(value: unknown): RemoteAccessStatus {
   ) {
     throw new Error("Remote access response is malformed");
   }
-  const apply = value.apply;
-  if (apply.state !== "applying" && apply.state !== "ready" && apply.state !== "failed") {
-    throw new Error("Remote access response is malformed");
-  }
+  const apply = parseApplyStatus(value.apply);
   return {
     remote_access: {
       enabled: model.enabled,
@@ -165,11 +173,22 @@ export function parseRemoteAccessStatus(value: unknown): RemoteAccessStatus {
     suggestions: value.suggestions,
     mutation_allowed: value.mutation_allowed === true,
     mutation_reason: typeof value.mutation_reason === "string" ? value.mutation_reason : null,
-    apply: {
-      state: apply.state,
-      reason: typeof apply.reason === "string" ? apply.reason : null,
-      restored: typeof apply.restored === "boolean" ? apply.restored : null,
-    },
+    apply,
+  };
+}
+
+function parseApplyStatus(value: unknown): RemoteAccessApplyStatus {
+  if (!isRecord(value) ||
+      (value.id !== undefined && value.id !== null &&
+        (typeof value.id !== "string" || !/^[A-Za-z0-9_-]{1,128}$/.test(value.id))) ||
+      (value.state !== "applying" && value.state !== "ready" && value.state !== "failed")) {
+    throw new Error("Remote access response is malformed");
+  }
+  return {
+    id: typeof value.id === "string" ? value.id : null,
+    state: value.state,
+    reason: typeof value.reason === "string" ? value.reason : null,
+    restored: typeof value.restored === "boolean" ? value.restored : null,
   };
 }
 

--- a/web/src/remoteAccess.ts
+++ b/web/src/remoteAccess.ts
@@ -1,0 +1,108 @@
+import { apiErrorMessage, type BridgeHttpUrl } from "./bridgeApi";
+import { fetchWithTimeout } from "./fetchWithTimeout";
+
+export type RemoteAccessModel = {
+  enabled: boolean;
+  accepted_hosts: string[];
+  allowed_page_origins: string[];
+  allowed_bridge_origins: string[];
+  password_configured: boolean;
+};
+
+export type RemoteAccessStatus = {
+  remote_access: RemoteAccessModel;
+  port: number;
+  suggestions: string[];
+  mutation_allowed: boolean;
+  mutation_reason?: string | null;
+  apply: {
+    state: "applying" | "ready" | "failed";
+    reason?: string | null;
+    restored?: boolean | null;
+  };
+};
+
+export type RemoteAccessDraft = Omit<RemoteAccessModel, "password_configured">;
+export type RemotePasswordAction = "keep" | "set" | "remove";
+
+export async function fetchRemoteAccess(httpUrl: BridgeHttpUrl): Promise<RemoteAccessStatus> {
+  const response = await fetchWithTimeout(httpUrl("/api/local/remote-access"));
+  if (!response.ok) throw new Error((await apiErrorMessage(response)) ?? `Remote access failed (${response.status})`);
+  const value: unknown = await response.json();
+  return parseRemoteAccessStatus(value);
+}
+
+export async function applyRemoteAccess(
+  httpUrl: BridgeHttpUrl,
+  draft: RemoteAccessDraft,
+  passwordAction: RemotePasswordAction,
+  password?: string,
+) {
+  const response = await fetchWithTimeout(httpUrl("/api/local/remote-access"), {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      remote_access: draft,
+      password_action: passwordAction,
+      ...(passwordAction === "set" ? { password } : {}),
+    }),
+  });
+  if (!response.ok) throw new Error((await apiErrorMessage(response)) ?? `Remote access failed (${response.status})`);
+  return (await response.json()) as RemoteAccessStatus["apply"];
+}
+
+export function parseRemoteAccessStatus(value: unknown): RemoteAccessStatus {
+  if (!isRecord(value) || !isRecord(value.remote_access) || !isRecord(value.apply)) {
+    throw new Error("Remote access response is malformed");
+  }
+  const model = value.remote_access;
+  if (
+    typeof model.enabled !== "boolean" ||
+    typeof model.password_configured !== "boolean" ||
+    !stringList(model.accepted_hosts) ||
+    !stringList(model.allowed_page_origins) ||
+    !stringList(model.allowed_bridge_origins) ||
+    typeof value.port !== "number" ||
+    !Number.isSafeInteger(value.port) ||
+    !stringList(value.suggestions)
+  ) {
+    throw new Error("Remote access response is malformed");
+  }
+  const apply = value.apply;
+  if (apply.state !== "applying" && apply.state !== "ready" && apply.state !== "failed") {
+    throw new Error("Remote access response is malformed");
+  }
+  return {
+    remote_access: {
+      enabled: model.enabled,
+      accepted_hosts: model.accepted_hosts,
+      allowed_page_origins: model.allowed_page_origins,
+      allowed_bridge_origins: model.allowed_bridge_origins,
+      password_configured: model.password_configured,
+    },
+    port: value.port,
+    suggestions: value.suggestions,
+    mutation_allowed: value.mutation_allowed === true,
+    mutation_reason: typeof value.mutation_reason === "string" ? value.mutation_reason : null,
+    apply: {
+      state: apply.state,
+      reason: typeof apply.reason === "string" ? apply.reason : null,
+      restored: typeof apply.restored === "boolean" ? apply.restored : null,
+    },
+  };
+}
+
+export function bridgeAddress(host: string, port: number) {
+  const displayHost = host.includes(":") && !host.startsWith("[") ? `[${host}]` : host;
+  return `http://${displayHost}:${port}`;
+}
+
+function stringList(value: unknown): value is string[] {
+  return Array.isArray(value) && value.length <= 32 && value.every(
+    (item) => typeof item === "string" && new TextEncoder().encode(item).length <= 512,
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/web/src/remoteAccess.ts
+++ b/web/src/remoteAccess.ts
@@ -25,6 +25,9 @@ export type RemoteAccessStatus = {
 export type RemoteAccessDraft = Omit<RemoteAccessModel, "password_configured">;
 export type RemotePasswordAction = "keep" | "set" | "remove";
 
+const APPLY_TIMEOUT_MS = 20_000;
+const APPLY_POLL_INTERVAL_MS = 500;
+
 export async function fetchRemoteAccess(httpUrl: BridgeHttpUrl): Promise<RemoteAccessStatus> {
   const response = await fetchWithTimeout(httpUrl("/api/local/remote-access"));
   if (!response.ok) throw new Error((await apiErrorMessage(response)) ?? `Remote access failed (${response.status})`);
@@ -49,6 +52,84 @@ export async function applyRemoteAccess(
   });
   if (!response.ok) throw new Error((await apiErrorMessage(response)) ?? `Remote access failed (${response.status})`);
   return (await response.json()) as RemoteAccessStatus["apply"];
+}
+
+export function remoteAccessDraft(status: RemoteAccessStatus): RemoteAccessDraft {
+  return {
+    enabled: status.remote_access.enabled,
+    accepted_hosts: [...status.remote_access.accepted_hosts],
+    allowed_page_origins: [...status.remote_access.allowed_page_origins],
+    allowed_bridge_origins: [...status.remote_access.allowed_bridge_origins],
+  };
+}
+
+export async function waitForRemoteAccessReady(
+  httpUrl: BridgeHttpUrl,
+  expected: (status: RemoteAccessStatus) => boolean = () => true,
+  timeoutMs = APPLY_TIMEOUT_MS,
+  pollIntervalMs = APPLY_POLL_INTERVAL_MS,
+) {
+  const deadline = Date.now() + timeoutMs;
+  let lastError: unknown = null;
+  while (Date.now() < deadline) {
+    let status: RemoteAccessStatus | null = null;
+    try {
+      status = await fetchRemoteAccess(httpUrl);
+    } catch (error) {
+      lastError = error;
+    }
+    if (status?.apply.state === "ready" && expected(status)) return status;
+    if (status?.apply.state === "failed") {
+      throw new Error(status.apply.reason ?? "The bridge could not apply the settings");
+    }
+    await new Promise((resolve) => globalThis.setTimeout(resolve, pollIntervalMs));
+  }
+  throw lastError instanceof Error
+    ? new Error(`The bridge did not become ready: ${lastError.message}`)
+    : new Error("The bridge did not become ready after applying settings");
+}
+
+export function remoteAccessMatchesDraft(
+  status: RemoteAccessStatus,
+  draft: RemoteAccessDraft,
+  passwordConfigured: boolean,
+) {
+  const model = status.remote_access;
+  return model.enabled === draft.enabled &&
+    model.password_configured === passwordConfigured &&
+    sameValues(model.accepted_hosts, draft.accepted_hosts.map(normalizeHost)) &&
+    sameValues(model.allowed_page_origins, draft.allowed_page_origins.map(normalizeOrigin)) &&
+    sameValues(model.allowed_bridge_origins, draft.allowed_bridge_origins.map(normalizeOrigin));
+}
+
+export async function allowBridgeDestinations(
+  httpUrl: BridgeHttpUrl,
+  origins: readonly string[],
+) {
+  const status = await fetchRemoteAccess(httpUrl);
+  const additions = origins.filter(
+    (origin) => !status.remote_access.allowed_bridge_origins.includes(origin),
+  );
+  if (additions.length === 0) return { changed: false, status };
+  if (!status.mutation_allowed) {
+    throw new Error(
+      status.mutation_reason ??
+        "This launch cannot update browser connection permissions automatically.",
+    );
+  }
+  const draft = remoteAccessDraft(status);
+  draft.allowed_bridge_origins = [...draft.allowed_bridge_origins, ...additions];
+  const apply = await applyRemoteAccess(httpUrl, draft, "keep");
+  if (apply.state === "failed") {
+    throw new Error(apply.reason ?? "The bridge could not apply the browser permissions");
+  }
+  const ready = await waitForRemoteAccessReady(
+    httpUrl,
+    (next) => additions.every(
+      (origin) => next.remote_access.allowed_bridge_origins.includes(origin),
+    ),
+  );
+  return { changed: true, status: ready };
 }
 
 export function parseRemoteAccessStatus(value: unknown): RemoteAccessStatus {
@@ -101,6 +182,21 @@ function stringList(value: unknown): value is string[] {
   return Array.isArray(value) && value.length <= 32 && value.every(
     (item) => typeof item === "string" && new TextEncoder().encode(item).length <= 512,
   );
+}
+
+function normalizeHost(value: string) {
+  return value.trim().replace(/^\[|\]$/g, "").replace(/\.$/, "").toLowerCase();
+}
+
+function normalizeOrigin(value: string) {
+  return value.trim().toLowerCase();
+}
+
+function sameValues(left: readonly string[], right: readonly string[]) {
+  const normalizedLeft = [...new Set(left)].sort();
+  const normalizedRight = [...new Set(right)].sort();
+  return normalizedLeft.length === normalizedRight.length &&
+    normalizedLeft.every((value, index) => value === normalizedRight[index]);
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/web/src/runtimeConnection.ts
+++ b/web/src/runtimeConnection.ts
@@ -3,6 +3,7 @@ import type { Dispatch, MutableRefObject, SetStateAction } from "react";
 import { applyActivityMessage, parseActivityEventData, replayActivityMessages } from "./activity";
 import type { ActivityLogEntry } from "./activity";
 import type { BridgeId, BridgeRuntime } from "./bridge";
+import { bridgeWebSocketProtocols } from "./bridgeApi";
 import { createSnapshotRefreshController } from "./refreshCoordinator";
 import { fetchRuntimeSnapshot, RuntimeCache } from "./runtimeClient";
 import type { RuntimeLoadState } from "./runtimeClient";
@@ -560,7 +561,7 @@ function openEventsSocket(
     if (closed) {
       return;
     }
-    const next = new WebSocket(url);
+    const next = new WebSocket(url, bridgeWebSocketProtocols(url));
     socket = next;
     next.addEventListener("open", () => {
       attempts = 0;

--- a/web/src/runtimeConnection.ts
+++ b/web/src/runtimeConnection.ts
@@ -3,7 +3,7 @@ import type { Dispatch, MutableRefObject, SetStateAction } from "react";
 import { applyActivityMessage, parseActivityEventData, replayActivityMessages } from "./activity";
 import type { ActivityLogEntry } from "./activity";
 import type { BridgeId, BridgeRuntime } from "./bridge";
-import { bridgeWebSocketProtocols } from "./bridgeApi";
+import { bridgeWebSocketProtocols, refreshBridgeAuthentication } from "./bridgeApi";
 import { createSnapshotRefreshController } from "./refreshCoordinator";
 import { fetchRuntimeSnapshot, RuntimeCache } from "./runtimeClient";
 import type { RuntimeLoadState } from "./runtimeClient";
@@ -230,7 +230,16 @@ export function RuntimeConnection({
       interval = window.setInterval(refresh, SNAPSHOT_REFRESH_INTERVAL_MS);
     }, SNAPSHOT_REFRESH_INTERVAL_MS + refreshOffset);
 
-    const events = openEventsSocket(wsUrlRef.current, "/ws/events", requestEventRefresh);
+    const events = openEventsSocket(wsUrlRef.current, "/ws/events", requestEventRefresh, {
+      onClose: () => {
+        void refreshBridgeAuthentication(wsUrlRef.current("/ws/events")).catch((error) => {
+          officeDebug("events-socket:reauthentication-failed", {
+            path: "/ws/events",
+            error: error instanceof Error ? error.message : String(error),
+          });
+        });
+      },
+    });
     const activity = openEventsSocket(
       wsUrlRef.current,
       "/ws/activity",
@@ -548,7 +557,7 @@ function openEventsSocket(
   wsUrl: (path: string, query?: URLSearchParams) => string,
   path: string,
   onEvent: (event: MessageEvent) => void,
-  options: { onOpen?: () => void } = {},
+  options: { onOpen?: () => void; onClose?: () => void } = {},
 ) {
   const url = wsUrl(path);
   let socket: WebSocket | null = null;
@@ -584,6 +593,7 @@ function openEventsSocket(
       if (closed || socket !== next || reconnectTimer !== null) {
         return;
       }
+      options.onClose?.();
       const delay = Math.min(500 * 2 ** attempts, 5_000);
       attempts += 1;
       officeDebug("events-socket:close", { path, attempts, retryDelayMs: delay });

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -4840,6 +4840,58 @@ button {
   gap: 6px;
 }
 
+.remote-access-advanced {
+  border: 1px solid var(--line);
+  border-radius: var(--r-sm);
+  color: var(--subtext0);
+  font-size: 12px;
+}
+
+.remote-access-advanced > summary {
+  padding: 8px;
+  color: var(--text);
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.remote-access-advanced-content {
+  display: grid;
+  gap: 9px;
+  padding: 2px 8px 8px;
+}
+
+.remote-access-advanced-actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 7px;
+}
+
+.bridge-destination-settings {
+  max-width: none;
+}
+
+.bridge-destination-notice {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 8px;
+  border: 1px solid color-mix(in srgb, var(--yellow) 45%, var(--line));
+  border-radius: var(--r-sm);
+  color: var(--subtext0);
+  font-size: 11.5px;
+}
+
+.bridge-destination-notice > div {
+  display: grid;
+  gap: 2px;
+}
+
+.bridge-destination-notice strong {
+  color: var(--text);
+}
+
 .remote-access-address {
   flex-wrap: wrap;
   justify-content: space-between;

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -4700,6 +4700,37 @@ button {
   color: var(--overlay1);
 }
 
+.bridge-auth-target {
+  display: grid;
+  gap: 3px;
+  padding: 12px 14px;
+  border: 1px solid color-mix(in srgb, var(--blue) 38%, var(--line));
+  border-radius: var(--r-md);
+  background: color-mix(in srgb, var(--blue) 8%, var(--surface0));
+}
+
+.bridge-auth-target span {
+  color: var(--overlay1);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.bridge-auth-target strong {
+  overflow: hidden;
+  color: var(--text);
+  font-size: 16px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.bridge-auth-target code {
+  overflow-wrap: anywhere;
+  color: var(--blue);
+  font-size: 13px;
+}
+
 .backend-warning {
   color: var(--peach);
 }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -4490,6 +4490,11 @@ button {
   min-width: 0;
 }
 
+.network-area-tabs {
+  max-width: 360px;
+  margin: 10px 0 16px;
+}
+
 .bridge-settings-grid {
   display: grid;
   grid-template-columns: minmax(260px, 1.05fr) minmax(320px, 0.95fr);
@@ -4503,60 +4508,6 @@ button {
   gap: 6px;
   overflow-y: auto;
   padding-right: 2px;
-}
-
-.backend-fleet-summary {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 10px;
-  padding: 8px 9px;
-  border: 1px solid var(--line);
-  border-radius: var(--r-sm);
-  color: var(--subtext0);
-  background: color-mix(in srgb, var(--surface0) 72%, transparent);
-}
-
-.backend-fleet-summary strong,
-.backend-fleet-summary small {
-  display: block;
-}
-
-.backend-fleet-summary strong {
-  color: var(--text);
-  font-size: 11.5px;
-}
-
-.backend-fleet-summary small {
-  margin-top: 2px;
-  font-family: var(--mono);
-  font-size: 10px;
-}
-
-.backend-fleet-actions {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: flex-end;
-  gap: 4px;
-}
-
-.settings-inline-action {
-  padding: 4px 6px;
-  border: 1px solid var(--surface1);
-  border-radius: var(--r-sm);
-  color: var(--subtext0);
-  background: var(--surface0);
-  font-size: 10px;
-}
-
-.settings-inline-action:hover:not(:disabled) {
-  border-color: var(--accent);
-  color: var(--text);
-}
-
-.settings-inline-action:disabled {
-  cursor: default;
-  opacity: 0.45;
 }
 
 .backend-row {
@@ -4645,6 +4596,20 @@ button {
   font-size: 10.5px;
 }
 
+.connection-status {
+  color: var(--overlay1);
+  font-family: var(--ui);
+  font-weight: 600;
+}
+
+.connection-status[data-state="connected"] {
+  color: var(--green);
+}
+
+.connection-status[data-state="offline"] {
+  color: var(--red);
+}
+
 .backend-toggle {
   position: relative;
   width: 34px;
@@ -4695,6 +4660,34 @@ button {
   color: var(--text);
   font-size: 13px;
   font-weight: 600;
+}
+
+.connection-customize {
+  margin-top: 2px;
+}
+
+.connection-customize-content {
+  gap: 12px;
+}
+
+.connection-state {
+  width: fit-content;
+  padding: 3px 7px;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  color: var(--overlay1);
+  font-size: 11px;
+  font-weight: 600;
+}
+
+.connection-state[data-state="connected"] {
+  border-color: color-mix(in srgb, var(--green) 45%, var(--line));
+  color: var(--green);
+}
+
+.connection-state[data-state="offline"] {
+  border-color: color-mix(in srgb, var(--red) 45%, var(--line));
+  color: var(--red);
 }
 
 .backend-note,

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -4740,6 +4740,148 @@ button {
   line-height: 1.5;
 }
 
+.remote-access-settings {
+  max-width: 620px;
+}
+
+.remote-access-toggle-row {
+  padding: 8px 0;
+}
+
+.remote-access-subsection {
+  display: grid;
+  gap: 7px;
+  padding-top: 8px;
+  border-top: 1px solid var(--line);
+  color: var(--subtext0);
+  font-size: 12px;
+}
+
+.remote-access-subsection > strong,
+.remote-access-permission-list > span {
+  color: var(--text);
+  font-size: 12.5px;
+  font-weight: 600;
+}
+
+.remote-access-chip {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 5px 7px;
+  border: 1px solid var(--line);
+  border-radius: var(--r-sm);
+  color: var(--text);
+  background: color-mix(in srgb, var(--surface0) 72%, transparent);
+  font-family: var(--mono);
+  font-size: 10.5px;
+}
+
+.remote-access-chip span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.remote-access-chip button {
+  display: inline-grid;
+  flex: 0 0 auto;
+  width: 20px;
+  height: 20px;
+  padding: 0;
+  place-items: center;
+  border: 0;
+  color: var(--overlay1);
+  background: transparent;
+}
+
+.remote-access-chip button:hover,
+.remote-access-chip button:focus-visible {
+  color: var(--red);
+}
+
+.remote-access-add-row,
+.remote-access-password-row,
+.remote-access-address {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+}
+
+.remote-access-add-row .field,
+.remote-access-password-row .field {
+  min-width: 0;
+  flex: 1 1 auto;
+}
+
+.remote-access-suggestion {
+  display: grid;
+  grid-template-columns: 16px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 6px;
+  border-radius: var(--r-sm);
+  color: var(--subtext0);
+  background: color-mix(in srgb, var(--surface0) 45%, transparent);
+  font-family: var(--mono);
+  font-size: 10.5px;
+}
+
+.remote-access-suggestion small {
+  color: var(--overlay0);
+  font-family: var(--ui);
+  font-size: 10px;
+}
+
+.remote-access-permission-list {
+  display: grid;
+  gap: 6px;
+}
+
+.remote-access-address {
+  flex-wrap: wrap;
+  justify-content: space-between;
+  padding: 8px;
+  border: 1px solid color-mix(in srgb, var(--accent) 42%, var(--line));
+  border-radius: var(--r-sm);
+  color: var(--subtext0);
+}
+
+.remote-access-address code {
+  min-width: 0;
+  overflow: hidden;
+  flex: 1 1 180px;
+  color: var(--text);
+  font-size: 10.5px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.remote-access-apply {
+  display: grid;
+  gap: 2px;
+  padding: 8px;
+  border: 1px solid var(--line);
+  border-radius: var(--r-sm);
+  color: var(--subtext0);
+  font-size: 11.5px;
+  line-height: 1.4;
+}
+
+.remote-access-apply strong {
+  color: var(--text);
+}
+
+.remote-access-apply-applying {
+  border-color: color-mix(in srgb, var(--yellow) 45%, var(--line));
+}
+
+.remote-access-apply-failed {
+  border-color: color-mix(in srgb, var(--red) 55%, var(--line));
+}
+
 .world-settings-health {
   display: flex;
   align-items: center;

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -4788,6 +4788,66 @@ button {
   font-weight: 600;
 }
 
+.remote-access-password-heading,
+.remote-access-password-actions,
+.remote-access-password-pending {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.remote-access-password-heading {
+  justify-content: space-between;
+}
+
+.remote-access-password-heading strong,
+.remote-access-password-pending strong {
+  color: var(--text);
+  font-size: 12.5px;
+  font-weight: 600;
+}
+
+.remote-access-password-state {
+  padding: 2px 7px;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  color: var(--overlay1);
+  font-size: 10.5px;
+  font-weight: 650;
+}
+
+.remote-access-password-state[data-state="on"] {
+  border-color: color-mix(in srgb, var(--green) 42%, var(--line));
+  color: var(--green);
+}
+
+.remote-access-password-state[data-state="pending"] {
+  border-color: color-mix(in srgb, var(--yellow) 42%, var(--line));
+  color: var(--yellow);
+}
+
+.remote-access-password-actions {
+  flex-wrap: wrap;
+}
+
+.remote-access-password-editor {
+  display: grid;
+  gap: 7px;
+}
+
+.remote-access-password-pending {
+  justify-content: space-between;
+  padding: 9px;
+  border: 1px solid color-mix(in srgb, var(--yellow) 42%, var(--line));
+  border-radius: var(--r-sm);
+  background: color-mix(in srgb, var(--yellow) 7%, transparent);
+}
+
+.remote-access-password-pending > div {
+  display: grid;
+  gap: 2px;
+}
+
 .remote-access-chip {
   display: flex;
   min-width: 0;


### PR DESCRIPTION
## Summary

Implements Spec 019 with a progressive-disclosure network UX over the existing direct HTTP/WebSocket bridge transport:

- Replaces the separate Bridges and sharing areas with one **Network** area containing **Connections** and **Allow connections**.
- Makes the normal outbound flow **Add connection → Herdr address → Connect**. New connections are saved and enabled immediately; optional name and color controls are under **Customize connection**.
- Makes the normal inbound flow a single **Allow connections to this Herdr** control with a copyable address and password controls.
- Keeps exact Host, browser-origin, and destination restrictions under **Advanced network permissions**, with direction-specific plain-language labels.
- Uses Herdr/connection terminology in normal UI and keeps bridge terminology for protocol, implementation, and developer diagnostics.

The networking and security architecture remains intact: exact Host/origin/CSP policy, loopback-only local management authorization, Argon2id password verification, authenticated HTTP and WebSocket routes, bounded attempts, managed restart/readiness, and rollback are preserved.

## Authentication behaviour

- Passwords are never stored by the client.
- The bearer session token is retained only in the current tab, so an ordinary page refresh does not ask for the password again.
- Restarting the target Herdr invalidates its in-memory sessions and therefore asks connected clients for the password again. The prompt now explains this explicitly. Avoiding that would require a separate secure persistent-session design.

## Security boundary

Direct HTTP/WebSocket connections are intended for a trusted LAN or VPN; the UI warns that a password does not encrypt traffic. The owner-approved initial loopback exception is unchanged: an actual loopback TCP peer is treated as local, so an operator-created proxy or SSH forward terminating on loopback must supply its own trust boundary.

## Validation

- `npm run check` passed, including 517 web tests, 119 compatibility-crate tests, 178 bridge tests, lint/formatting, privacy, dependency notices, release/development suites, and production builds.
- Full Playwright coverage passed locally (63 passed, 2 environment-gated skips), including allow-connections configuration, address-only connection creation/enabling, authentication, refresh token reuse, destination permission reload, and connection diagnostics.
- The Connections, Add connection, and Allow connections views were visually checked at desktop and phone viewport sizes.
- All required GitHub checks pass on the latest head, including four browser shards, the main repository check, and both macOS lifecycle jobs.
