### PR TITLE
Align Tree toolbar and show zoom percentage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ Web's own release history remains in its upstream changelog.
 ### Added
 
 - Added a statically bundled Tree World theme with a bounded host-to-space-to-agent/terminal
-  hierarchy, searchable ancestor context, branch collapse, pan/zoom/fit controls, operational
+  hierarchy, searchable ancestor context, branch collapse, pan/zoom/fit controls with a current
+  zoom percentage, operational
   details and guarded terminal/Spaces actions, plus an accessible compact semantic presentation.
   ([#81](https://github.com/IvoryHeart/herdr-world/pull/81))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ Web's own release history remains in its upstream changelog.
   hierarchy, searchable ancestor context, branch collapse, pan/zoom/fit controls with a current
   zoom percentage, operational
   details and guarded terminal/Spaces actions, plus an accessible compact semantic presentation.
-  ([#81](https://github.com/IvoryHeart/herdr-world/pull/81))
+  ([#81](https://github.com/IvoryHeart/herdr-world/pull/81),
+  [#83](https://github.com/IvoryHeart/herdr-world/pull/83))
 
 - Added repository OpenSpec contracts, agent skills, shared worktree tooling, bounded Ralph
   execution from a short goal with resumable interviews, persistent role histories and

--- a/web/src/world/tree/TreeTheme.css
+++ b/web/src/world/tree/TreeTheme.css
@@ -9,15 +9,17 @@
   color: #e7edf5;
   background: radial-gradient(ellipse at 48% 30%, #10202b66, transparent 65%), #090f16;
 }
-.tree-stage-bar { z-index: 3; display: flex; align-items: center; gap: 10px; min-height: 58px; padding: 9px 14px; border-bottom: 1px solid var(--tree-line); background: #0c131c; }
-.tree-stage-heading { display: grid; min-width: 150px; }
-.tree-stage-heading strong { font-size: 14px; }
-.tree-stage-heading span { color: var(--tree-muted); font-size: 11px; }
-.tree-search { display: flex; align-items: center; gap: 7px; width: min(340px, 36vw); margin-left: auto; padding: 0 10px; border: 1px solid var(--tree-line); border-radius: 7px; background: #090f16; }
+.tree-stage-bar { position: relative; z-index: 3; display: flex; min-width: 0; min-height: 54px; flex: 0 0 auto; align-items: center; gap: 10px; padding: 7px 12px; border-bottom: 1px solid var(--tree-line); background: #0c131c; }
+.tree-stage-heading { display: grid; min-width: 130px; gap: 2px; }
+.tree-stage-heading strong { font-size: 13px; }
+.tree-stage-heading span { color: var(--tree-muted); font-size: 9px; }
+.tree-search { display: flex; min-width: 150px; max-width: 420px; height: 34px; flex: 1 1 260px; align-items: center; gap: 7px; padding: 0 10px; border: 1px solid var(--tree-line); border-radius: 7px; background: #090f16; }
 .tree-search:focus-within { border-color: #74c4ff; }
-.tree-search input { width: 100%; height: 34px; border: 0; outline: 0; color: #e7edf5; background: transparent; }
-.tree-zoom-controls { display: flex; gap: 4px; }
-.tree-fit { gap: 6px; white-space: nowrap; }
+.tree-search input { min-width: 0; flex: 1 1 auto; border: 0; outline: 0; color: #e7edf5; background: transparent; font: inherit; font-size: 11px; }
+.tree-zoom-controls { display: inline-flex; flex: 0 0 auto; align-items: center; gap: 3px; }
+.tree-zoom-button { width: 34px; min-width: 34px; min-height: 34px; }
+.tree-zoom-readout { display: inline-flex; min-width: 38px; min-height: 34px; align-items: center; justify-content: center; color: var(--tree-muted); font-size: 11px; font-variant-numeric: tabular-nums; white-space: nowrap; }
+.tree-fit { display: inline-flex; min-height: 34px; align-items: center; gap: 6px; white-space: nowrap; }
 .tree-overview { display: flex; align-items: center; flex-wrap: wrap; gap: 10px 22px; padding: 11px 18px; border-bottom: 1px solid var(--tree-line); color: var(--tree-muted); font-size: 11px; }
 .tree-overview strong { color: #e7edf5; font-size: 13px; }
 .tree-legend { display: flex; gap: 15px; margin-left: auto; }

--- a/web/src/world/tree/TreeTheme.test.tsx
+++ b/web/src/world/tree/TreeTheme.test.tsx
@@ -132,6 +132,18 @@ describe("Tree theme", () => {
     expect(new Set(codexNames).size).toBe(2);
   });
 
+  it("shows the current zoom and updates it after zooming in", async () => {
+    const { container } = await render(context());
+    const zoom = () => container.querySelector<HTMLOutputElement>("output[aria-label='Current zoom']");
+
+    expect(zoom()?.textContent).toBe("100%");
+
+    const zoomIn = container.querySelector<HTMLButtonElement>("button[aria-label='Zoom in']");
+    await act(async () => zoomIn?.click());
+
+    expect(zoom()?.textContent).toBe("115%");
+  });
+
   it("exercises Fit, zoom, wheel, and pointer handlers within camera bounds and persists them", async () => {
     const { container } = await render(context());
     const viewport = container.querySelector<HTMLDivElement>(".tree-viewport");

--- a/web/src/world/tree/TreeTheme.tsx
+++ b/web/src/world/tree/TreeTheme.tsx
@@ -163,8 +163,9 @@ function TreeStage({ context }: { context: WorldThemeContext }) {
       <header className="tree-stage-bar">
         <button className="icon-btn" type="button"
           aria-label={context.compact ? "Back to Herdr sidebar" : "Toggle sidebar"}
+          title={context.compact ? "Back" : "Toggle sidebar"}
           onClick={context.compact ? context.onBackToSidebar : context.onToggleSidebar}>
-          {context.compact ? <ChevronLeft size={20} /> : <PanelLeft size={18} />}
+          {context.compact ? <ChevronLeft size={20} aria-hidden="true" /> : <PanelLeft size={18} aria-hidden="true" />}
         </button>
         <div className="tree-stage-heading"><strong>World Tree</strong><span>
           {projection.coverage.presentedHosts} hosts · {projection.coverage.presentedSpaces} spaces · {projection.coverage.presentedTerminals} leaves
@@ -175,10 +176,11 @@ function TreeStage({ context }: { context: WorldThemeContext }) {
             onChange={(event) => setQuery(event.currentTarget.value)} />
         </label>
         <div className="tree-zoom-controls" role="group" aria-label="Tree zoom controls">
-          <button className="icon-btn" type="button" aria-label="Zoom out" onClick={() => zoomBy(0.85)}><ZoomOut size={16} /></button>
-          <button className="icon-btn" type="button" aria-label="Zoom in" onClick={() => zoomBy(1.15)}><ZoomIn size={16} /></button>
+          <button className="icon-btn tree-zoom-button" type="button" aria-label="Zoom out" title="Zoom out" onClick={() => zoomBy(0.85)}><ZoomOut size={16} aria-hidden="true" /></button>
+          <output className="tree-zoom-readout" aria-label="Current zoom">{Math.round(camera.zoom * 100)}%</output>
+          <button className="icon-btn tree-zoom-button" type="button" aria-label="Zoom in" title="Zoom in" onClick={() => zoomBy(1.15)}><ZoomIn size={16} aria-hidden="true" /></button>
         </div>
-        <button className="btn tree-fit" type="button" onClick={fit}><Maximize2 size={14} />Fit tree</button>
+        <button className="btn tree-fit" type="button" onClick={fit}><Maximize2 size={14} aria-hidden="true" />Fit tree</button>
       </header>
       <section className="tree-overview" aria-label="Tree operational overview">
         <span><strong>{projection.coverage.presentedHosts}</strong> of {projection.coverage.configuredHosts} configured hosts</span>


### PR DESCRIPTION
The Tree toolbar previously used looser, Tree-specific sizing and gave no numeric feedback while zooming. This aligns its bar, search, zoom buttons, and Fit action with the Graph view and adds a live whole-number percentage between the zoom controls, driven directly by the existing bounded camera state.

The focused component test covers the initial `100%` value and a real zoom action. The existing compact layout continues to hide desktop zoom controls.

Validation:

- `npm run check`
- `npx playwright test tests/e2e/world-tree.spec.ts` (7 passed)
- `npm run spec:check` (6 strict validations passed)
- Rendered inspection at 1536px desktop and 390px compact widths using the synthetic Tree fixture
- Scoped task review and final whole-branch review found no issues

Execution used Superpowers 6.3.0 and native Codex with sequential implementation writers and independent native review. This PR targets and depends on #78.
