### PR TITLE
Add collapsed sidebar theme switcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ Web's own release history remains in its upstream changelog.
 
 ### Added
 
+- Added a compact in-stage switcher for Spaces, Office, Graph and Tree when the common desktop
+  sidebar is collapsed.
+
 - Added a statically bundled Tree World theme with a bounded host-to-space-to-agent/terminal
   hierarchy, searchable ancestor context, branch collapse, pan/zoom/fit controls with a current
   zoom percentage, operational

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Web's own release history remains in its upstream changelog.
 ### Added
 
 - Added a compact in-stage switcher for Spaces, Office, Graph and Tree when the common desktop
-  sidebar is collapsed.
+  sidebar is collapsed. ([#84](https://github.com/IvoryHeart/herdr-world/pull/84))
 
 - Added a statically bundled Tree World theme with a bounded host-to-space-to-agent/terminal
   hierarchy, searchable ancestor context, branch collapse, pan/zoom/fit controls with a current

--- a/tests/e2e/responsive.spec.ts
+++ b/tests/e2e/responsive.spec.ts
@@ -93,3 +93,64 @@ test("keeps the terminal responsive through rapid window resizing", async ({ pag
   await page.reload();
   await expect(page.locator(".terminal-stage")).toBeVisible();
 });
+
+test("keeps narrow-stage header actions above the collapsed-sidebar theme switcher", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 1440, height: 900 });
+  await page.goto("/spaces");
+  const refit = page.getByRole("button", { name: "Refit terminal" });
+  await expect(refit).toBeVisible();
+
+  await page.getByRole("button", { name: "Toggle sidebar" }).click();
+  await expect(page.locator(".app")).toHaveAttribute("data-sidebar", "closed");
+  await page.locator(".stage > .stage-bar").getByRole("button", { name: "Notes" }).click();
+  await expect(page.locator(".app")).toHaveAttribute("data-notes", "open");
+  await page.setViewportSize({ width: 821, height: 900 });
+  await expect.poll(async () =>
+    Math.round((await page.locator(".stage").boundingBox())?.width ?? 0),
+  ).toBe(261);
+
+  await page.screenshot({
+    path: resolve(evidenceDir, "responsive-821x900-collapsed-notes.png"),
+    animations: "disabled",
+  });
+  const refitBox = await refit.boundingBox();
+  expect(refitBox).not.toBeNull();
+  const hitTargetLabel = await page.evaluate(({ x, y }) => {
+    const target = document.elementFromPoint(x, y);
+    return target?.closest("button")?.getAttribute("aria-label") ?? null;
+  }, {
+    x: refitBox!.x + refitBox!.width / 2,
+    y: refitBox!.y + refitBox!.height / 2,
+  });
+  expect(hitTargetLabel).toBe("Refit terminal");
+});
+
+test("keeps the collapsed-sidebar theme switcher inside an empty Spaces header", async ({
+  page,
+  request,
+}) => {
+  await request.post("http://127.0.0.1:4173/__fixture/state", {
+    data: { hostId: "host-a", snapshotVariant: "empty" },
+  });
+  await page.setViewportSize({ width: 1440, height: 900 });
+  await page.goto("/spaces");
+  await expect(page.locator(".stage-sub")).toHaveText("no pane selected");
+  await page.getByRole("button", { name: "Toggle sidebar" }).click();
+  await expect(page.locator(".app")).toHaveAttribute("data-sidebar", "closed");
+  await expect(page.locator(".tabbar")).toHaveCount(0);
+
+  const headerBox = await page.locator(".stage > .stage-bar").boundingBox();
+  const switcherBox = await page.locator(".stage-theme-switcher").boundingBox();
+  expect(headerBox).not.toBeNull();
+  expect(switcherBox).not.toBeNull();
+  expect(switcherBox!.y).toBeGreaterThanOrEqual(headerBox!.y);
+  expect(switcherBox!.y + switcherBox!.height).toBeLessThanOrEqual(
+    headerBox!.y + headerBox!.height,
+  );
+  await page.screenshot({
+    path: resolve(evidenceDir, "responsive-empty-spaces-switcher.png"),
+    animations: "disabled",
+  });
+});

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -171,6 +171,7 @@ import { terminalSessionDescriptor } from "./terminalSessions";
 import { coreSurfaceRegistry } from "./surfaceRegistry";
 import { SurfaceSlotBoundary } from "./SurfaceSlotBoundary";
 import { SidebarToolbar } from "./SidebarToolbar";
+import type { ToolbarPrimaryView } from "./SidebarToolbar";
 import {
   officeAgentHandoffRequest,
   officeRoomHandoffRequest,
@@ -3244,6 +3245,29 @@ export function App() {
     setShowDetail(false);
   };
 
+  const currentPrimaryView = activeSurface.id === "spaces" ? "spaces" : activeWorldTheme.id;
+  const selectPrimaryView = (view: ToolbarPrimaryView) => {
+    if (view === currentPrimaryView) {
+      return;
+    }
+    compactViewFocusRef.current = true;
+    if (view === "spaces") {
+      worldSelectionSeedPendingRef.current = false;
+      navigatePrimaryView("spaces");
+      return;
+    }
+    worldSelectionSeedPendingRef.current = activeSurface.id !== "world";
+    navigateWorldTheme(
+      view,
+      isCompactLayout
+        ? withMobileDetailHistoryState(window.history.state)
+        : undefined,
+    );
+    if (isCompactLayout) {
+      openMobileDetail();
+    }
+  };
+
   const openPane = (bridgeId: BridgeId, pane: PaneInfo) => {
     compactViewFocusRef.current = false;
     const runtime = bridge.getRuntime(bridgeId);
@@ -4918,28 +4942,7 @@ export function App() {
           bridgeViews={bridgeViews}
           primaryView={activeSurface.id}
           activeWorldTheme={activeWorldTheme}
-          onView={(view) => {
-            const currentView = activeSurface.id === "spaces" ? "spaces" : activeWorldTheme.id;
-            if (view === currentView) {
-              return;
-            }
-            compactViewFocusRef.current = true;
-            if (view === "spaces") {
-              worldSelectionSeedPendingRef.current = false;
-              navigatePrimaryView("spaces");
-              return;
-            }
-            worldSelectionSeedPendingRef.current = activeSurface.id !== "world";
-            navigateWorldTheme(
-              view,
-              isCompactLayout
-                ? withMobileDetailHistoryState(window.history.state)
-                : undefined,
-            );
-            if (isCompactLayout) {
-              openMobileDetail();
-            }
-          }}
+          onView={selectPrimaryView}
           onOpenCurrentView={isCompactLayout && activeSurface.id === "world" ? () => {
             compactViewFocusRef.current = true;
             openMobileDetail();
@@ -5103,6 +5106,8 @@ export function App() {
       <HerdrMainStage
         label={activeSurface.id === "world" ? `World ${activeWorldTheme.label}` : "Terminal"}
         inert={isCompactLayout && !showDetail ? true : undefined}
+        activeView={currentPrimaryView}
+        onView={selectPrimaryView}
       >
         {activeSurface.id === "world" ? worldStage : (
           <>

--- a/web/src/AppNavigation.test.tsx
+++ b/web/src/AppNavigation.test.tsx
@@ -1,0 +1,235 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { App } from "./App";
+import { CoreNavigationProvider } from "./CoreNavigation";
+import { coreSurfaceRegistry } from "./surfaceRegistry";
+import type { BridgeRuntime } from "./bridge";
+import type { HostProfile } from "./hostProfile";
+import type { BridgeConnectionRef, BridgeConnectionState } from "./runtimeConnection";
+import type { Snapshot } from "./types";
+
+const testState = vi.hoisted(() => ({
+  hostRegistry: null as unknown,
+  federatedRuntime: null as unknown,
+}));
+
+vi.mock("./hostRegistry", () => ({
+  useHostRegistry: () => testState.hostRegistry,
+}));
+
+vi.mock("./federatedRuntime", () => ({
+  useFederatedRuntime: () => testState.federatedRuntime,
+}));
+
+vi.mock("./TerminalView", () => ({
+  TerminalView: () => <div>Selected Spaces terminal</div>,
+}));
+
+vi.mock("./world/WorldSurface", () => ({
+  default: ({ context }: { context?: { selectedKey?: string | null } }) => (
+    <output data-testid="world-selection">{context?.selectedKey ?? "none"}</output>
+  ),
+  isWorldSurfaceContext: (value: unknown) => Boolean(value && typeof value === "object"),
+}));
+
+const roots: Root[] = [];
+
+beforeEach(() => {
+  (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean })
+    .IS_REACT_ACT_ENVIRONMENT = true;
+  window.history.replaceState({}, "", "/spaces");
+  window.localStorage.clear();
+  window.sessionStorage.clear();
+  window.localStorage.setItem(
+    "herdr.mobileWeb.displayPrefs.v2",
+    JSON.stringify({ sidebarOpen: false, notesEnabled: false }),
+  );
+  window.localStorage.setItem(
+    "herdr.mobileWeb.sharedNavigation.v1",
+    JSON.stringify({
+      selectedBridgeId: "host-a",
+      selectedPane: { bridgeId: "host-a", paneId: "pane-a" },
+      activeWorkspace: { bridgeId: "host-a", workspaceId: "space-a" },
+      selectedPanesByBridgeId: { "host-a": "pane-a" },
+      activeWorkspacesByBridgeId: { "host-a": "space-a" },
+    }),
+  );
+  Object.defineProperty(window, "innerWidth", { configurable: true, value: 1200 });
+  Object.defineProperty(window, "matchMedia", {
+    configurable: true,
+    value: vi.fn((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+  vi.spyOn(window, "requestAnimationFrame").mockImplementation((callback) => {
+    callback(0);
+    return 1;
+  });
+  vi.spyOn(window, "cancelAnimationFrame").mockImplementation(() => {});
+
+  const snapshot = selectedSpacesSnapshot();
+  const runtime = bridgeRuntime();
+  const connectionState: BridgeConnectionState = {
+    connectionKey: runtime.generationKey,
+    snapshot,
+    loadState: "ready",
+  };
+  const connectionRef: BridgeConnectionRef = {
+    connectionKey: runtime.generationKey,
+    snapshot,
+    activityGeneration: 0,
+    resyncBarrierGeneration: 0,
+    sharedSelectionOverride: null,
+    recoveryRequired: false,
+    awaitingCapabilityHandshake: false,
+  };
+  const profile: HostProfile = {
+    schemaVersion: 1,
+    profileId: runtime.id,
+    label: runtime.label,
+    baseUrl: "https://host-a.example.test",
+    enabled: true,
+    displayOrder: 0,
+  };
+
+  testState.hostRegistry = {
+    availableRuntimes: [runtime],
+    enabledRuntimes: [runtime],
+    enabledBridgeIds: [runtime.id],
+    profiles: [profile],
+    storeLoaded: true,
+    lastSelectedBridgeId: runtime.id,
+    getRuntime: (bridgeId: string | null | undefined) => bridgeId === runtime.id ? runtime : null,
+    setLastSelectedBridgeId: vi.fn(),
+    markBridgeUsed: vi.fn(),
+    retryBridgeProbe: vi.fn(),
+    routeTarget: vi.fn(() => runtime),
+  };
+  testState.federatedRuntime = {
+    connectionStates: { [runtime.id]: connectionState },
+    setConnectionStates: vi.fn(),
+    connectionRefs: { current: { [runtime.id]: connectionRef } },
+    runtimeCache: {},
+    refreshSnapshot: vi.fn(),
+    setObservers: vi.fn(),
+    setFollowSharedSelection: vi.fn(),
+  };
+});
+
+afterEach(async () => {
+  await act(async () => {
+    for (const root of roots.splice(0)) root.unmount();
+  });
+  document.body.innerHTML = "";
+  vi.restoreAllMocks();
+});
+
+describe("App view navigation", () => {
+  it("seeds the selected Spaces pane when the collapsed strip opens a World view", async () => {
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => {
+      root.render(
+        <CoreNavigationProvider registry={coreSurfaceRegistry}>
+          <App />
+        </CoreNavigationProvider>,
+      );
+    });
+
+    const office = container.querySelector<HTMLButtonElement>("[aria-label='Switch to Office']");
+    expect(office).not.toBeNull();
+    await act(async () => {
+      office?.click();
+      await Promise.resolve();
+    });
+    await waitForWorldSurface(container);
+
+    expect(container.querySelector("[data-testid='world-selection']")?.textContent).toBe(
+      '["host-a","terminal","terminal-a"]',
+    );
+  });
+});
+
+async function waitForWorldSurface(container: HTMLElement) {
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    if (container.querySelector("[data-testid='world-selection']")) {
+      return;
+    }
+    await act(async () => {
+      await new Promise((resolve) => window.setTimeout(resolve, 0));
+    });
+  }
+  throw new Error("World surface did not render");
+}
+
+function bridgeRuntime(): BridgeRuntime {
+  return {
+    id: "host-a",
+    mode: "configured",
+    label: "Host A",
+    color: "#89b4fa",
+    backend: null,
+    connectionKey: "host-a-connection",
+    capabilityGeneration: 1,
+    generationKey: "host-a-generation-1",
+    resumeToken: 0,
+    capabilities: {
+      commands: [],
+      features: ["snapshot", "terminal_attach"],
+    },
+    capabilityState: "ready",
+    capabilityError: null,
+    canConnect: true,
+    httpUrl: (path) => `https://host-a.example.test${path}`,
+    wsUrl: (path) => `wss://host-a.example.test${path}`,
+  };
+}
+
+function selectedSpacesSnapshot(): Snapshot {
+  return {
+    workspaces: [{
+      workspace_id: "space-a",
+      number: 1,
+      label: "Synthetic space",
+      focused: true,
+      pane_count: 1,
+      tab_count: 1,
+      active_tab_id: "tab-a",
+      agent_status: "working",
+    }],
+    tabs: [{
+      tab_id: "tab-a",
+      workspace_id: "space-a",
+      number: 1,
+      label: "Synthetic tab",
+      focused: true,
+      pane_count: 1,
+      agent_status: "working",
+    }],
+    panes: [{
+      pane_id: "pane-a",
+      terminal_id: "terminal-a",
+      workspace_id: "space-a",
+      tab_id: "tab-a",
+      focused: true,
+      display_agent: "Synthetic agent",
+      agent_status: "working",
+      revision: 1,
+    }],
+    layouts: [],
+    selected_pane_id: "pane-a",
+  };
+}

--- a/web/src/AppNavigation.test.tsx
+++ b/web/src/AppNavigation.test.tsx
@@ -86,10 +86,12 @@ beforeEach(() => {
     loadState: "ready",
   };
   const connectionRef: BridgeConnectionRef = {
+    profileConnectionKey: runtime.connectionKey,
     connectionKey: runtime.generationKey,
     snapshot,
     activityGeneration: 0,
     resyncBarrierGeneration: 0,
+    activityLog: [],
     sharedSelectionOverride: null,
     recoveryRequired: false,
     awaitingCapabilityHandshake: false,

--- a/web/src/HerdrClientFrame.test.tsx
+++ b/web/src/HerdrClientFrame.test.tsx
@@ -4,7 +4,7 @@ import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { CoreNavigationProvider } from "./CoreNavigation";
+import { CoreNavigationProvider, useCoreNavigation } from "./CoreNavigation";
 import { HerdrClientFrame, HerdrMainStage } from "./HerdrClientFrame";
 import { coreSurfaceRegistry } from "./surfaceRegistry";
 
@@ -106,28 +106,40 @@ async function renderFrame({ sidebarOpen, compact }: { sidebarOpen: boolean; com
     await act(async () => {
       root.render(
         <CoreNavigationProvider registry={coreSurfaceRegistry}>
-          <HerdrClientFrame
-            style={{}}
-            sidebarOpen={next.sidebarOpen}
-            notesOpen={false}
-            resizingSidebar={false}
-            resizingNotes={false}
-            resizingNotesList={false}
-            compact={next.compact}
-            touch={false}
-            detail={false}
-            primaryView="world"
-          >
-            <HerdrMainStage label="World Graph">
-              <header className="graph-stage-bar">Graph controls</header>
-            </HerdrMainStage>
-          </HerdrClientFrame>
+          <StageNavigationHarness {...next} />
         </CoreNavigationProvider>,
       );
     });
   };
   await render({ sidebarOpen, compact });
   return { container, rerender: render };
+}
+
+function StageNavigationHarness({ sidebarOpen, compact }: { sidebarOpen: boolean; compact: boolean }) {
+  const { activeSurface, activeWorldTheme, navigate, navigateWorldTheme } = useCoreNavigation();
+  const activeView = activeSurface.id === "spaces" ? "spaces" : activeWorldTheme.id;
+  return (
+    <HerdrClientFrame
+      style={{}}
+      sidebarOpen={sidebarOpen}
+      notesOpen={false}
+      resizingSidebar={false}
+      resizingNotes={false}
+      resizingNotesList={false}
+      compact={compact}
+      touch={false}
+      detail={false}
+      primaryView={activeSurface.id}
+    >
+      <HerdrMainStage
+        label="World Graph"
+        activeView={activeView}
+        onView={(view) => view === "spaces" ? navigate("spaces") : navigateWorldTheme(view)}
+      >
+        <header className="graph-stage-bar">Graph controls</header>
+      </HerdrMainStage>
+    </HerdrClientFrame>
+  );
 }
 
 function themeSwitcher(container: HTMLElement) {

--- a/web/src/HerdrClientFrame.test.tsx
+++ b/web/src/HerdrClientFrame.test.tsx
@@ -1,0 +1,139 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { CoreNavigationProvider } from "./CoreNavigation";
+import { HerdrClientFrame, HerdrMainStage } from "./HerdrClientFrame";
+import { coreSurfaceRegistry } from "./surfaceRegistry";
+
+const roots: Root[] = [];
+
+beforeEach(() => {
+  (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean })
+    .IS_REACT_ACT_ENVIRONMENT = true;
+  window.history.replaceState({}, "", "/?theme=graph");
+});
+
+afterEach(async () => {
+  await act(async () => {
+    for (const root of roots.splice(0)) root.unmount();
+  });
+  document.body.innerHTML = "";
+  vi.restoreAllMocks();
+});
+
+describe("collapsed-sidebar theme switcher", () => {
+  it("renders only in the closed, non-compact shared stage", async () => {
+    const rendered = await renderFrame({ sidebarOpen: true, compact: false });
+    expect(themeSwitcher(rendered.container)).toBeNull();
+
+    await rendered.rerender({ sidebarOpen: false, compact: true });
+    expect(themeSwitcher(rendered.container)).toBeNull();
+
+    await rendered.rerender({ sidebarOpen: false, compact: false });
+    const switcher = themeSwitcher(rendered.container);
+    expect(switcher).not.toBeNull();
+    expect(switcher?.closest(".stage")).not.toBeNull();
+  });
+
+  it("orders and names every destination and identifies the active view", async () => {
+    const { container } = await renderFrame({ sidebarOpen: false, compact: false });
+    const buttons = themeButtons(container);
+
+    expect(buttons.map((button) => button.getAttribute("aria-label"))).toEqual([
+      "Switch to Spaces",
+      "Switch to Office",
+      "Switch to Graph",
+      "Switch to Tree",
+    ]);
+    expect(buttons.map((button) => button.title)).toEqual([
+      "Spaces",
+      "Office",
+      "Graph",
+      "Tree",
+    ]);
+    expect(buttons.map((button) => button.getAttribute("aria-pressed"))).toEqual([
+      "false",
+      "false",
+      "true",
+      "false",
+    ]);
+    expect(buttons.map((button, index) => button.querySelector("svg")?.classList.contains([
+      "lucide-square-terminal",
+      "lucide-building-2",
+      "lucide-network",
+      "lucide-git-branch",
+    ][index]!))).toEqual([
+      true,
+      true,
+      true,
+      true,
+    ]);
+  });
+
+  it("routes each destination through the existing canonical navigation actions", async () => {
+    const push = vi.spyOn(window.history, "pushState");
+    const { container } = await renderFrame({ sidebarOpen: false, compact: false });
+
+    for (const [label, url] of [
+      ["Switch to Spaces", "/spaces"],
+      ["Switch to Office", "/"],
+      ["Switch to Graph", "/?theme=graph"],
+      ["Switch to Tree", "/?theme=tree"],
+    ] as const) {
+      await act(async () => {
+        container.querySelector<HTMLButtonElement>(`[aria-label='${label}']`)?.click();
+      });
+      expect(window.location.pathname + window.location.search).toBe(url);
+      expect(
+        container.querySelector<HTMLButtonElement>(`[aria-label='${label}']`)
+          ?.getAttribute("aria-pressed"),
+      ).toBe("true");
+    }
+
+    expect(push).toHaveBeenCalledTimes(4);
+  });
+});
+
+async function renderFrame({ sidebarOpen, compact }: { sidebarOpen: boolean; compact: boolean }) {
+  const container = document.createElement("div");
+  document.body.append(container);
+  const root = createRoot(container);
+  roots.push(root);
+  const render = async (next: { sidebarOpen: boolean; compact: boolean }) => {
+    await act(async () => {
+      root.render(
+        <CoreNavigationProvider registry={coreSurfaceRegistry}>
+          <HerdrClientFrame
+            style={{}}
+            sidebarOpen={next.sidebarOpen}
+            notesOpen={false}
+            resizingSidebar={false}
+            resizingNotes={false}
+            resizingNotesList={false}
+            compact={next.compact}
+            touch={false}
+            detail={false}
+            primaryView="world"
+          >
+            <HerdrMainStage label="World Graph">
+              <header className="graph-stage-bar">Graph controls</header>
+            </HerdrMainStage>
+          </HerdrClientFrame>
+        </CoreNavigationProvider>,
+      );
+    });
+  };
+  await render({ sidebarOpen, compact });
+  return { container, rerender: render };
+}
+
+function themeSwitcher(container: HTMLElement) {
+  return container.querySelector<HTMLElement>("[aria-label='Theme switcher']");
+}
+
+function themeButtons(container: HTMLElement) {
+  return [...(themeSwitcher(container)?.querySelectorAll<HTMLButtonElement>("button") ?? [])];
+}

--- a/web/src/HerdrClientFrame.tsx
+++ b/web/src/HerdrClientFrame.tsx
@@ -1,4 +1,14 @@
+import { createContext, useContext } from "react";
 import type { CSSProperties, ReactNode } from "react";
+
+import { StageThemeSwitcher } from "./StageThemeSwitcher";
+
+type FrameLayout = {
+  sidebarOpen: boolean;
+  compact: boolean;
+};
+
+const FrameLayoutContext = createContext<FrameLayout>({ sidebarOpen: true, compact: true });
 
 type HerdrClientFrameProps = {
   children: ReactNode;
@@ -28,21 +38,23 @@ export function HerdrClientFrame({
   primaryView,
 }: HerdrClientFrameProps) {
   return (
-    <div
-      className="app"
-      style={style}
-      data-sidebar={sidebarOpen ? "open" : "closed"}
-      data-notes={notesOpen ? "open" : "closed"}
-      data-resizing-sidebar={resizingSidebar ? "true" : "false"}
-      data-resizing-notes={resizingNotes ? "true" : "false"}
-      data-resizing-notes-list={resizingNotesList ? "true" : "false"}
-      data-compact={compact ? "true" : "false"}
-      data-touch={touch ? "true" : "false"}
-      data-detail={compact && detail ? "true" : "false"}
-      data-primary-view={primaryView}
-    >
-      {children}
-    </div>
+    <FrameLayoutContext.Provider value={{ sidebarOpen, compact }}>
+      <div
+        className="app"
+        style={style}
+        data-sidebar={sidebarOpen ? "open" : "closed"}
+        data-notes={notesOpen ? "open" : "closed"}
+        data-resizing-sidebar={resizingSidebar ? "true" : "false"}
+        data-resizing-notes={resizingNotes ? "true" : "false"}
+        data-resizing-notes-list={resizingNotesList ? "true" : "false"}
+        data-compact={compact ? "true" : "false"}
+        data-touch={touch ? "true" : "false"}
+        data-detail={compact && detail ? "true" : "false"}
+        data-primary-view={primaryView}
+      >
+        {children}
+      </div>
+    </FrameLayoutContext.Provider>
   );
 }
 export function HerdrClientSidebar({ children }: { children: ReactNode }) {
@@ -62,8 +74,10 @@ export function HerdrMainStage({
   children: ReactNode;
   inert?: boolean;
 }) {
+  const { sidebarOpen, compact } = useContext(FrameLayoutContext);
   return (
     <section className="stage" aria-label={label} inert={inert}>
+      {!sidebarOpen && !compact ? <StageThemeSwitcher /> : null}
       {children}
     </section>
   );

--- a/web/src/HerdrClientFrame.tsx
+++ b/web/src/HerdrClientFrame.tsx
@@ -1,6 +1,7 @@
 import { createContext, useContext } from "react";
 import type { CSSProperties, ReactNode } from "react";
 
+import type { ToolbarPrimaryView } from "./SidebarToolbar";
 import { StageThemeSwitcher } from "./StageThemeSwitcher";
 
 type FrameLayout = {
@@ -69,15 +70,21 @@ export function HerdrMainStage({
   label,
   children,
   inert,
+  activeView,
+  onView,
 }: {
   label: string;
   children: ReactNode;
   inert?: boolean;
+  activeView: string;
+  onView: (view: ToolbarPrimaryView) => void;
 }) {
   const { sidebarOpen, compact } = useContext(FrameLayoutContext);
   return (
     <section className="stage" aria-label={label} inert={inert}>
-      {!sidebarOpen && !compact ? <StageThemeSwitcher /> : null}
+      {!sidebarOpen && !compact
+        ? <StageThemeSwitcher activeView={activeView} onView={onView} />
+        : null}
       {children}
     </section>
   );

--- a/web/src/StageThemeSwitcher.tsx
+++ b/web/src/StageThemeSwitcher.tsx
@@ -1,6 +1,6 @@
 import { Building2, GitBranch, Network, SquareTerminal } from "lucide-react";
 
-import { useCoreNavigation } from "./CoreNavigation";
+import type { ToolbarPrimaryView } from "./SidebarToolbar";
 
 const DESTINATIONS = [
   { id: "spaces", label: "Spaces", Icon: SquareTerminal },
@@ -9,14 +9,17 @@ const DESTINATIONS = [
   { id: "tree", label: "Tree", Icon: GitBranch },
 ] as const;
 
-export function StageThemeSwitcher() {
-  const { activeSurface, activeWorldTheme, navigate, navigateWorldTheme } = useCoreNavigation();
-  const activeDestination = activeSurface.id === "spaces" ? "spaces" : activeWorldTheme.id;
-
+export function StageThemeSwitcher({
+  activeView,
+  onView,
+}: {
+  activeView: string;
+  onView: (view: ToolbarPrimaryView) => void;
+}) {
   return (
     <nav className="stage-theme-switcher" aria-label="Theme switcher">
       {DESTINATIONS.map(({ id, label, Icon }) => {
-        const active = id === activeDestination;
+        const active = id === activeView;
         return (
           <button
             key={id}
@@ -24,7 +27,7 @@ export function StageThemeSwitcher() {
             aria-label={`Switch to ${label}`}
             aria-pressed={active}
             title={label}
-            onClick={() => id === "spaces" ? navigate("spaces") : navigateWorldTheme(id)}
+            onClick={() => onView(id)}
           >
             <Icon size={16} aria-hidden="true" />
           </button>

--- a/web/src/StageThemeSwitcher.tsx
+++ b/web/src/StageThemeSwitcher.tsx
@@ -1,0 +1,35 @@
+import { Building2, GitBranch, Network, SquareTerminal } from "lucide-react";
+
+import { useCoreNavigation } from "./CoreNavigation";
+
+const DESTINATIONS = [
+  { id: "spaces", label: "Spaces", Icon: SquareTerminal },
+  { id: "office", label: "Office", Icon: Building2 },
+  { id: "graph", label: "Graph", Icon: Network },
+  { id: "tree", label: "Tree", Icon: GitBranch },
+] as const;
+
+export function StageThemeSwitcher() {
+  const { activeSurface, activeWorldTheme, navigate, navigateWorldTheme } = useCoreNavigation();
+  const activeDestination = activeSurface.id === "spaces" ? "spaces" : activeWorldTheme.id;
+
+  return (
+    <nav className="stage-theme-switcher" aria-label="Theme switcher">
+      {DESTINATIONS.map(({ id, label, Icon }) => {
+        const active = id === activeDestination;
+        return (
+          <button
+            key={id}
+            type="button"
+            aria-label={`Switch to ${label}`}
+            aria-pressed={active}
+            title={label}
+            onClick={() => id === "spaces" ? navigate("spaces") : navigateWorldTheme(id)}
+          >
+            <Icon size={16} aria-hidden="true" />
+          </button>
+        );
+      })}
+    </nav>
+  );
+}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -2996,6 +2996,76 @@ button {
   background: var(--term-bg);
 }
 
+.stage-theme-switcher {
+  position: absolute;
+  top: 10px;
+  right: 12px;
+  z-index: 8;
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  padding: 3px;
+  border: 1px solid color-mix(in srgb, var(--surface1) 72%, var(--line));
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--mantle) 94%, transparent);
+  box-shadow: 0 4px 14px #0005;
+}
+
+.stage-theme-switcher button {
+  position: relative;
+  display: inline-grid;
+  width: 28px;
+  height: 28px;
+  flex: 0 0 auto;
+  place-items: center;
+  padding: 0;
+  border: 1px solid transparent;
+  border-radius: 5px;
+  color: var(--overlay1);
+  background: transparent;
+  transition: color 120ms ease, border-color 120ms ease, background 120ms ease;
+}
+
+.stage-theme-switcher button:hover,
+.stage-theme-switcher button:focus-visible {
+  border-color: var(--surface1);
+  color: var(--text);
+  background: var(--surface0);
+}
+
+.stage-theme-switcher button:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+}
+
+.stage-theme-switcher button[aria-pressed="true"] {
+  border-color: color-mix(in srgb, var(--accent) 38%, var(--line));
+  color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 14%, var(--surface0));
+}
+
+.stage-theme-switcher button[aria-pressed="true"]::after {
+  position: absolute;
+  right: 7px;
+  bottom: 1px;
+  left: 7px;
+  height: 2px;
+  border-radius: 999px;
+  background: var(--accent);
+  content: "";
+}
+
+.app[data-sidebar="closed"][data-compact="false"] .stage > .stage-bar,
+.app[data-sidebar="closed"][data-compact="false"] .world-stage-bar,
+.app[data-sidebar="closed"][data-compact="false"] .graph-stage-bar,
+.app[data-sidebar="closed"][data-compact="false"] .tree-stage-bar {
+  padding-right: 150px;
+}
+
+.app[data-primary-view="spaces"] .stage-theme-switcher {
+  top: 50px;
+}
+
 .stage-bar {
   display: flex;
   align-items: center;

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -2994,6 +2994,7 @@ button {
   flex-direction: column;
   overflow: hidden;
   background: var(--term-bg);
+  container: main-stage / inline-size;
 }
 
 .stage-theme-switcher {
@@ -3062,8 +3063,27 @@ button {
   padding-right: 150px;
 }
 
-.app[data-primary-view="spaces"] .stage-theme-switcher {
+.app[data-primary-view="spaces"] .stage:has(> .tabbar) > .stage-theme-switcher {
   top: 50px;
+}
+
+@container main-stage (max-width: 520px) {
+  .stage-theme-switcher {
+    position: static;
+    align-self: flex-end;
+    margin: 6px 12px;
+  }
+
+  .app[data-sidebar="closed"][data-compact="false"] .stage > .stage-bar {
+    height: auto;
+    min-height: 56px;
+    flex-wrap: wrap;
+    padding: 8px 10px;
+  }
+
+  .app[data-sidebar="closed"][data-compact="false"] .stage > .stage-bar .stage-id {
+    flex-basis: calc(100% - 44px);
+  }
 }
 
 .stage-bar {


### PR DESCRIPTION
## Summary

- add a compact Spaces / Office / Graph / Tree icon strip at the top right when the desktop sidebar is closed
- preserve the existing App-owned navigation and Spaces-to-World selection handoff
- keep sidebar-open and compact/mobile navigation unchanged
- adapt to actual stage width so the default Notes panel cannot cover terminal header actions
- tie the Spaces offset to a rendered tab bar so the strip stays inside an empty Spaces header

## Verification

- `npm run check`
- focused RED/GREEN component, App navigation, Notes-open hit-target, and empty-Spaces layout tests
- synthetic browser inspection across all four destinations plus the exact 1440→821/default-Notes/261px-stage and empty-snapshot cases
- independent task reviews, whole-branch reviews, and scoped re-reviews; all findings resolved
- final CI run passed, including all four browser shards and the delivery gate

## Workflow

Execution used Superpowers and native Codex with the owner-selected Sol/high allocation for the lead and every subagent. This is the native trial change targeting the agent-development harness work in PR #78.
